### PR TITLE
chore: release v2.8.1 — --header CLI flag for custom HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-04-28
+
+### Added
+
+- **`--header` CLI flag for custom HTTP headers** (#167, thanks @imantsk) — Inject extra headers (e.g. `--header "CF-Access-Client-Id: ..." --header "CF-Access-Client-Secret: ..."`) on every outbound request. Useful for Cloudflare Zero Trust, custom auth proxies, and other middleware sitting in front of Coolify. Multiple `--header` flags can be combined. Reserved headers (`Authorization`, `Content-Type`) are filtered with a warning to prevent silently overriding the Coolify bearer token.
+
 ## [2.8.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ claude mcp add coolify \
 env COOLIFY_ACCESS_TOKEN=your-api-token COOLIFY_BASE_URL=https://your-coolify-instance.com npx -y @masonator/coolify-mcp
 ```
 
+### Custom HTTP Headers (Cloudflare Zero Trust, Auth Proxies)
+
+If your Coolify instance sits behind a Cloudflare Access tunnel or other auth-proxy middleware, pass extra headers on every outbound request with `--header`:
+
+```json
+{
+  "mcpServers": {
+    "coolify": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@masonator/coolify-mcp",
+        "--header",
+        "CF-Access-Client-Id: abc123.access",
+        "--header",
+        "CF-Access-Client-Secret: your-secret"
+      ],
+      "env": {
+        "COOLIFY_ACCESS_TOKEN": "your-api-token",
+        "COOLIFY_BASE_URL": "https://your-coolify-instance.com"
+      }
+    }
+  }
+}
+```
+
+Multiple `--header` flags can be combined. The reserved headers `Authorization` and `Content-Type` are filtered (with a warning) to prevent silently overriding the Coolify bearer token.
+
 ## Context-Optimized Responses
 
 ### Why This Matters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masonator/coolify-mcp",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@masonator/coolify-mcp",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "mcpName": "io.github.StuMason/coolify",
   "description": "MCP server for Coolify — 38 optimized tools for infrastructure management, diagnostics, and documentation search",
   "type": "module",


### PR DESCRIPTION
## Summary
Cuts v2.8.1. One feature: the `--header` CLI flag from #167 (thanks @imantsk).

### What's in
- **`--header` flag** on the MCP server CLI for injecting custom HTTP headers on every outbound request. Targets Cloudflare Zero Trust, auth proxies, and similar middleware. Multiple `--header` flags combine. Reserved headers (`Authorization`, `Content-Type`) are filtered with a warning.

README gets a new "Custom HTTP Headers" section under Installation showing the Cloudflare Access example.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 279 pass (was 270 on 2.8.0 — @imantsk's 9 new tests included)
- [ ] After merge, publish.yml auto-publishes 2.8.1 to npm and cuts the GitHub Release from the CHANGELOG block