### PR TITLE
fix: remove is_build_time from env_vars create action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use `lines` parameter to include truncated logs when needed
   - Response includes `logs_info` field indicating log availability and size
 
+- **env_vars Create Validation Error** - Remove `is_build_time` parameter (#97):
+  - Coolify API rejects `is_build_time` on env var create despite OpenAPI docs
+  - Removed parameter from schema to avoid misleading users
+
 ## [2.5.0] - 2026-01-15
 
 ### Added

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -825,9 +825,8 @@ export class CoolifyMcpServer extends McpServer {
         key: z.string().optional(),
         value: z.string().optional(),
         env_uuid: z.string().optional(),
-        is_build_time: z.boolean().optional(),
       },
-      async ({ resource, action, uuid, key, value, env_uuid, is_build_time }) => {
+      async ({ resource, action, uuid, key, value, env_uuid }) => {
         if (resource === 'application') {
           switch (action) {
             case 'list':
@@ -835,9 +834,8 @@ export class CoolifyMcpServer extends McpServer {
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
-              return wrap(() =>
-                this.client.createApplicationEnvVar(uuid, { key, value, is_build_time }),
-              );
+              // Note: is_build_time is not passed - Coolify API rejects it for create action
+              return wrap(() => this.client.createApplicationEnvVar(uuid, { key, value }));
             case 'update':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
## Summary

Remove `is_build_time` parameter from the `env_vars` tool schema. Coolify API rejects this field for env var creation despite it being documented in the OpenAPI spec.

## Changes

- Remove `is_build_time` from tool schema (was misleading users)
- Remove from create action handler
- Add comment explaining why

## Test plan

- [x] `npm test` - 219 tests passing
- [x] Verified against issue reproduction steps

Fixes #97