### PR TITLE
fix(applications): pass domains, instant_deploy, custom_docker_run_options, custom_labels to Coolify API

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1202,6 +1202,88 @@ describe('CoolifyClient', () => {
       expect(callBody.fqdn).toBeUndefined();
     });
 
+    it('should map fqdn to domains in createApplicationDockerImage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
+
+      await client.createApplicationDockerImage({
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+        docker_registry_image_name: 'traefik/whoami',
+        ports_exposes: '80',
+        fqdn: 'https://whoami.example.com',
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.domains).toBe('https://whoami.example.com');
+      expect(callBody.fqdn).toBeUndefined();
+    });
+
+    it('should map fqdn to domains in createApplicationDockerfile', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
+
+      await client.createApplicationDockerfile({
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+        dockerfile: 'FROM nginx',
+        fqdn: 'https://app.example.com',
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.domains).toBe('https://app.example.com');
+      expect(callBody.fqdn).toBeUndefined();
+    });
+
+    it('should map fqdn to domains in createApplicationDockerCompose', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
+
+      await client.createApplicationDockerCompose({
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+        docker_compose_raw: 'version: "3"\n',
+        fqdn: 'https://compose.example.com',
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.domains).toBe('https://compose.example.com');
+      expect(callBody.fqdn).toBeUndefined();
+    });
+
+    it('should accept explicit domains and prefer it over fqdn', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
+
+      await client.createApplicationDockerImage({
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+        docker_registry_image_name: 'traefik/whoami',
+        ports_exposes: '80',
+        fqdn: 'https://from-fqdn.example.com',
+        domains: 'https://from-domains.example.com',
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.domains).toBe('https://from-domains.example.com');
+      expect(callBody.fqdn).toBeUndefined();
+    });
+
+    it('should pass instant_deploy and custom_* fields through createApplicationDockerImage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
+
+      await client.createApplicationDockerImage({
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+        docker_registry_image_name: 'traefik/whoami',
+        ports_exposes: '80',
+        instant_deploy: true,
+        custom_docker_run_options: '--network=my-net',
+        custom_labels: 'dHJhZWZpaw==',
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.instant_deploy).toBe(true);
+      expect(callBody.custom_docker_run_options).toBe('--network=my-net');
+      expect(callBody.custom_labels).toBe('dHJhZWZpaw==');
+    });
+
     it('should pass destination_uuid through in createApplicationPublic', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -201,10 +201,16 @@ function toBase64(value: string): string {
  * Coolify API uses 'domains' field for setting application domain, not 'fqdn'.
  * This provides backward compatibility for callers using 'fqdn'.
  */
-function mapFqdnToDomains<T extends { fqdn?: string }>(
+function mapFqdnToDomains<T extends { fqdn?: string; domains?: string }>(
   data: T,
 ): Omit<T, 'fqdn'> & { domains?: string } {
   const { fqdn, ...rest } = data;
+  // Explicit `domains` always wins. `fqdn` is only used when `domains` was
+  // not provided — kept for backward compatibility because `get_application`
+  // surfaces the field as `fqdn` in responses.
+  if (rest.domains !== undefined) {
+    return rest;
+  }
   if (fqdn === undefined) {
     return rest;
   }
@@ -648,7 +654,7 @@ export class CoolifyClient {
   ): Promise<UuidResponse> {
     return this.request<UuidResponse>('/applications/dockerfile', {
       method: 'POST',
-      body: JSON.stringify(data),
+      body: JSON.stringify(mapFqdnToDomains(data)),
     });
   }
 
@@ -657,14 +663,15 @@ export class CoolifyClient {
   ): Promise<UuidResponse> {
     return this.request<UuidResponse>('/applications/dockerimage', {
       method: 'POST',
-      body: JSON.stringify(data),
+      body: JSON.stringify(mapFqdnToDomains(data)),
     });
   }
 
   async createApplicationDockerCompose(
     data: CreateApplicationDockerComposeRequest,
   ): Promise<UuidResponse> {
-    const payload = { ...data };
+    const mapped = mapFqdnToDomains(data);
+    const payload = { ...mapped };
     if (payload.docker_compose_raw) {
       payload.docker_compose_raw = toBase64(payload.docker_compose_raw);
     }

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -473,6 +473,10 @@ export class CoolifyMcpServer extends McpServer {
         name: z.string().optional(),
         description: z.string().optional(),
         fqdn: z.string().optional(),
+        domains: z.string().optional(),
+        custom_docker_run_options: z.string().optional(),
+        custom_labels: z.string().optional(),
+        instant_deploy: z.boolean().optional(),
         // Health check fields
         health_check_enabled: z.boolean().optional(),
         health_check_path: z.string().optional(),
@@ -524,6 +528,10 @@ export class CoolifyMcpServer extends McpServer {
                 name: args.name,
                 description: args.description,
                 fqdn: args.fqdn,
+                domains: args.domains,
+                custom_docker_run_options: args.custom_docker_run_options,
+                custom_labels: args.custom_labels,
+                instant_deploy: args.instant_deploy,
               }),
             );
           case 'create_github':
@@ -558,6 +566,10 @@ export class CoolifyMcpServer extends McpServer {
                 name: args.name,
                 description: args.description,
                 fqdn: args.fqdn,
+                domains: args.domains,
+                custom_docker_run_options: args.custom_docker_run_options,
+                custom_labels: args.custom_labels,
+                instant_deploy: args.instant_deploy,
               }),
             );
           case 'create_key':
@@ -592,6 +604,10 @@ export class CoolifyMcpServer extends McpServer {
                 name: args.name,
                 description: args.description,
                 fqdn: args.fqdn,
+                domains: args.domains,
+                custom_docker_run_options: args.custom_docker_run_options,
+                custom_labels: args.custom_labels,
+                instant_deploy: args.instant_deploy,
               }),
             );
           case 'create_dockerimage':
@@ -623,6 +639,10 @@ export class CoolifyMcpServer extends McpServer {
                 name: args.name,
                 description: args.description,
                 fqdn: args.fqdn,
+                domains: args.domains,
+                custom_docker_run_options: args.custom_docker_run_options,
+                custom_labels: args.custom_labels,
+                instant_deploy: args.instant_deploy,
               }),
             );
           case 'update': {

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -255,6 +255,7 @@ export interface CreateApplicationPublicRequest {
   name?: string;
   description?: string;
   fqdn?: string;
+  domains?: string;
   git_repository: string;
   git_branch: string;
   git_commit_sha?: string;
@@ -266,6 +267,8 @@ export interface CreateApplicationPublicRequest {
   install_command?: string;
   build_command?: string;
   start_command?: string;
+  custom_docker_run_options?: string;
+  custom_labels?: string;
   instant_deploy?: boolean;
 }
 
@@ -296,11 +299,14 @@ export interface CreateApplicationDockerfileRequest {
   name?: string;
   description?: string;
   fqdn?: string;
+  domains?: string;
   dockerfile: string;
   dockerfile_location?: string;
   ports_exposes?: string;
   ports_mappings?: string;
   base_directory?: string;
+  custom_docker_run_options?: string;
+  custom_labels?: string;
   instant_deploy?: boolean;
 }
 
@@ -313,10 +319,13 @@ export interface CreateApplicationDockerImageRequest {
   name?: string;
   description?: string;
   fqdn?: string;
+  domains?: string;
   docker_registry_image_name: string;
   docker_registry_image_tag?: string;
   ports_exposes: string;
   ports_mappings?: string;
+  custom_docker_run_options?: string;
+  custom_labels?: string;
   instant_deploy?: boolean;
 }
 
@@ -328,10 +337,14 @@ export interface CreateApplicationDockerComposeRequest {
   destination_uuid?: string;
   name?: string;
   description?: string;
+  fqdn?: string;
+  domains?: string;
   docker_compose_raw: string;
   docker_compose_location?: string;
   docker_compose_custom_start_command?: string;
   docker_compose_custom_build_command?: string;
+  custom_docker_run_options?: string;
+  custom_labels?: string;
   instant_deploy?: boolean;
 }
 
@@ -339,6 +352,9 @@ export interface UpdateApplicationRequest {
   name?: string;
   description?: string;
   fqdn?: string;
+  domains?: string;
+  custom_docker_run_options?: string;
+  custom_labels?: string;
   git_repository?: string;
   git_branch?: string;
   git_commit_sha?: string;


### PR DESCRIPTION
> Stacked on top of #161. Rebases to main cleanly once that merges.

## Three related issues with the `application` tool's create/update fields

### 1. Bug — fqdn silently dropped on three create paths

The `mapFqdnToDomains()` translation in the client was applied on the public / private-github-app / private-deploy-key / update paths, but **not** on `dockerfile`, `dockerimage`, or `dockercompose`. So calling

```jsonc
{
  \"action\": \"create_dockerimage\",
  \"docker_registry_image_name\": \"traefik/whoami\",
  \"ports_exposes\": \"80\",
  \"fqdn\": \"https://whoami.example.com\",
  \"...\": \"...\"
}
```

sent the literal key `fqdn` to Coolify, which dropped it. The app got created with no domain and no error surfaced to the caller — pure silent failure.

### 2. No way to pass `domains` directly

Callers naturally try `domains` because the Coolify API documents that name **and** because `get_application` returns the field labeled `fqdn` in responses. Both should work. Now both do — if both are present, explicit `domains` wins.

### 3. Three useful API fields weren't exposed

Coolify already accepts these on create + update; they were just absent from the MCP surface:

| Field | Why it's useful |
|---|---|
| `instant_deploy: boolean` | Create + deploy in one call. (Was already in the TS request types but not in the MCP schema.) |
| `custom_docker_run_options: string` | Add flags like \`--network=...\` without going to the UI. |
| `custom_labels: string` (base64) | Custom Traefik routing rules beyond what FQDN auto-generates. |

## Changes

**`src/lib/coolify-client.ts`**
- Apply `mapFqdnToDomains()` to `createApplicationDockerImage`, `createApplicationDockerfile`, `createApplicationDockerCompose`.
- Update `mapFqdnToDomains()` to prefer an explicit `domains` value over the legacy `fqdn` alias when both are present.

**`src/types/coolify.ts`**
- Add `domains?: string`, `custom_docker_run_options?: string`, `custom_labels?: string` to all 6 `CreateApplication*Request` types and to `UpdateApplicationRequest`. (`instant_deploy` was already typed.)

**`src/lib/mcp-server.ts`**
- Add `domains`, `custom_docker_run_options`, `custom_labels`, `instant_deploy` to the `application` tool input schema.
- Thread all four through the four `create_*` dispatch arms. `update` picks them up via the existing rest-spread.

## Tests (`+5`, 268 total)

- `dockerimage`: `fqdn → domains` mapping (regression test for the bug)
- `dockerfile`: same
- `dockercompose`: same
- explicit `domains` takes precedence over `fqdn` when both are passed
- `instant_deploy`, `custom_docker_run_options`, `custom_labels` pass through on `dockerimage`

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 268 passed (263 existing + 5 new)
- [x] Live verification deferred: I'm wiring this up in production via a fork-build right after merge; happy to add the run output here if useful.