### PR TITLE
fix: deployment logs truncation by character count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Deployment Logs Massive Payload** - Add character-based truncation (#82):
+  - `deployment` tool's `lines` parameter only limited line count, not characters
+  - Giant log lines (base64, docker build output) could still return 900K+ chars
+  - Fix: Default to last 200 lines AND cap at 50K characters
+  - Added `max_chars` parameter for customization
+
 ## [2.4.0] - 2026-01-15
 
 ### Added


### PR DESCRIPTION
## Problem

When fetching deployment logs with `lines: 50`, the API returns 917K+ characters because:
1. Coolify API doesn't support `lines` param - we fetch full log and truncate client-side
2. Our truncation only limited line COUNT, not CHARACTER count
3. Docker build logs have giant lines (base64 encoded data, minified code)

## Solution

Add **character-based truncation** as a safety net:

| Behavior | Before | After |
|----------|--------|-------|
| Default lines | Unlimited | Last 200 |
| Character limit | None | 50K (configurable) |
| Truncation indicator | None | `...[truncated]...` prefix |

## Changes

- Default to last 200 lines when `lines` not specified
- Cap at 50K characters regardless of line count
- Add `max_chars` parameter for customization
- Prepend `...[truncated]...` when character limit applied

## Test Plan

- [x] `npm test` - All 191 tests pass
- [x] `npm run build` - TypeScript compiles
- [ ] Manual: `deployment(action: "get", uuid: "...")` should return < 100K chars

Closes #82

Stu Mason + AI <me@stumason.dev>