### PR TITLE
feat: add --header flag for custom HTTP headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1762,6 +1763,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2255,6 +2257,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2603,6 +2606,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3336,6 +3340,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3642,6 +3647,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4229,6 +4235,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4649,6 +4656,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -5695,6 +5703,7 @@
       "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "globby": "16.2.0",
         "js-yaml": "4.1.1",
@@ -8021,6 +8030,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8187,6 +8197,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8702,6 +8713,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky || true",
-    "postinstall": "npm run build || true",
+    "prepare": "husky",
     "prepublishOnly": "npm test && npm run lint",
     "start": "node dist/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky",
+    "prepare": "husky || true",
+    "postinstall": "npm run build || true",
     "prepublishOnly": "npm test && npm run lint",
     "start": "node dist/index.js"
   },

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -150,6 +150,51 @@ describe('CoolifyClient', () => {
         expect.any(Object),
       );
     });
+
+    it('should merge customHeaders into outgoing requests', async () => {
+      const c = new CoolifyClient({
+        baseUrl: 'http://localhost:3000',
+        accessToken: 'test-token',
+        customHeaders: { 'CF-Access-Client-Id': 'abc', 'CF-Access-Client-Secret': 'xyz' },
+      });
+      mockFetch.mockResolvedValueOnce(mockResponse([{ uuid: 's1', name: 'srv' }]));
+
+      await c.listServers();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'CF-Access-Client-Id': 'abc',
+            'CF-Access-Client-Secret': 'xyz',
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('should filter reserved headers from customHeaders', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const c = new CoolifyClient({
+        baseUrl: 'http://localhost:3000',
+        accessToken: 'test-token',
+        customHeaders: {
+          Authorization: 'Bearer override',
+          'Content-Type': 'text/plain',
+          'X-Safe-Header': 'allowed',
+        },
+      });
+      mockFetch.mockResolvedValueOnce(mockResponse([{ uuid: 's1', name: 'srv' }]));
+
+      await c.listServers();
+
+      const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer test-token');
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['X-Safe-Header']).toBe('allowed');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+    });
   });
 
   describe('listServers', () => {

--- a/src/__tests__/parse-headers.test.ts
+++ b/src/__tests__/parse-headers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseHeaders } from '../lib/parse-headers.js';
+
+describe('parseHeaders', () => {
+  it('should parse a single header', () => {
+    const result = parseHeaders(['--header', 'X-Custom: value']);
+    expect(result).toEqual({ 'X-Custom': 'value' });
+  });
+
+  it('should parse multiple headers', () => {
+    const result = parseHeaders(['--header', 'X-First: one', '--header', 'X-Second: two']);
+    expect(result).toEqual({ 'X-First': 'one', 'X-Second': 'two' });
+  });
+
+  it('should ignore malformed headers without a colon', () => {
+    const result = parseHeaders(['--header', 'no-colon-here']);
+    expect(result).toEqual({});
+  });
+
+  it('should trim whitespace from key and value', () => {
+    const result = parseHeaders(['--header', '  X-Spaced  :  some value  ']);
+    expect(result).toEqual({ 'X-Spaced': 'some value' });
+  });
+
+  it('should handle header value containing colons', () => {
+    const result = parseHeaders(['--header', 'Authorization: Bearer abc:def:ghi']);
+    expect(result).toEqual({ Authorization: 'Bearer abc:def:ghi' });
+  });
+
+  it('should return empty object when no headers provided', () => {
+    expect(parseHeaders([])).toEqual({});
+    expect(parseHeaders(['--other', 'flag'])).toEqual({});
+  });
+
+  it('should ignore --header without a following value', () => {
+    const result = parseHeaders(['--header']);
+    expect(result).toEqual({});
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,22 +2,8 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CoolifyMcpServer } from './lib/mcp-server.js';
+import { parseHeaders } from './lib/parse-headers.js';
 import type { CoolifyConfig } from './types/coolify.js';
-
-function parseHeaders(argv: string[]): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--header' && i + 1 < argv.length) {
-      const value = argv[i + 1];
-      const colonIndex = value.indexOf(':');
-      if (colonIndex > 0) {
-        headers[value.slice(0, colonIndex).trim()] = value.slice(colonIndex + 1).trim();
-      }
-      i++;
-    }
-  }
-  return headers;
-}
 
 async function main(): Promise<void> {
   const customHeaders = parseHeaders(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,28 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CoolifyMcpServer } from './lib/mcp-server.js';
 import type { CoolifyConfig } from './types/coolify.js';
 
+function parseHeaders(argv: string[]): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--header' && i + 1 < argv.length) {
+      const value = argv[i + 1];
+      const colonIndex = value.indexOf(':');
+      if (colonIndex > 0) {
+        headers[value.slice(0, colonIndex).trim()] = value.slice(colonIndex + 1).trim();
+      }
+      i++;
+    }
+  }
+  return headers;
+}
+
 async function main(): Promise<void> {
+  const customHeaders = parseHeaders(process.argv);
+
   const config: CoolifyConfig = {
     baseUrl: process.env.COOLIFY_BASE_URL || 'http://localhost:3000',
     accessToken: process.env.COOLIFY_ACCESS_TOKEN || '',
+    customHeaders: Object.keys(customHeaders).length > 0 ? customHeaders : undefined,
   };
 
   if (!config.accessToken) {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -332,6 +332,7 @@ function toEnvVarSummary(envVar: EnvironmentVariable): EnvVarSummary {
 export class CoolifyClient {
   private readonly baseUrl: string;
   private readonly accessToken: string;
+  private readonly customHeaders: Record<string, string>;
   private cachedVersion: string | null = null;
 
   constructor(config: CoolifyConfig) {
@@ -343,6 +344,7 @@ export class CoolifyClient {
     }
     this.baseUrl = config.baseUrl.replace(/\/$/, '');
     this.accessToken = config.accessToken;
+    this.customHeaders = config.customHeaders ?? {};
   }
 
   // ===========================================================================
@@ -358,6 +360,7 @@ export class CoolifyClient {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.accessToken}`,
+          ...this.customHeaders,
           ...options.headers,
         },
       });
@@ -418,6 +421,7 @@ export class CoolifyClient {
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
+        ...this.customHeaders,
       },
     });
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -344,7 +344,18 @@ export class CoolifyClient {
     }
     this.baseUrl = config.baseUrl.replace(/\/$/, '');
     this.accessToken = config.accessToken;
-    this.customHeaders = config.customHeaders ?? {};
+
+    const reserved = new Set(['authorization', 'content-type']);
+    const raw = config.customHeaders ?? {};
+    const filtered: Record<string, string> = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (reserved.has(key.toLowerCase())) {
+        console.warn(`Custom header "${key}" ignored: reserved by the Coolify client`);
+      } else {
+        filtered[key] = value;
+      }
+    }
+    this.customHeaders = filtered;
   }
 
   // ===========================================================================

--- a/src/lib/parse-headers.ts
+++ b/src/lib/parse-headers.ts
@@ -1,0 +1,14 @@
+export function parseHeaders(argv: string[]): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--header' && i + 1 < argv.length) {
+      const value = argv[i + 1];
+      const colonIndex = value.indexOf(':');
+      if (colonIndex > 0) {
+        headers[value.slice(0, colonIndex).trim()] = value.slice(colonIndex + 1).trim();
+      }
+      i++;
+    }
+  }
+  return headers;
+}

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -10,6 +10,7 @@
 export interface CoolifyConfig {
   baseUrl: string;
   accessToken: string;
+  customHeaders?: Record<string, string>;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds `--header` CLI flag to inject custom HTTP headers on all API requests
- Multiple `--header` flags can be specified (e.g., `--header "CF-Access-Client-Id: value" --header "CF-Access-Client-Secret: value"`)
- Headers are applied to all outgoing requests alongside the existing `Authorization: Bearer` header
- Useful for Cloudflare Zero Trust, custom auth proxies, and other middleware that requires additional headers

## Changes
- `CoolifyConfig` interface: added optional `customHeaders` field
- `CoolifyClient`: spreads `customHeaders` into all fetch requests (both `request()` and `getVersion()`)
- `index.ts`: parses `--header "Name: Value"` from argv, passes to config

## Usage
```bash
npx @masonator/coolify-mcp \
  --header "CF-Access-Client-Id: abc123.access" \
  --header "CF-Access-Client-Secret: secret"
```

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] Verified headers appear on outbound requests using echo server
- [x] MCP tools/list works with custom headers
- [x] Multiple --header flags coexist correctly