### PR TITLE
fix: strip MCP-internal fields before API calls

### DIFF
--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -303,7 +303,8 @@ export class CoolifyMcpServer extends McpServer {
         delete_volumes: z.boolean().optional(),
       },
       async (args) => {
-        const { action, uuid } = args;
+        // Strip MCP-internal fields before passing to API (fixes #76)
+        const { action, uuid, delete_volumes, ...apiData } = args;
         switch (action) {
           case 'create_public':
             if (
@@ -323,7 +324,7 @@ export class CoolifyMcpServer extends McpServer {
                 ],
               };
             }
-            return wrap(() => this.client.createApplicationPublic(args as any));
+            return wrap(() => this.client.createApplicationPublic(apiData as any));
           case 'create_github':
             if (
               !args.project_uuid ||
@@ -341,7 +342,7 @@ export class CoolifyMcpServer extends McpServer {
                 ],
               };
             }
-            return wrap(() => this.client.createApplicationPrivateGH(args as any));
+            return wrap(() => this.client.createApplicationPrivateGH(apiData as any));
           case 'create_key':
             if (
               !args.project_uuid ||
@@ -359,7 +360,7 @@ export class CoolifyMcpServer extends McpServer {
                 ],
               };
             }
-            return wrap(() => this.client.createApplicationPrivateKey(args as any));
+            return wrap(() => this.client.createApplicationPrivateKey(apiData as any));
           case 'create_dockerimage':
             if (
               !args.project_uuid ||
@@ -376,16 +377,16 @@ export class CoolifyMcpServer extends McpServer {
                 ],
               };
             }
-            return wrap(() => this.client.createApplicationDockerImage(args as any));
+            return wrap(() => this.client.createApplicationDockerImage(apiData as any));
           case 'update':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            return wrap(() => this.client.updateApplication(uuid, args));
+            return wrap(() => this.client.updateApplication(uuid, apiData));
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
             return wrap(() =>
-              this.client.deleteApplication(uuid, { deleteVolumes: args.delete_volumes }),
+              this.client.deleteApplication(uuid, { deleteVolumes: delete_volumes }),
             );
         }
       },
@@ -522,7 +523,8 @@ export class CoolifyMcpServer extends McpServer {
         delete_volumes: z.boolean().optional(),
       },
       async (args) => {
-        const { action, uuid } = args;
+        // Strip MCP-internal fields before passing to API (fixes #76)
+        const { action, uuid, delete_volumes, ...apiData } = args;
         switch (action) {
           case 'create':
             if (!args.server_uuid || !args.project_uuid) {
@@ -532,17 +534,15 @@ export class CoolifyMcpServer extends McpServer {
                 ],
               };
             }
-            return wrap(() => this.client.createService(args as any));
+            return wrap(() => this.client.createService(apiData as any));
           case 'update':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            return wrap(() => this.client.updateService(uuid, args));
+            return wrap(() => this.client.updateService(uuid, apiData));
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            return wrap(() =>
-              this.client.deleteService(uuid, { deleteVolumes: args.delete_volumes }),
-            );
+            return wrap(() => this.client.deleteService(uuid, { deleteVolumes: delete_volumes }));
         }
       },
     );


### PR DESCRIPTION
## Summary

- Fixes the `application` tool passing `action`, `uuid`, `delete_volumes` to the Coolify API
- Fixes the `service` tool with the same issue
- Adds tests documenting client pass-through behavior

## Root Cause

The consolidated tools use an `action` parameter for internal routing (e.g., `create_public`, `update`, `delete`). The handlers were passing the full `args` object to client methods, but the Coolify API rejects `action` with "This field is not allowed."

## Solution

Destructure args to separate MCP-internal fields from API payload:

```typescript
const { action, uuid, delete_volumes, ...apiData } = args;
// Now use apiData for API calls
```

## Test Plan

- [x] All 186 tests passing
- [x] Build successful
- [x] Lint clean

Fixes #76

Stu Mason + AI <me@stumason.dev>