### PR TITLE
fix(client): listApplicationDeployments returns envelope, defaults to essential projection

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -2118,16 +2118,46 @@ describe('CoolifyClient', () => {
       });
     });
 
-    it('should list application deployments', async () => {
-      mockFetch.mockResolvedValueOnce(mockResponse([mockDeployment]));
+    it('should list application deployments as essential by default (no logs)', async () => {
+      const withLogs = { ...mockDeployment, logs: 'x'.repeat(30000) };
+      // Real Coolify wraps the list in an envelope: { count, deployments: [...] }
+      mockFetch.mockResolvedValueOnce(mockResponse({ count: 1, deployments: [withLogs] }));
 
       const result = await client.listApplicationDeployments('app-uuid');
 
-      expect(result).toEqual([mockDeployment]);
+      expect(result.count).toBe(1);
+      expect(result.deployments).toHaveLength(1);
+      const [first] = result.deployments as Array<{
+        logs?: unknown;
+        logs_available?: boolean;
+        id?: unknown;
+      }>;
+      // Essential projection: no raw logs, but a `logs_available` breadcrumb.
+      expect(first.logs).toBeUndefined();
+      expect(first.logs_available).toBe(true);
+      // Essential also drops fields like `id`
+      expect(first.id).toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/deployments/applications/app-uuid',
         expect.any(Object),
       );
+    });
+
+    it('should return full deployments when includeLogs is true', async () => {
+      const withLogs = { ...mockDeployment, logs: 'build log stream' };
+      mockFetch.mockResolvedValueOnce(mockResponse({ count: 1, deployments: [withLogs] }));
+
+      const result = await client.listApplicationDeployments('app-uuid', { includeLogs: true });
+
+      expect(result).toEqual({ count: 1, deployments: [withLogs] });
+    });
+
+    it('should tolerate a malformed envelope (missing deployments array)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({}));
+
+      const result = await client.listApplicationDeployments('app-uuid');
+
+      expect(result).toEqual({ count: 0, deployments: [] });
     });
   });
 
@@ -2752,7 +2782,9 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(mockApp))
           .mockResolvedValueOnce(mockResponse(mockLogs))
           .mockResolvedValueOnce(mockResponse(mockEnvVars))
-          .mockResolvedValueOnce(mockResponse(mockDeployments));
+          .mockResolvedValueOnce(
+            mockResponse({ count: mockDeployments.length, deployments: mockDeployments }),
+          );
 
         const result = await client.diagnoseApplication(testAppUuid);
 
@@ -2781,7 +2813,7 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(unhealthyApp))
           .mockResolvedValueOnce(mockResponse(mockLogs))
           .mockResolvedValueOnce(mockResponse(mockEnvVars))
-          .mockResolvedValueOnce(mockResponse([]));
+          .mockResolvedValueOnce(mockResponse({ count: 0, deployments: [] }));
 
         const result = await client.diagnoseApplication(testAppUuid);
 
@@ -2798,7 +2830,9 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(mockApp))
           .mockResolvedValueOnce(mockResponse(mockLogs))
           .mockResolvedValueOnce(mockResponse(mockEnvVars))
-          .mockResolvedValueOnce(mockResponse(failedDeployments));
+          .mockResolvedValueOnce(
+            mockResponse({ count: failedDeployments.length, deployments: failedDeployments }),
+          );
 
         const result = await client.diagnoseApplication(testAppUuid);
 
@@ -2810,7 +2844,9 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(mockApp))
           .mockRejectedValueOnce(new Error('Logs unavailable'))
           .mockResolvedValueOnce(mockResponse(mockEnvVars))
-          .mockResolvedValueOnce(mockResponse(mockDeployments));
+          .mockResolvedValueOnce(
+            mockResponse({ count: mockDeployments.length, deployments: mockDeployments }),
+          );
 
         const result = await client.diagnoseApplication(testAppUuid);
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1009,8 +1009,29 @@ export class CoolifyClient {
     );
   }
 
-  async listApplicationDeployments(appUuid: string): Promise<Deployment[]> {
-    return this.request<Deployment[]>(`/deployments/applications/${appUuid}`);
+  /**
+   * List deployments for an application.
+   *
+   * Coolify returns `{ count, deployments: Deployment[] }` for this endpoint
+   * (NOT a raw array — upstream @masonator type was incorrect).
+   *
+   * By default returns a DeploymentEssential summary (no `logs` field) because
+   * each deployment's log blob can be 30–100KB, and a typical list has 20–35
+   * deployments — exceeding MCP response token limits. Pass `includeLogs: true`
+   * to get raw Deployment objects with full build logs.
+   */
+  async listApplicationDeployments(
+    appUuid: string,
+    options?: { includeLogs?: boolean },
+  ): Promise<{ count: number; deployments: Deployment[] | DeploymentEssential[] }> {
+    const envelope = await this.request<{ count: number; deployments: Deployment[] }>(
+      `/deployments/applications/${appUuid}`,
+    );
+    const deployments = Array.isArray(envelope?.deployments) ? envelope.deployments : [];
+    return {
+      count: typeof envelope?.count === 'number' ? envelope.count : deployments.length,
+      deployments: options?.includeLogs ? deployments : deployments.map(toDeploymentEssential),
+    };
   }
 
   // ===========================================================================
@@ -1334,7 +1355,10 @@ export class CoolifyClient {
     const app = extract(results[0], 'application');
     const logs = extract(results[1], 'logs');
     const envVars = extract(results[2], 'environment_variables');
-    const deployments = extract(results[3], 'deployments');
+    // listApplicationDeployments now returns { count, deployments: [...] } —
+    // flatten back to the array that the diagnostics consumer expects.
+    const deploymentsEnvelope = extract(results[3], 'deployments');
+    const deployments = deploymentsEnvelope?.deployments ?? [];
 
     // Determine health status and issues
     const issues: string[] = [];

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -954,7 +954,7 @@ export class CoolifyMcpServer extends McpServer {
 
     this.tool(
       'deployment',
-      'Manage deployment: get/cancel/list_for_app (logs excluded by default, use lines param to include)',
+      'Manage deployment: get/cancel/list_for_app. Logs excluded by default on all actions — for get use `lines` (paginated tail), for list_for_app use `include_logs: true` to include raw build-log blobs.',
       {
         action: z.enum(['get', 'cancel', 'list_for_app']),
         uuid: z.string(),

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -961,8 +961,9 @@ export class CoolifyMcpServer extends McpServer {
         lines: z.number().optional(), // Include logs truncated to last N entries (omit for no logs)
         page: z.number().optional(), // Log page (1=most recent, 2=older, etc.)
         max_chars: z.number().optional(), // Limit log output to last N chars (default: 50000)
+        include_logs: z.boolean().optional(), // list_for_app only: include raw build logs (default false; upstream returns ~30KB per deployment)
       },
-      async ({ action, uuid, lines, page, max_chars }) => {
+      async ({ action, uuid, lines, page, max_chars, include_logs }) => {
         switch (action) {
           case 'get':
             // If lines param specified, include logs and truncate
@@ -1014,7 +1015,9 @@ export class CoolifyMcpServer extends McpServer {
           case 'cancel':
             return wrap(() => this.client.cancelDeployment(uuid));
           case 'list_for_app':
-            return wrap(() => this.client.listApplicationDeployments(uuid));
+            return wrap(() =>
+              this.client.listApplicationDeployments(uuid, { includeLogs: include_logs }),
+            );
         }
       },
     );


### PR DESCRIPTION
## Symptom

`listApplicationDeployments(uuid)` can return responses **larger than 1 MB** on apps with a typical deployment history (20–40 deployments). When called from an MCP client (e.g. Claude Code), the response can blow past the model's context window or simply exhaust the MCP token budget on a single tool call. Smoke-tested live against Coolify `4.0.0-beta.472`: a 35-deployment app returned ~1 MB JSON, of which >99% was raw build-log blobs embedded in each deployment.

## Root cause

Two issues, same fix:

1. **Type lie.** The current return type `Promise<Deployment[]>` does not match the real Coolify response. `GET /api/v1/deployments/applications/{uuid}` actually returns an envelope:

   ```json
   { "count": 35, "deployments": [ /* Deployment[] */ ] }
   ```

   Verified live against Coolify `4.0.0-beta.472`. The existing type causes any caller using `.length`, `.map()`, etc. to blow up at runtime — only no-op callers were unaffected.

2. **No projection.** Each `Deployment` carries a full `logs` field (the entire build-log stream, often 30–100 KB per deployment). Returning all of them by default is a footgun for LLM/MCP callers.

## Fix

- Return the envelope shape `{ count, deployments }` honestly.
- Default `deployments` to `DeploymentEssential[]` (no `logs` blob, sets `logs_available: true` breadcrumb so callers know to refetch a single one if needed).
- Add `options.includeLogs?: boolean` opt-in for callers that genuinely want the raw build logs.
- Tolerate malformed envelopes (`{}` → `{ count: 0, deployments: [] }`).
- Update `diagnoseApplication` (the only internal caller) to flatten the envelope before iterating.
- Plumb a matching `include_logs` knob through the `deployment` MCP tool's `list_for_app` action.

## Smoke test (real Coolify 4.0.0-beta.472)

| Mode | Bytes |
|---|---|
| Old (`Deployment[]` w/ logs) | ~1,000,000+ |
| New default (`DeploymentEssential[]`) | **4,194** |
| New `includeLogs: true` | unchanged from old |

That's a ~250× reduction by default, and the raw-log path is still available behind a flag.

## Tests

- Replaced `should list application deployments` with three cases:
  - default essential projection (no `logs`, has `logs_available: true`, drops `id`)
  - `includeLogs: true` returns full deployments unchanged
  - tolerates malformed envelope (`{}`)
- Updated 4 `mockResponse(...)` calls in `diagnoseApplication` tests to wrap their input in the new envelope shape.
- `npm test`: 264/264 pass. Coverage stays at 97.7% statements / 83.9% branches / 99.4% functions / 98.7% lines.
- `npm run lint`: clean (4 pre-existing warnings, 0 new).
- `npm run build`: clean.

## Breaking change

Yes, but signaled by the signature change: `Promise<Deployment[]>` → `Promise<{ count: number; deployments: Deployment[] | DeploymentEssential[] }>`. Any caller currently treating the result as an array would have already been broken at runtime against real Coolify (since the API doesn't actually return an array), so in practice this only fixes broken callers and gives them a typed migration path.

---

Generated with [Claude Code](https://claude.com/claude-code).
