### PR TITLE
fix: filter MCP-specific fields from database creation requests

### DIFF
--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -403,12 +403,10 @@ export class CoolifyMcpServer extends McpServer {
         dragonfly_password: z.string().optional(),
       },
       async (args) => {
-        const { action, type, uuid } = args;
+        const { action, type, uuid, delete_volumes, ...dbData } = args;
         if (action === 'delete') {
           if (!uuid) return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-          return wrap(() =>
-            this.client.deleteDatabase(uuid, { deleteVolumes: args.delete_volumes }),
-          );
+          return wrap(() => this.client.deleteDatabase(uuid, { deleteVolumes: delete_volumes }));
         }
         // create
         if (!type || !args.server_uuid || !args.project_uuid) {
@@ -428,7 +426,7 @@ export class CoolifyMcpServer extends McpServer {
           clickhouse: (d) => this.client.createClickhouse(d),
           dragonfly: (d) => this.client.createDragonfly(d),
         };
-        return wrap(() => dbMethods[type](args));
+        return wrap(() => dbMethods[type](dbData));
       },
     );
 


### PR DESCRIPTION
## Problem
The `database` MCP tool was returning `Error: Validation failed.` when trying to create databases, even with all required parameters provided.

## Root Cause
The tool was passing ALL parameters to the Coolify API, including MCP-specific fields (`action`, `type`, `uuid`, `delete_volumes`). The Coolify API validation rejected these extra fields.

## Solution
Extract MCP-specific fields before passing data to the API:
```typescript
const { action, type, uuid, delete_volumes, ...dbData } = args;
return wrap(() => dbMethods[type](dbData));
```

Now only database-specific fields are sent to the API.

## Testing
- ✅ All existing tests pass  
- ✅ Build succeeds
- ✅ Pre-commit hooks (lint + format) pass

## Closes
Fixes #58