### PR TITLE
fix: add repository field for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,9 @@ jobs:
         if: steps.version.outputs.exists == 'false'
         run: npm run build
 
-      - name: Publish to npm (provenance)
+      - name: Publish to npm (trusted publishing)
         if: steps.version.outputs.exists == 'false'
-        run: npm publish --access public --provenance
+        run: npm publish --access public
 
       - name: Extract changelog for version
         if: steps.version.outputs.exists == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-01-02
+
+### Fixed
+
+- Add `repository` field to package.json for npm trusted publishing
+
 ## [0.7.0] - 2026-01-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server implementation for Coolify",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,6 +39,10 @@
   ],
   "author": "Stuart Mason",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/StuMason/coolify-mcp.git"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "zod": "^3.24.2"

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -31,7 +31,7 @@ import {
 } from './coolify-client.js';
 import type { CoolifyConfig } from '../types/coolify.js';
 
-const VERSION = '0.7.0';
+const VERSION = '0.7.1';
 
 /** Wrap tool handler with consistent error handling */
 function wrapHandler<T>(


### PR DESCRIPTION
## Summary
- Add `repository` field to package.json (required for npm OIDC verification)
- Remove `--provenance` flag (automatic with trusted publishing)

## Why
npm trusted publishing requires `repository.url` in package.json to match the GitHub repo URL for OIDC token verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)