### PR TITLE
fix(ci): unblock Claude workflows with explicit github_token + current model IDs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: 'claude'
           prompt: |
             REPO: ${{ github.repository }}
@@ -51,4 +52,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-sonnet-4-6 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model claude-opus-4-5
+            --model claude-opus-4-7
             --allowedTools "Bash(gh:*),Bash(npm:*),Bash(composer:*)"
             --system-prompt "You can create PRs with 'gh pr create', merge with 'gh pr merge', and comment with 'gh issue comment'. Use gh CLI for all GitHub operations."


### PR DESCRIPTION
## Summary
- Pass `github_token: \${{ secrets.GITHUB_TOKEN }}` to `anthropics/claude-code-action@v1` in both Claude workflows. Per upstream issue [anthropics/claude-code-action#649](https://github.com/anthropics/claude-code-action/issues/649), this bypasses the broken OIDC fetch path that's been failing every PR review with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` (despite `id-token: write` being granted).
- Bump stale model IDs: `claude-opus-4-5` / `claude-opus-4-5-20251101` → `claude-opus-4-7` (interactive `claude.yml`) and `claude-sonnet-4-6` (review-only `claude-code-review.yml`, sonnet is enough for diff review and cheaper).

## Test plan
- [x] Confirm yaml lints
- [ ] Merge and observe Claude review fires successfully on the next PR (#161 / #162 are good test candidates — re-trigger after merge)
- [ ] Confirm @claude mention dispatch still works on issues / PR comments