### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-01-05
+
+### Changed
+
+- **Dependency Updates** - Major upgrade to latest secure versions:
+  - ESLint 8→9 with new flat config format
+  - zod 3→4
+  - @types/node 20→25
+  - dotenv 16→17
+  - lint-staged 15→16
+  - eslint-config-prettier 9→10
+  - @typescript-eslint packages 7→8
+
+### Added
+
+- Auto-delete branches on merge
+- Dependabot auto-merge for patch/minor updates
+- Weekly OpenAPI drift detection (monitors Coolify API changes)
+- Claude Code review on PRs
+- CONTRIBUTING.md with maintenance documentation
+
 ## [1.1.0] - 2026-01-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server implementation for Coolify",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -31,7 +31,7 @@ import {
 } from './coolify-client.js';
 import type { CoolifyConfig } from '../types/coolify.js';
 
-const VERSION = '1.1.0';
+const VERSION = '1.1.1';
 
 /** Wrap tool handler with consistent error handling */
 function wrapHandler<T>(


### PR DESCRIPTION
## Summary
- Bump version to 1.1.1
- Update CHANGELOG with dependency updates and maintenance automation

## What's in this release

### Dependency Updates
- ESLint 8→9 with new flat config format
- zod 3→4
- @types/node 20→25
- dotenv 16→17
- lint-staged 15→16
- eslint-config-prettier 9→10
- @typescript-eslint packages 7→8

### Maintenance Automation
- Auto-delete branches on merge
- Dependabot auto-merge for patch/minor updates
- Weekly OpenAPI drift detection (monitors Coolify API changes)
- Claude Code review on PRs
- CONTRIBUTING.md with maintenance documentation

## Test plan
- [x] Build passes
- [x] All 185 tests pass
- [x] 98% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)