### PR TITLE
chore: release v2.8.0 — application params + deployment listing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-04-28
+
+### Added
+
+- **`destination_uuid` on application create** (#161, thanks @barbe1bc) — Specify which Docker network destination on multi-destination Coolify hosts. Without it, hosts with multiple destinations silently fell back to the default destination.
+- **`domains` field accepted on application create** (#162, thanks @barbe1bc) — Pass `domains` directly alongside the existing `fqdn` alias. Explicit `domains` wins when both are set.
+- **`instant_deploy`, `custom_docker_run_options`, `custom_labels` on application create** (#162, thanks @barbe1bc) — All three were already accepted by Coolify; now exposed on the MCP tool surface.
+- **`include_logs` opt-in on `deployment list_for_app`** (#158, thanks @kashik0i) — Set `include_logs: true` to retrieve raw build logs (default: false).
+
+### Fixed
+
+- **Silent drop of `fqdn` on dockerfile/dockerimage/dockercompose creates** (#162, thanks @barbe1bc) — `mapFqdnToDomains()` was applied on public/github/key paths but not on the docker-\* paths. Calls passing `fqdn` got an app with no domain and no error surfaced.
+- **`listApplicationDeployments` response shape** (#158, thanks @kashik0i) — Now correctly parses Coolify's actual `{ count, deployments: [] }` envelope. Previously typed as `Promise<Deployment[]>` which was wrong-at-runtime — any caller using `.length` / `.map()` would crash against a real Coolify server.
+- **MCP token budget on deployment listing** (#158, thanks @kashik0i) — `list_for_app` now returns `DeploymentEssential` summaries by default (no raw `logs` blobs). A typical 35-deployment response shrinks from ~1 MB to ~4 KB (~250×). Pass `include_logs: true` to opt back in.
+
+### Changed (breaking, typed-only)
+
+- **`listApplicationDeployments` signature** (#158): `Promise<Deployment[]>` → `Promise<{ count: number; deployments: Deployment[] | DeploymentEssential[] }>`. Programmatic consumers of `@masonator/coolify-mcp` will need to update destructuring. Note: the previous type was wrong-at-runtime against real Coolify, so any caller that worked end-to-end was already accommodating the envelope shape.
+
+### Internal
+
+- Fixed Claude Code workflows broken on OIDC token fetch (#165) — explicit `github_token`, current model IDs.
+- Dependency bumps: dependabot/fetch-metadata 3, actions/github-script 9, action-gh-release 3 (#154, #155, #156); npm minor-and-patch group of 9 dev-deps (#160).
+
 ## [2.7.3] - 2026-02-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ The Coolify API returns extremely verbose responses - a single application can c
 
 ### Response Size Comparison
 
-| Endpoint              | Full Response | Summary Response | Reduction |
-| --------------------- | ------------- | ---------------- | --------- |
-| list_applications     | ~170KB        | ~4.4KB           | **97%**   |
-| list_services         | ~367KB        | ~1.2KB           | **99%**   |
-| list_servers          | ~4KB          | ~0.4KB           | **90%**   |
-| list_application_envs | ~3KB/var      | ~0.1KB/var       | **97%**   |
-| deployment get        | ~13KB         | ~1KB             | **92%**   |
+| Endpoint                | Full Response | Summary Response | Reduction |
+| ----------------------- | ------------- | ---------------- | --------- |
+| list_applications       | ~170KB        | ~4.4KB           | **97%**   |
+| list_services           | ~367KB        | ~1.2KB           | **99%**   |
+| list_servers            | ~4KB          | ~0.4KB           | **90%**   |
+| list_application_envs   | ~3KB/var      | ~0.1KB/var       | **97%**   |
+| deployment get          | ~13KB         | ~1KB             | **92%**   |
+| deployment list_for_app | ~1MB          | ~4KB             | **99.6%** |
 
 ### HATEOAS-style Response Actions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masonator/coolify-mcp",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@masonator/coolify-mcp",
-      "version": "2.7.3",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "mcpName": "io.github.StuMason/coolify",
   "description": "MCP server for Coolify — 38 optimized tools for infrastructure management, diagnostics, and documentation search",
   "type": "module",


### PR DESCRIPTION
## Summary
Cuts v2.8.0. Includes three contributor PRs (thanks @barbe1bc and @kashik0i), the Claude workflow OIDC fix, and routine dep bumps.

### Highlights
- **New on `application` tool**: `destination_uuid`, `domains`, `instant_deploy`, `custom_docker_run_options`, `custom_labels` (#161, #162)
- **New on `deployment` tool**: `include_logs` opt-in for `list_for_app` (#158)
- **Bug fix**: silent `fqdn` drop on `dockerfile`/`dockerimage`/`dockercompose` creates (#162)
- **Bug fix**: `listApplicationDeployments` now parses Coolify's real `{ count, deployments: [] }` envelope (#158)
- **Token budget**: `list_for_app` default response shrinks ~250× (1 MB → 4 KB) by dropping log blobs unless requested (#158)

### One typed-only breaking note
`listApplicationDeployments` signature changed (see CHANGELOG). The old type was wrong-at-runtime, so working callers were already accommodating the new shape.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 270 pass
- [ ] After merge, publish.yml auto-publishes to npm and creates a GitHub Release from the CHANGELOG section