### PR TITLE
fix: cross-reference missing database types in environment endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Environment Endpoint Missing Database Types** - Cross-reference missing Dragonfly, KeyDB, and ClickHouse databases (#88):
+  - Coolify API's `/projects/{uuid}/{environment}` endpoint doesn't include `dragonflys`, `keydbs`, and `clickhouses` arrays
+  - The `environments` tool's `get` action now cross-references with `list_databases` to populate these missing types
+  - Databases are matched by `environment_uuid` or `environment_name`
+  - New `getProjectEnvironmentWithDatabases` client method added
+  - New `EnvironmentWithDatabases` type added to types
+  - This prevents invisible databases when auditing infrastructure or deleting projects
+
 ## [2.5.0] - 2026-01-15
 
 ### Added

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -57,6 +57,7 @@ describe('CoolifyMcpServer v2', () => {
       // Environment operations
       expect(typeof client.listProjectEnvironments).toBe('function');
       expect(typeof client.getProjectEnvironment).toBe('function');
+      expect(typeof client.getProjectEnvironmentWithDatabases).toBe('function');
       expect(typeof client.createProjectEnvironment).toBe('function');
       expect(typeof client.deleteProjectEnvironment).toBe('function');
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -237,7 +237,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'environments',
-      'Manage environments: list/get/create/delete',
+      'Manage environments: list/get/create/delete. Get action includes all database types (including dragonflys, keydbs, clickhouses that are missing from API)',
       {
         action: z.enum(['list', 'get', 'create', 'delete']),
         project_uuid: z.string(),
@@ -251,7 +251,8 @@ export class CoolifyMcpServer extends McpServer {
           case 'get':
             if (!name)
               return { content: [{ type: 'text' as const, text: 'Error: name required' }] };
-            return wrap(() => this.client.getProjectEnvironment(project_uuid, name));
+            // Use enhanced method that cross-references missing database types (#88)
+            return wrap(() => this.client.getProjectEnvironmentWithDatabases(project_uuid, name));
           case 'create':
             if (!name)
               return { content: [{ type: 'text' as const, text: 'Error: name required' }] };

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -1078,3 +1078,30 @@ export interface BatchOperationResult {
   succeeded: Array<{ uuid: string; name: string }>;
   failed: Array<{ uuid: string; name: string; error: string }>;
 }
+
+// =============================================================================
+// Extended Environment Types (for cross-referencing missing database types)
+// =============================================================================
+
+/**
+ * Environment with all database types.
+ * The Coolify API's environment endpoint doesn't include dragonflys, keydbs, and clickhouses
+ * in the response, even when they exist. This extended interface includes these missing
+ * database types, populated by cross-referencing with the list_databases endpoint.
+ * @see https://github.com/StuMason/coolify-mcp/issues/88
+ */
+export interface EnvironmentWithDatabases extends Environment {
+  // These arrays may be present in the API response
+  postgresqls?: Database[];
+  mysqls?: Database[];
+  mariadbs?: Database[];
+  mongodbs?: Database[];
+  redis?: Database[];
+  // These arrays are missing from the API but populated by cross-reference
+  dragonflys?: Database[];
+  keydbs?: Database[];
+  clickhouses?: Database[];
+  // Also include applications and services if present
+  applications?: Application[];
+  services?: Service[];
+}


### PR DESCRIPTION
## Summary

- Add cross-reference logic to populate missing Dragonfly, KeyDB, and ClickHouse databases in environment details
- The Coolify API doesn't include these database types in the environment endpoint response
- New `getProjectEnvironmentWithDatabases` method fetches environment and cross-references `list_databases`

Fixes #88

## Test plan

- [ ] Verify all 202 tests pass
- [ ] Test with a Dragonfly database in an environment - should now appear in response
- [ ] Verify KeyDB and ClickHouse databases also appear

🤖 Generated with [Claude Code](https://claude.ai/claude-code)