### PR TITLE
feat: add support for creating applications from public repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ These tools accept human-friendly identifiers instead of just UUIDs:
 - `list_applications` - List all applications (returns summary)
 - `get_application` - Get application details
 - `application_logs` - Get application logs
-- `application` - Create, update, or delete apps with `action: create_github|create_key|update|delete`
+- `application` - Create, update, or delete apps with `action: create_public|create_github|create_key|update|delete`
 - `env_vars` - Manage env vars with `resource: application, action: list|create|update|delete`
 - `control` - Start/stop/restart with `resource: application, action: start|stop|restart`
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -63,6 +63,7 @@ describe('CoolifyMcpServer v2', () => {
       // Application operations
       expect(typeof client.listApplications).toBe('function');
       expect(typeof client.getApplication).toBe('function');
+      expect(typeof client.createApplicationPublic).toBe('function');
       expect(typeof client.createApplicationPrivateGH).toBe('function');
       expect(typeof client.createApplicationPrivateKey).toBe('function');
       expect(typeof client.createApplicationDockerImage).toBe('function');

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -259,7 +259,7 @@ export class CoolifyMcpServer extends McpServer {
       'application',
       'Manage app: create/update/delete',
       {
-        action: z.enum(['create_github', 'create_key', 'create_dockerimage', 'update', 'delete']),
+        action: z.enum(['create_public', 'create_github', 'create_key', 'create_dockerimage', 'update', 'delete']),
         uuid: z.string().optional(),
         // Create fields
         project_uuid: z.string().optional(),
@@ -269,6 +269,7 @@ export class CoolifyMcpServer extends McpServer {
         git_repository: z.string().optional(),
         git_branch: z.string().optional(),
         environment_name: z.string().optional(),
+        environment_uuid: z.string().optional(),
         build_pack: z.string().optional(),
         ports_exposes: z.string().optional(),
         // Docker image fields
@@ -297,6 +298,25 @@ export class CoolifyMcpServer extends McpServer {
       async (args) => {
         const { action, uuid } = args;
         switch (action) {
+          case 'create_public':
+            if (
+              !args.project_uuid ||
+              !args.server_uuid ||
+              !args.git_repository ||
+              !args.git_branch ||
+              !args.build_pack ||
+              !args.ports_exposes
+            ) {
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: project_uuid, server_uuid, git_repository, git_branch, build_pack, ports_exposes required',
+                  },
+                ],
+              };
+            }
+            return wrap(() => this.client.createApplicationPublic(args as any));
           case 'create_github':
             if (
               !args.project_uuid ||


### PR DESCRIPTION
Rebased version of #70 by @gorquan

## Changes
- Add `create_public` action to the application tool
- Allows creating applications from public Git repositories without SSH keys
- Adds `environment_uuid` field to application tool schema

## Original PR
https://github.com/StuMason/coolify-mcp/pull/70

Co-authored-by: gorquan <gorquanwu@gmail.com>