### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-01-06
+
+### Added
+
+- **Database Creation Tools** - Full CRUD support for all database types:
+  - `create_postgresql` - Create PostgreSQL databases
+  - `create_mysql` - Create MySQL databases
+  - `create_mariadb` - Create MariaDB databases
+  - `create_mongodb` - Create MongoDB databases
+  - `create_redis` - Create Redis databases
+  - `create_keydb` - Create KeyDB databases
+  - `create_clickhouse` - Create ClickHouse databases
+  - `create_dragonfly` - Create Dragonfly databases (Redis-compatible)
+
+### Changed
+
+- Total tool count increased from 67 to 75 tools
+- Database tools section now has 14 tools (was 6)
+
 ## [1.5.0] - 2026-01-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Coolify that provides 67 tools and 7 workflow prompts for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, smart diagnostics, and batch operations. Prompts provide guided workflows for debugging, deployment, health checks, and more.
+MCP (Model Context Protocol) server for Coolify that provides 75 tools and 7 workflow prompts for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, smart diagnostics, and batch operations. Prompts provide guided workflows for debugging, deployment, health checks, and more.
 
 ## Commands
 
@@ -101,7 +101,7 @@ When making changes to the codebase, ensure documentation is updated:
    - Follow [Keep a Changelog](https://keepachangelog.com/) format
 
 2. **README.md** - Update if:
-   - Tool count changes (update "67 tools" in Features section)
+   - Tool count changes (update "75 tools" in Features section)
    - New tools added (add to appropriate category in Available Tools)
    - New example prompts needed
    - Response size improvements made (update comparison table)

--- a/README.md
+++ b/README.md
@@ -9,27 +9,27 @@
 [![codecov](https://codecov.io/gh/StuMason/coolify-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/StuMason/coolify-mcp)
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/stumason-coolify-mcp-badge.png)](https://mseep.ai/app/stumason-coolify-mcp)
 
-> **The most comprehensive MCP server for Coolify** - 67 tools, 7 workflow prompts, smart diagnostics, and batch operations for managing your self-hosted PaaS through AI assistants.
+> **The most comprehensive MCP server for Coolify** - 75 tools, 7 workflow prompts, smart diagnostics, and batch operations for managing your self-hosted PaaS through AI assistants.
 
 A Model Context Protocol (MCP) server for [Coolify](https://coolify.io/), enabling AI assistants to manage and debug your Coolify instances through natural language.
 
 ## Features
 
-This MCP server provides **67 tools** and **7 workflow prompts** for **debugging, management, and deployment**:
+This MCP server provides **75 tools** and **7 workflow prompts** for **debugging, management, and deployment**:
 
-| Category             | Tools                                                                                                    |
-| -------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Infrastructure**   | overview, mcp_version (all resources at once)                                                            |
-| **Diagnostics**      | diagnose_app, diagnose_server, find_issues (smart lookup by name/domain/IP)                              |
-| **Batch Operations** | restart_project_apps, bulk_env_update, stop_all_apps, redeploy_project                                   |
-| **Servers**          | list, get, validate, resources, domains                                                                  |
-| **Projects**         | list, get, create, update, delete                                                                        |
-| **Environments**     | list, get, create, delete                                                                                |
-| **Applications**     | list, get, update, delete, start, stop, restart, logs, env vars (CRUD), create (private-gh, private-key) |
-| **Databases**        | list, get, delete, start, stop, restart, backups (list, get), backup executions (list, get)              |
-| **Services**         | list, get, create, update, delete, start, stop, restart, env vars (list, create, delete)                 |
-| **Deployments**      | list, get, deploy, cancel, list by application                                                           |
-| **Private Keys**     | list, get, create, update, delete                                                                        |
+| Category             | Tools                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Infrastructure**   | overview, mcp_version (all resources at once)                                                                 |
+| **Diagnostics**      | diagnose_app, diagnose_server, find_issues (smart lookup by name/domain/IP)                                   |
+| **Batch Operations** | restart_project_apps, bulk_env_update, stop_all_apps, redeploy_project                                        |
+| **Servers**          | list, get, validate, resources, domains                                                                       |
+| **Projects**         | list, get, create, update, delete                                                                             |
+| **Environments**     | list, get, create, delete                                                                                     |
+| **Applications**     | list, get, update, delete, start, stop, restart, logs, env vars (CRUD), create (private-gh, private-key)      |
+| **Databases**        | list, get, create (8 types), delete, start, stop, restart, backups (list, get), backup executions (list, get) |
+| **Services**         | list, get, create, update, delete, start, stop, restart, env vars (list, create, delete)                      |
+| **Deployments**      | list, get, deploy, cancel, list by application                                                                |
+| **Private Keys**     | list, get, create, update, delete                                                                             |
 
 ### Workflow Prompts
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server implementation for Coolify",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1177,6 +1177,135 @@ describe('CoolifyClient', () => {
         expect.any(Object),
       );
     });
+
+    it('should create a PostgreSQL database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'pg-uuid' }));
+
+      const result = await client.createPostgresql({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        environment_name: 'production',
+        postgres_user: 'myuser',
+        postgres_db: 'mydb',
+      });
+
+      expect(result).toEqual({ uuid: 'pg-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/postgresql',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a MySQL database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'mysql-uuid' }));
+
+      const result = await client.createMysql({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        mysql_user: 'myuser',
+        mysql_database: 'mydb',
+      });
+
+      expect(result).toEqual({ uuid: 'mysql-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/mysql',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a MariaDB database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'mariadb-uuid' }));
+
+      const result = await client.createMariadb({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+      });
+
+      expect(result).toEqual({ uuid: 'mariadb-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/mariadb',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a MongoDB database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'mongo-uuid' }));
+
+      const result = await client.createMongodb({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        mongo_initdb_root_username: 'admin',
+      });
+
+      expect(result).toEqual({ uuid: 'mongo-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/mongodb',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a Redis database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'redis-uuid' }));
+
+      const result = await client.createRedis({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        redis_password: 'secret',
+      });
+
+      expect(result).toEqual({ uuid: 'redis-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/redis',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a KeyDB database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'keydb-uuid' }));
+
+      const result = await client.createKeydb({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+      });
+
+      expect(result).toEqual({ uuid: 'keydb-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/keydb',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a ClickHouse database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'clickhouse-uuid' }));
+
+      const result = await client.createClickhouse({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        clickhouse_admin_user: 'admin',
+      });
+
+      expect(result).toEqual({ uuid: 'clickhouse-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/clickhouse',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should create a Dragonfly database', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'dragonfly-uuid' }));
+
+      const result = await client.createDragonfly({
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        dragonfly_password: 'secret',
+      });
+
+      expect(result).toEqual({ uuid: 'dragonfly-uuid' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/dragonfly',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
   });
 
   // =========================================================================

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -18,6 +18,14 @@ const mockDiagnoseApplication = jest.fn<CoolifyClient['diagnoseApplication']>();
 const mockDiagnoseServer = jest.fn<CoolifyClient['diagnoseServer']>();
 const mockFindInfrastructureIssues = jest.fn<CoolifyClient['findInfrastructureIssues']>();
 const mockDeleteDatabase = jest.fn<CoolifyClient['deleteDatabase']>();
+const mockCreatePostgresql = jest.fn<CoolifyClient['createPostgresql']>();
+const mockCreateMysql = jest.fn<CoolifyClient['createMysql']>();
+const mockCreateMariadb = jest.fn<CoolifyClient['createMariadb']>();
+const mockCreateMongodb = jest.fn<CoolifyClient['createMongodb']>();
+const mockCreateRedis = jest.fn<CoolifyClient['createRedis']>();
+const mockCreateKeydb = jest.fn<CoolifyClient['createKeydb']>();
+const mockCreateClickhouse = jest.fn<CoolifyClient['createClickhouse']>();
+const mockCreateDragonfly = jest.fn<CoolifyClient['createDragonfly']>();
 
 // Mock the CoolifyClient module
 jest.mock('../lib/coolify-client.js', () => ({
@@ -31,6 +39,14 @@ jest.mock('../lib/coolify-client.js', () => ({
     diagnoseServer: mockDiagnoseServer,
     findInfrastructureIssues: mockFindInfrastructureIssues,
     deleteDatabase: mockDeleteDatabase,
+    createPostgresql: mockCreatePostgresql,
+    createMysql: mockCreateMysql,
+    createMariadb: mockCreateMariadb,
+    createMongodb: mockCreateMongodb,
+    createRedis: mockCreateRedis,
+    createKeydb: mockCreateKeydb,
+    createClickhouse: mockCreateClickhouse,
+    createDragonfly: mockCreateDragonfly,
     getVersion: jest.fn(),
   })),
 }));
@@ -374,6 +390,96 @@ describe('CoolifyMcpServer', () => {
         await mockDeleteDatabase('db-uuid-123', { deleteVolumes: true });
 
         expect(mockDeleteDatabase).toHaveBeenCalledWith('db-uuid-123', { deleteVolumes: true });
+      });
+    });
+
+    describe('database creation tools', () => {
+      const baseParams = {
+        server_uuid: 'server-uuid',
+        project_uuid: 'project-uuid',
+        environment_name: 'production',
+      };
+
+      it('should call createPostgresql with correct params', async () => {
+        mockCreatePostgresql.mockResolvedValue({ uuid: 'pg-uuid' });
+
+        await mockCreatePostgresql({ ...baseParams, postgres_user: 'myuser' });
+
+        expect(mockCreatePostgresql).toHaveBeenCalledWith({
+          ...baseParams,
+          postgres_user: 'myuser',
+        });
+      });
+
+      it('should call createMysql with correct params', async () => {
+        mockCreateMysql.mockResolvedValue({ uuid: 'mysql-uuid' });
+
+        await mockCreateMysql({ ...baseParams, mysql_user: 'myuser' });
+
+        expect(mockCreateMysql).toHaveBeenCalledWith({
+          ...baseParams,
+          mysql_user: 'myuser',
+        });
+      });
+
+      it('should call createMariadb with correct params', async () => {
+        mockCreateMariadb.mockResolvedValue({ uuid: 'mariadb-uuid' });
+
+        await mockCreateMariadb(baseParams);
+
+        expect(mockCreateMariadb).toHaveBeenCalledWith(baseParams);
+      });
+
+      it('should call createMongodb with correct params', async () => {
+        mockCreateMongodb.mockResolvedValue({ uuid: 'mongo-uuid' });
+
+        await mockCreateMongodb({ ...baseParams, mongo_initdb_root_username: 'admin' });
+
+        expect(mockCreateMongodb).toHaveBeenCalledWith({
+          ...baseParams,
+          mongo_initdb_root_username: 'admin',
+        });
+      });
+
+      it('should call createRedis with correct params', async () => {
+        mockCreateRedis.mockResolvedValue({ uuid: 'redis-uuid' });
+
+        await mockCreateRedis({ ...baseParams, redis_password: 'secret' });
+
+        expect(mockCreateRedis).toHaveBeenCalledWith({
+          ...baseParams,
+          redis_password: 'secret',
+        });
+      });
+
+      it('should call createKeydb with correct params', async () => {
+        mockCreateKeydb.mockResolvedValue({ uuid: 'keydb-uuid' });
+
+        await mockCreateKeydb(baseParams);
+
+        expect(mockCreateKeydb).toHaveBeenCalledWith(baseParams);
+      });
+
+      it('should call createClickhouse with correct params', async () => {
+        mockCreateClickhouse.mockResolvedValue({ uuid: 'clickhouse-uuid' });
+
+        await mockCreateClickhouse({ ...baseParams, clickhouse_admin_user: 'admin' });
+
+        expect(mockCreateClickhouse).toHaveBeenCalledWith({
+          ...baseParams,
+          clickhouse_admin_user: 'admin',
+        });
+      });
+
+      it('should call createDragonfly with correct params', async () => {
+        mockCreateDragonfly.mockResolvedValue({ uuid: 'dragonfly-uuid' });
+
+        await mockCreateDragonfly({ ...baseParams, dragonfly_password: 'secret' });
+
+        expect(mockCreateDragonfly).toHaveBeenCalledWith({
+          ...baseParams,
+          dragonfly_password: 'secret',
+        });
       });
     });
   });

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -42,6 +42,15 @@ import type {
   // Database types
   Database,
   UpdateDatabaseRequest,
+  CreatePostgresqlRequest,
+  CreateMysqlRequest,
+  CreateMariadbRequest,
+  CreateMongodbRequest,
+  CreateRedisRequest,
+  CreateKeydbRequest,
+  CreateClickhouseRequest,
+  CreateDragonflyRequest,
+  CreateDatabaseResponse,
   DatabaseBackup,
   BackupExecution,
   // Service types
@@ -654,6 +663,63 @@ export class CoolifyClient {
   async restartDatabase(uuid: string): Promise<MessageResponse> {
     return this.request<MessageResponse>(`/databases/${uuid}/restart`, {
       method: 'POST',
+    });
+  }
+
+  // Database creation methods
+  async createPostgresql(data: CreatePostgresqlRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/postgresql', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createMysql(data: CreateMysqlRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/mysql', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createMariadb(data: CreateMariadbRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/mariadb', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createMongodb(data: CreateMongodbRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/mongodb', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createRedis(data: CreateRedisRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/redis', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createKeydb(data: CreateKeydbRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/keydb', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createClickhouse(data: CreateClickhouseRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/clickhouse', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createDragonfly(data: CreateDragonflyRequest): Promise<CreateDatabaseResponse> {
+    return this.request<CreateDatabaseResponse>('/databases/dragonfly', {
+      method: 'POST',
+      body: JSON.stringify(data),
     });
   }
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -31,7 +31,7 @@ import {
 } from './coolify-client.js';
 import type { CoolifyConfig } from '../types/coolify.js';
 
-const VERSION = '1.5.0';
+const VERSION = '1.6.0';
 
 /** Wrap tool handler with consistent error handling */
 function wrapHandler<T>(
@@ -445,7 +445,7 @@ export class CoolifyMcpServer extends McpServer {
     );
 
     // =========================================================================
-    // Databases (6 tools)
+    // Databases (14 tools)
     // =========================================================================
     this.tool(
       'list_databases',
@@ -495,6 +495,127 @@ export class CoolifyMcpServer extends McpServer {
       },
       async ({ uuid, delete_volumes }) =>
         wrapHandler(() => this.client.deleteDatabase(uuid, { deleteVolumes: delete_volumes })),
+    );
+
+    // Database creation tools - shared schema for base fields
+    const databaseBaseSchema = {
+      server_uuid: z.string().describe('Server UUID'),
+      project_uuid: z.string().describe('Project UUID'),
+      environment_name: z.string().optional().describe('Environment name'),
+      environment_uuid: z.string().optional().describe('Environment UUID'),
+      destination_uuid: z.string().optional().describe('Destination UUID'),
+      name: z.string().optional().describe('Database name'),
+      description: z.string().optional().describe('Database description'),
+      image: z.string().optional().describe('Docker image'),
+      is_public: z.boolean().optional().describe('Make database publicly accessible'),
+      public_port: z.number().optional().describe('Public port'),
+      limits_memory: z.string().optional().describe('Memory limit'),
+      limits_memory_swap: z.string().optional().describe('Memory swap limit'),
+      limits_memory_swappiness: z.number().optional().describe('Memory swappiness'),
+      limits_memory_reservation: z.string().optional().describe('Memory reservation'),
+      limits_cpus: z.string().optional().describe('CPU limit'),
+      limits_cpuset: z.string().optional().describe('CPU set'),
+      limits_cpu_shares: z.number().optional().describe('CPU shares'),
+      instant_deploy: z.boolean().optional().describe('Deploy immediately after creation'),
+    };
+
+    this.tool(
+      'create_postgresql',
+      'Create a new PostgreSQL database',
+      {
+        ...databaseBaseSchema,
+        postgres_user: z.string().optional().describe('PostgreSQL user'),
+        postgres_password: z.string().optional().describe('PostgreSQL password'),
+        postgres_db: z.string().optional().describe('PostgreSQL database name'),
+        postgres_initdb_args: z.string().optional().describe('PostgreSQL initdb args'),
+        postgres_host_auth_method: z.string().optional().describe('PostgreSQL host auth method'),
+        postgres_conf: z.string().optional().describe('PostgreSQL configuration'),
+      },
+      async (args) => wrapHandler(() => this.client.createPostgresql(args)),
+    );
+
+    this.tool(
+      'create_mysql',
+      'Create a new MySQL database',
+      {
+        ...databaseBaseSchema,
+        mysql_root_password: z.string().optional().describe('MySQL root password'),
+        mysql_user: z.string().optional().describe('MySQL user'),
+        mysql_password: z.string().optional().describe('MySQL password'),
+        mysql_database: z.string().optional().describe('MySQL database name'),
+        mysql_conf: z.string().optional().describe('MySQL configuration'),
+      },
+      async (args) => wrapHandler(() => this.client.createMysql(args)),
+    );
+
+    this.tool(
+      'create_mariadb',
+      'Create a new MariaDB database',
+      {
+        ...databaseBaseSchema,
+        mariadb_root_password: z.string().optional().describe('MariaDB root password'),
+        mariadb_user: z.string().optional().describe('MariaDB user'),
+        mariadb_password: z.string().optional().describe('MariaDB password'),
+        mariadb_database: z.string().optional().describe('MariaDB database name'),
+        mariadb_conf: z.string().optional().describe('MariaDB configuration'),
+      },
+      async (args) => wrapHandler(() => this.client.createMariadb(args)),
+    );
+
+    this.tool(
+      'create_mongodb',
+      'Create a new MongoDB database',
+      {
+        ...databaseBaseSchema,
+        mongo_initdb_root_username: z.string().optional().describe('MongoDB root username'),
+        mongo_initdb_root_password: z.string().optional().describe('MongoDB root password'),
+        mongo_initdb_database: z.string().optional().describe('MongoDB database name'),
+        mongo_conf: z.string().optional().describe('MongoDB configuration'),
+      },
+      async (args) => wrapHandler(() => this.client.createMongodb(args)),
+    );
+
+    this.tool(
+      'create_redis',
+      'Create a new Redis database',
+      {
+        ...databaseBaseSchema,
+        redis_password: z.string().optional().describe('Redis password'),
+        redis_conf: z.string().optional().describe('Redis configuration'),
+      },
+      async (args) => wrapHandler(() => this.client.createRedis(args)),
+    );
+
+    this.tool(
+      'create_keydb',
+      'Create a new KeyDB database',
+      {
+        ...databaseBaseSchema,
+        keydb_password: z.string().optional().describe('KeyDB password'),
+        keydb_conf: z.string().optional().describe('KeyDB configuration'),
+      },
+      async (args) => wrapHandler(() => this.client.createKeydb(args)),
+    );
+
+    this.tool(
+      'create_clickhouse',
+      'Create a new ClickHouse database',
+      {
+        ...databaseBaseSchema,
+        clickhouse_admin_user: z.string().optional().describe('ClickHouse admin user'),
+        clickhouse_admin_password: z.string().optional().describe('ClickHouse admin password'),
+      },
+      async (args) => wrapHandler(() => this.client.createClickhouse(args)),
+    );
+
+    this.tool(
+      'create_dragonfly',
+      'Create a new Dragonfly database (Redis-compatible)',
+      {
+        ...databaseBaseSchema,
+        dragonfly_password: z.string().optional().describe('Dragonfly password'),
+      },
+      async (args) => wrapHandler(() => this.client.createDragonfly(args)),
     );
 
     // =========================================================================

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -545,6 +545,83 @@ export interface UpdateDatabaseRequest {
   dragonfly_password?: string;
 }
 
+// Base interface for database creation requests
+export interface CreateDatabaseBaseRequest {
+  server_uuid: string;
+  project_uuid: string;
+  environment_name?: string;
+  environment_uuid?: string;
+  destination_uuid?: string;
+  name?: string;
+  description?: string;
+  image?: string;
+  is_public?: boolean;
+  public_port?: number;
+  limits_memory?: string;
+  limits_memory_swap?: string;
+  limits_memory_swappiness?: number;
+  limits_memory_reservation?: string;
+  limits_cpus?: string;
+  limits_cpuset?: string;
+  limits_cpu_shares?: number;
+  instant_deploy?: boolean;
+}
+
+export interface CreatePostgresqlRequest extends CreateDatabaseBaseRequest {
+  postgres_user?: string;
+  postgres_password?: string;
+  postgres_db?: string;
+  postgres_initdb_args?: string;
+  postgres_host_auth_method?: string;
+  postgres_conf?: string;
+}
+
+export interface CreateMysqlRequest extends CreateDatabaseBaseRequest {
+  mysql_root_password?: string;
+  mysql_user?: string;
+  mysql_password?: string;
+  mysql_database?: string;
+  mysql_conf?: string;
+}
+
+export interface CreateMariadbRequest extends CreateDatabaseBaseRequest {
+  mariadb_root_password?: string;
+  mariadb_user?: string;
+  mariadb_password?: string;
+  mariadb_database?: string;
+  mariadb_conf?: string;
+}
+
+export interface CreateMongodbRequest extends CreateDatabaseBaseRequest {
+  mongo_initdb_root_username?: string;
+  mongo_initdb_root_password?: string;
+  mongo_initdb_database?: string;
+  mongo_conf?: string;
+}
+
+export interface CreateRedisRequest extends CreateDatabaseBaseRequest {
+  redis_password?: string;
+  redis_conf?: string;
+}
+
+export interface CreateKeydbRequest extends CreateDatabaseBaseRequest {
+  keydb_password?: string;
+  keydb_conf?: string;
+}
+
+export interface CreateClickhouseRequest extends CreateDatabaseBaseRequest {
+  clickhouse_admin_user?: string;
+  clickhouse_admin_password?: string;
+}
+
+export interface CreateDragonflyRequest extends CreateDatabaseBaseRequest {
+  dragonfly_password?: string;
+}
+
+export interface CreateDatabaseResponse {
+  uuid: string;
+}
+
 // =============================================================================
 // Database Backup Types
 // =============================================================================


### PR DESCRIPTION
## Summary

Release v1.6.0 with 8 new database creation tools.

### Added
- **Database Creation Tools** - Full CRUD support for all database types:
  - `create_postgresql` - Create PostgreSQL databases
  - `create_mysql` - Create MySQL databases
  - `create_mariadb` - Create MariaDB databases
  - `create_mongodb` - Create MongoDB databases
  - `create_redis` - Create Redis databases
  - `create_keydb` - Create KeyDB databases
  - `create_clickhouse` - Create ClickHouse databases
  - `create_dragonfly` - Create Dragonfly databases (Redis-compatible)

### Changed
- Total tool count increased from 67 to 75 tools
- Database tools section now has 14 tools (was 6)

## Test plan
- [x] All 201 tests pass
- [x] Build succeeds
- [x] Lint passes
- [x] Documentation updated (README, CHANGELOG, CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)