### PR TITLE
chore: add Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,12 @@ jobs:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
           verbose: true
+
+      - name: Upload test results to Codecov
+        if: matrix.node-version == '20.x'
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/junit.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Codecov Test Analytics** - Enable test result tracking (#84):
+  - Added `jest-junit` reporter for JUnit XML output
+  - CI workflow now uploads test results to Codecov
+  - Enables flaky test detection and test performance tracking
+
 ### Fixed
 
 - **Deployment Logs Massive Payload** - Add character-based truncation (#82):

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,16 @@ export default {
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'text-summary', 'lcov'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'coverage',
+        outputName: 'junit.xml',
+      },
+    ],
+  ],
   coverageThreshold: {
     global: {
       statements: 80,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "globals": "^17.0.0",
         "husky": "^9.0.11",
         "jest": "^29.7.0",
+        "jest-junit": "^16.0.0",
         "lint-staged": "^16.2.7",
         "markdownlint-cli2": "^0.20.0",
         "prettier": "^3.5.3",
@@ -4501,6 +4502,22 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -6003,6 +6020,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -7857,6 +7887,16 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -8020,6 +8060,13 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "globals": "^17.0.0",
     "husky": "^9.0.11",
     "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
     "lint-staged": "^16.2.7",
     "markdownlint-cli2": "^0.20.0",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Summary

Adds Codecov Test Analytics to the CI pipeline, enabling:
- Flaky test detection
- Test performance tracking over time
- Test failure insights

## Changes

- Added `jest-junit` reporter for JUnit XML output
- Updated CI workflow with `codecov/test-results-action@v1` step
- JUnit output saved to `coverage/junit.xml`

## Note on Bundle Analysis

Issue #84 also mentioned JS Bundle Analysis, but that doesn't apply here since:
- This is a Node.js CLI tool, not a browser bundle
- No webpack/rollup/vite bundler - just TypeScript compiled to JS

## Test Plan

- [x] `npm test` - 199 tests pass, JUnit XML generated
- [x] Verified `coverage/junit.xml` contains correct test results

Closes #84

Stu Mason + AI <me@stumason.dev>