### PR TITLE
feat: Docker image deployment, health checks, log limiting & better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - Unreleased
+
+### Added
+
+- **Docker Image Deployment** - Deploy pre-built images from Docker Hub or registries (#69):
+  - `application` tool now supports `create_dockerimage` action
+  - Required fields: `project_uuid`, `server_uuid`, `docker_registry_image_name`, `ports_exposes`
+  - Optional: `docker_registry_image_tag` (defaults to `latest`)
+
+- **Health Check Configuration** - Configure application health checks during create/update (#62):
+  - 12 health check fields now supported in `application` tool:
+    - `health_check_enabled` - Enable/disable health checks
+    - `health_check_path` - URL path for health check (e.g., `/up`, `/health`)
+    - `health_check_port` - Port to check
+    - `health_check_host` - Host for health check
+    - `health_check_method` - HTTP method (GET, POST, etc.)
+    - `health_check_return_code` - Expected HTTP status code
+    - `health_check_scheme` - HTTP or HTTPS
+    - `health_check_response_text` - Expected response text
+    - `health_check_interval` - Seconds between checks
+    - `health_check_timeout` - Seconds to wait for response
+    - `health_check_retries` - Number of retries before marking unhealthy
+    - `health_check_start_period` - Seconds to wait before starting checks
+
+- **Deployment Log Line Limiting** - Reduce token usage for large deployment logs (#68):
+  - `deployment` tool `get` action now supports `lines` parameter
+  - Returns only the last N lines of logs when specified
+  - Example: `deployment(action: 'get', uuid: 'xxx', lines: 50)`
+
+### Changed
+
+- **Improved Validation Errors** - API validation errors now include field-level details (#69):
+  - Errors like "Validation failed." now include: "Validation failed. - field: error message"
+  - Multiple validation errors per field are comma-separated
+  - Multiple fields are semicolon-separated
+
 ## [2.1.0] - 2026-01-07
 
 ### Added

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -521,6 +521,26 @@ describe('CoolifyClient', () => {
 
       await expect(client.listServers()).rejects.toThrow('HTTP 500: Error');
     });
+
+    it('should include validation errors in error message', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          {
+            message: 'Validation failed.',
+            errors: {
+              name: ['The name field is required.'],
+              email: ['The email must be valid.', 'The email is already taken.'],
+            },
+          },
+          false,
+          422,
+        ),
+      );
+
+      await expect(client.listServers()).rejects.toThrow(
+        'Validation failed. - name: The name field is required.; email: The email must be valid., The email is already taken.',
+      );
+    });
   });
 
   // =========================================================================

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -65,6 +65,7 @@ describe('CoolifyMcpServer v2', () => {
       expect(typeof client.getApplication).toBe('function');
       expect(typeof client.createApplicationPrivateGH).toBe('function');
       expect(typeof client.createApplicationPrivateKey).toBe('function');
+      expect(typeof client.createApplicationDockerImage).toBe('function');
       expect(typeof client.updateApplication).toBe('function');
       expect(typeof client.deleteApplication).toBe('function');
       expect(typeof client.getApplicationLogs).toBe('function');

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -278,7 +278,15 @@ export class CoolifyClient {
 
       if (!response.ok) {
         const error = data as ErrorResponse;
-        throw new Error(error.message || `HTTP ${response.status}: ${response.statusText}`);
+        // Include validation errors if present
+        let errorMessage = error.message || `HTTP ${response.status}: ${response.statusText}`;
+        if (error.errors && Object.keys(error.errors).length > 0) {
+          const validationDetails = Object.entries(error.errors)
+            .map(([field, messages]) => `${field}: ${messages.join(', ')}`)
+            .join('; ');
+          errorMessage = `${errorMessage} - ${validationDetails}`;
+        }
+        throw new Error(errorMessage);
       }
 
       return data as T;

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -20,6 +20,7 @@ export interface ErrorResponse {
   error?: string;
   message: string;
   status?: number;
+  errors?: Record<string, string[]>; // Validation errors by field
 }
 
 export interface DeleteOptions {
@@ -344,12 +345,24 @@ export interface UpdateApplicationRequest {
   install_command?: string;
   build_command?: string;
   start_command?: string;
+  // Health check configuration
   health_check_enabled?: boolean;
   health_check_path?: string;
   health_check_port?: number;
+  health_check_host?: string;
+  health_check_method?: string;
+  health_check_return_code?: number;
+  health_check_scheme?: string;
+  health_check_response_text?: string;
+  health_check_interval?: number;
+  health_check_timeout?: number;
+  health_check_retries?: number;
+  health_check_start_period?: number;
+  // Resource limits
   limits_memory?: string;
   limits_memory_swap?: string;
   limits_cpus?: string;
+  // HTTP Basic Auth
   is_http_basic_auth_enabled?: boolean;
   http_basic_auth_username?: string;
   http_basic_auth_password?: string;


### PR DESCRIPTION
## Summary

- **Docker Image Deployment** - Add `create_dockerimage` action to deploy from Docker Hub/registries
- **Health Check Configuration** - Add 12 health check fields to application create/update
- **Deployment Log Limiting** - Add `lines` parameter to truncate large deployment logs
- **Better Validation Errors** - Include field-level details in all API error messages

## Closes

- #62 - Health check configuration
- #68 - Deployment log line limiting  
- #69 - Validation errors + Docker image deployment

## Test plan

- [x] Unit tests pass (183 tests)
- [x] Manual testing against live Coolify instance
- [x] All 12 health check fields verified readable from API
- [x] Docker image method hits API correctly
- [x] Log truncation logic verified (200 → 50 lines)
- [x] Validation error formatting verified

Stu Mason + AI <me@stumason.dev>