### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] - 2026-01-05
+## [1.5.0] - 2026-01-06
 
 ### Fixed
 
 - `delete_environment` now uses correct API path `/projects/{project_uuid}/environments/{environment_name_or_uuid}` (breaking: now requires `project_uuid` parameter)
+
+### Changed
+
+- Claude Code review workflow now only runs on PR creation (not every push)
+- Upgraded to Prettier 4.0
+
+### Removed
+
+- Obsolete documentation files in `docs/features/` (14 ADR files) and `docs/mcp-*.md` files (~7,700 lines removed)
+
+## [1.1.1] - 2026-01-05
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "1.1.1",
+  "version": "1.5.0",
   "description": "MCP server implementation for Coolify",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -31,7 +31,7 @@ import {
 } from './coolify-client.js';
 import type { CoolifyConfig } from '../types/coolify.js';
 
-const VERSION = '1.1.1';
+const VERSION = '1.5.0';
 
 /** Wrap tool handler with consistent error handling */
 function wrapHandler<T>(


### PR DESCRIPTION
## Summary

- Bump version to 1.5.0
- Fix `delete_environment` API path (breaking: now requires `project_uuid` parameter)
- Claude Code review workflow now only runs on PR creation
- Upgraded to Prettier 4.0
- Removed obsolete documentation (~7,700 lines)

## Changelog

```
## [1.5.0] - 2026-01-06

### Fixed

- `delete_environment` now uses correct API path `/projects/{project_uuid}/environments/{environment_name_or_uuid}` (breaking: now requires `project_uuid` parameter)

### Changed

- Claude Code review workflow now only runs on PR creation (not every push)
- Upgraded to Prettier 4.0

### Removed

- Obsolete documentation files in `docs/features/` (14 ADR files) and `docs/mcp-*.md` files (~7,700 lines removed)
```

## Test plan

- [ ] CI passes (lint, format, tests)
- [ ] npm publish workflow triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)