### PR TITLE
feat: add 7 new tools and expand 3 existing (38 → 45 total)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`delete_preview` moved into `application` tool** — `delete_preview` is now `action: 'delete_preview'` on the existing `application` tool (alongside create/update/delete), consistent with the v2.0.0 consolidation pattern. The standalone `delete_preview` tool is removed.
+- **`system` tool consolidates health/resource/API controls** — `health`, `list_resources`, and `api_control` are removed as standalone tools and replaced by a single `system` tool with `action: 'health' | 'list_resources' | 'enable_api' | 'disable_api'`. Net tool count: 45 → 42.
+- **`storages` `update` action now requires `storage_uuid`** — Previously `storage_uuid` was not validated for `update`, causing the PATCH to send without the required field. Also fixed data construction to occur inside each action branch (after validation), so non-null assertions are guaranteed.
+
+### Fixed
+
+- **`listResources()` explicit return type** — Changed from `Promise<unknown>` to `Promise<ResourceListItem[]>` with a new `ResourceListItem` interface in `src/types/coolify.ts`, complying with the project's no-implicit-any policy.
+
 ## [2.10.0] - 2026-05-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,6 @@ When making changes to the codebase, ensure documentation is updated:
    - New example prompts needed
    - Response size improvements made (update comparison table)
 
-3. **This file (CLAUDE.md)** - Update tool count if changed (currently 38 tools)
+3. **This file (CLAUDE.md)** - Update tool count if changed (currently 45 tools)
 
 Always work on a feature branch and include documentation updates in the same PR as code changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Coolify that provides 38 token-optimized tools for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, teams, cloud tokens, documentation search, smart diagnostics, and batch operations. v2.0.0 reduced token usage by 85% (from ~43,000 to ~6,600 tokens) by consolidating related operations into single tools with action parameters.
+MCP (Model Context Protocol) server for Coolify that provides 42 token-optimized tools for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, teams, cloud tokens, documentation search, smart diagnostics, and batch operations. v2.0.0 reduced token usage by 85% (from ~43,000 to ~6,600 tokens) by consolidating related operations into single tools with action parameters.
 
 ## Commands
 
@@ -144,6 +144,6 @@ When making changes to the codebase, ensure documentation is updated:
    - New example prompts needed
    - Response size improvements made (update comparison table)
 
-3. **This file (CLAUDE.md)** - Update tool count if changed (currently 45 tools)
+3. **This file (CLAUDE.md)** - Update tool count if changed (currently 42 tools)
 
 Always work on a feature branch and include documentation updates in the same PR as code changes.

--- a/README.md
+++ b/README.md
@@ -9,26 +9,26 @@
 [![codecov](https://codecov.io/gh/StuMason/coolify-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/StuMason/coolify-mcp)
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/stumason-coolify-mcp-badge.png)](https://mseep.ai/app/stumason-coolify-mcp)
 
-> **The most comprehensive MCP server for Coolify** - 45 optimized tools, smart diagnostics, documentation search, and batch operations for managing your self-hosted PaaS through AI assistants.
+> **The most comprehensive MCP server for Coolify** - 42 optimized tools, smart diagnostics, documentation search, and batch operations for managing your self-hosted PaaS through AI assistants.
 
 A Model Context Protocol (MCP) server for [Coolify](https://coolify.io/), enabling AI assistants to manage and debug your Coolify instances through natural language.
 
 ## Features
 
-This MCP server provides **45 token-optimized tools** for **debugging, management, and deployment**:
+This MCP server provides **42 token-optimized tools** for **debugging, management, and deployment**:
 
 | Category             | Tools                                                                                                                               |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `list_resources`, `health`                                         |
+| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `system` (health, list_resources, enable/disable API)              |
 | **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                                    |
 | **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                                      |
 | **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`                                               |
 | **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                     |
 | **Environments**     | `environments` (list, get, create, delete via action param)                                                                         |
-| **Applications**     | `list_applications`, `get_application`, `application` (CRUD), `application_logs`, `delete_preview`                                  |
+| **Applications**     | `list_applications`, `get_application`, `application` (CRUD + delete_preview), `application_logs`                                   |
 | **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, delete), `database_backups` (CRUD schedules, executions incl. delete) |
 | **Services**         | `list_services`, `get_service`, `service` (create, update, delete)                                                                  |
-| **Control**          | `control` (start/stop/restart for apps, databases, services), `api_control` (enable/disable API)                                    |
+| **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                        |
 | **Env Vars**         | `env_vars` (CRUD + bulk_update for application, service, and database env vars)                                                     |
 | **Storages**         | `storages` (list, create, update, delete persistent/file storages for apps, databases, services)                                    |
 | **Scheduled Tasks**  | `scheduled_tasks` (list, create, update, delete, list_executions for apps and services)                                             |

--- a/README.md
+++ b/README.md
@@ -9,33 +9,36 @@
 [![codecov](https://codecov.io/gh/StuMason/coolify-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/StuMason/coolify-mcp)
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/stumason-coolify-mcp-badge.png)](https://mseep.ai/app/stumason-coolify-mcp)
 
-> **The most comprehensive MCP server for Coolify** - 38 optimized tools, smart diagnostics, documentation search, and batch operations for managing your self-hosted PaaS through AI assistants.
+> **The most comprehensive MCP server for Coolify** - 45 optimized tools, smart diagnostics, documentation search, and batch operations for managing your self-hosted PaaS through AI assistants.
 
 A Model Context Protocol (MCP) server for [Coolify](https://coolify.io/), enabling AI assistants to manage and debug your Coolify instances through natural language.
 
 ## Features
 
-This MCP server provides **38 token-optimized tools** for **debugging, management, and deployment**:
+This MCP server provides **45 token-optimized tools** for **debugging, management, and deployment**:
 
-| Category             | Tools                                                                                                                       |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`                                                             |
-| **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                            |
-| **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                              |
-| **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`                                       |
-| **Projects**         | `projects` (list, get, create, update, delete via action param)                                                             |
-| **Environments**     | `environments` (list, get, create, delete via action param)                                                                 |
-| **Applications**     | `list_applications`, `get_application`, `application` (CRUD), `application_logs`                                            |
-| **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, delete), `database_backups` (CRUD schedules, view executions) |
-| **Services**         | `list_services`, `get_service`, `service` (create, update, delete)                                                          |
-| **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                |
-| **Env Vars**         | `env_vars` (CRUD for application and service env vars)                                                                      |
-| **Deployments**      | `list_deployments`, `deploy`, `deployment` (get, cancel, list_for_app)                                                      |
-| **Private Keys**     | `private_keys` (list, get, create, update, delete via action param)                                                         |
-| **GitHub Apps**      | `github_apps` (list, get, create, update, delete via action param)                                                          |
-| **Teams**            | `teams` (list, get, get_members, get_current, get_current_members)                                                          |
-| **Cloud Tokens**     | `cloud_tokens` (Hetzner/DigitalOcean: list, get, create, update, delete, validate)                                          |
-| **Documentation**    | `search_docs` (full-text search across Coolify docs)                                                                        |
+| Category             | Tools                                                                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `list_resources`, `health`                                         |
+| **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                                    |
+| **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                                      |
+| **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`                                               |
+| **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                     |
+| **Environments**     | `environments` (list, get, create, delete via action param)                                                                         |
+| **Applications**     | `list_applications`, `get_application`, `application` (CRUD), `application_logs`, `delete_preview`                                  |
+| **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, delete), `database_backups` (CRUD schedules, executions incl. delete) |
+| **Services**         | `list_services`, `get_service`, `service` (create, update, delete)                                                                  |
+| **Control**          | `control` (start/stop/restart for apps, databases, services), `api_control` (enable/disable API)                                    |
+| **Env Vars**         | `env_vars` (CRUD + bulk_update for application, service, and database env vars)                                                     |
+| **Storages**         | `storages` (list, create, update, delete persistent/file storages for apps, databases, services)                                    |
+| **Scheduled Tasks**  | `scheduled_tasks` (list, create, update, delete, list_executions for apps and services)                                             |
+| **Deployments**      | `list_deployments`, `deploy`, `deployment` (get, cancel, list_for_app)                                                              |
+| **Private Keys**     | `private_keys` (list, get, create, update, delete via action param)                                                                 |
+| **GitHub Apps**      | `github_apps` (list, get, create, update, delete, list_repos, list_branches)                                                        |
+| **Teams**            | `teams` (list, get, get_members, get_current, get_current_members)                                                                  |
+| **Cloud Tokens**     | `cloud_tokens` (Hetzner/DigitalOcean: list, get, create, update, delete, validate)                                                  |
+| **Hetzner Cloud**    | `hetzner` (list_locations, list_server_types, list_images, list_ssh_keys, create_server)                                            |
+| **Documentation**    | `search_docs` (full-text search across Coolify docs)                                                                                |
 
 ### Token-Optimized Design
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4128,4 +4128,714 @@ describe('CoolifyClient', () => {
       });
     });
   });
+
+  // ===========================================================================
+  // Application Storage endpoints
+  // ===========================================================================
+
+  describe('listApplicationStorages', () => {
+    it('should list application storages', async () => {
+      const mockData = { persistent_storages: [], file_storages: [] };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockData));
+      const result = await client.listApplicationStorages('app-uuid');
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/storages',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createApplicationStorage', () => {
+    it('should create application storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Storage created.' }));
+      const result = await client.createApplicationStorage('app-uuid', {
+        type: 'persistent',
+        mount_path: '/data',
+        name: 'my-vol',
+      });
+      expect(result).toEqual({ message: 'Storage created.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/storages',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('updateApplicationStorage', () => {
+    it('should update application storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Storage updated.' }));
+      const result = await client.updateApplicationStorage('app-uuid', {
+        uuid: 'stor-uuid',
+        type: 'persistent',
+        name: 'renamed',
+      });
+      expect(result).toEqual({ message: 'Storage updated.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/storages',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('deleteApplicationStorage', () => {
+    it('should delete application storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Storage deleted.' }));
+      const result = await client.deleteApplicationStorage('app-uuid', 'stor-uuid');
+      expect(result).toEqual({ message: 'Storage deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/storages/stor-uuid',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Application Scheduled Task endpoints
+  // ===========================================================================
+
+  describe('listApplicationScheduledTasks', () => {
+    it('should list scheduled tasks', async () => {
+      const mockTasks = [
+        {
+          id: 1,
+          uuid: 'task-1',
+          name: 'backup',
+          command: 'pg_dump',
+          frequency: '0 * * * *',
+          enabled: true,
+          timeout: 300,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse(mockTasks));
+      const result = await client.listApplicationScheduledTasks('app-uuid');
+      expect(result).toEqual(mockTasks);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/scheduled-tasks',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createApplicationScheduledTask', () => {
+    it('should create a scheduled task', async () => {
+      const mockTask = {
+        id: 1,
+        uuid: 'task-1',
+        name: 'backup',
+        command: 'pg_dump',
+        frequency: '0 * * * *',
+        enabled: true,
+        timeout: 300,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockTask));
+      const result = await client.createApplicationScheduledTask('app-uuid', {
+        name: 'backup',
+        command: 'pg_dump',
+        frequency: '0 * * * *',
+      });
+      expect(result).toEqual(mockTask);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/scheduled-tasks',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('updateApplicationScheduledTask', () => {
+    it('should update a scheduled task', async () => {
+      const mockTask = {
+        id: 1,
+        uuid: 'task-1',
+        name: 'backup-v2',
+        command: 'pg_dump -Fc',
+        frequency: '0 * * * *',
+        enabled: true,
+        timeout: 300,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockTask));
+      const result = await client.updateApplicationScheduledTask('app-uuid', 'task-1', {
+        name: 'backup-v2',
+      });
+      expect(result).toEqual(mockTask);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/scheduled-tasks/task-1',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('deleteApplicationScheduledTask', () => {
+    it('should delete a scheduled task', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Scheduled task deleted.' }));
+      const result = await client.deleteApplicationScheduledTask('app-uuid', 'task-1');
+      expect(result).toEqual({ message: 'Scheduled task deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/scheduled-tasks/task-1',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  describe('listApplicationScheduledTaskExecutions', () => {
+    it('should list task executions', async () => {
+      const mockExecs = [
+        {
+          uuid: 'exec-1',
+          status: 'success',
+          retry_count: 0,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse(mockExecs));
+      const result = await client.listApplicationScheduledTaskExecutions('app-uuid', 'task-1');
+      expect(result).toEqual(mockExecs);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/scheduled-tasks/task-1/executions',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Application Preview endpoint
+  // ===========================================================================
+
+  describe('deleteApplicationPreview', () => {
+    it('should delete a preview deployment', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Preview deleted.' }));
+      const result = await client.deleteApplicationPreview('app-uuid', 42);
+      expect(result).toEqual({ message: 'Preview deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/previews/42',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Database Environment Variable endpoints
+  // ===========================================================================
+
+  describe('listDatabaseEnvVars', () => {
+    it('should list database env vars', async () => {
+      const mockEnvs = [
+        {
+          id: 1,
+          uuid: 'env-1',
+          key: 'DB_HOST',
+          value: 'localhost',
+          is_build_time: false,
+          is_literal: false,
+          is_multiline: false,
+          is_preview: false,
+          is_shared: false,
+          is_shown_once: false,
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid');
+      expect(result).toEqual(mockEnvs);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/envs',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createDatabaseEnvVar', () => {
+    it('should create a database env var', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'env-1' }));
+      const result = await client.createDatabaseEnvVar('db-uuid', {
+        key: 'DB_HOST',
+        value: 'localhost',
+      });
+      expect(result).toEqual({ uuid: 'env-1' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/envs',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('updateDatabaseEnvVar', () => {
+    it('should update a database env var', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Updated.' }));
+      const result = await client.updateDatabaseEnvVar('db-uuid', {
+        key: 'DB_HOST',
+        value: '127.0.0.1',
+      });
+      expect(result).toEqual({ message: 'Updated.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/envs',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('bulkUpdateDatabaseEnvVars', () => {
+    it('should bulk update database env vars', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Bulk updated.' }));
+      const result = await client.bulkUpdateDatabaseEnvVars('db-uuid', {
+        data: [{ key: 'A', value: '1' }],
+      });
+      expect(result).toEqual({ message: 'Bulk updated.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/envs/bulk',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('deleteDatabaseEnvVar', () => {
+    it('should delete a database env var', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Deleted.' }));
+      const result = await client.deleteDatabaseEnvVar('db-uuid', 'env-uuid');
+      expect(result).toEqual({ message: 'Deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/envs/env-uuid',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Database Storage endpoints
+  // ===========================================================================
+
+  describe('listDatabaseStorages', () => {
+    it('should list database storages', async () => {
+      const mockData = { persistent_storages: [], file_storages: [] };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockData));
+      const result = await client.listDatabaseStorages('db-uuid');
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/storages',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createDatabaseStorage', () => {
+    it('should create database storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Created.' }));
+      const result = await client.createDatabaseStorage('db-uuid', {
+        type: 'persistent',
+        mount_path: '/data',
+      });
+      expect(result).toEqual({ message: 'Created.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/storages',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('updateDatabaseStorage', () => {
+    it('should update database storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Updated.' }));
+      const result = await client.updateDatabaseStorage('db-uuid', {
+        type: 'persistent',
+        name: 'new-name',
+      });
+      expect(result).toEqual({ message: 'Updated.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/storages',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('deleteDatabaseStorage', () => {
+    it('should delete database storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Deleted.' }));
+      const result = await client.deleteDatabaseStorage('db-uuid', 'stor-uuid');
+      expect(result).toEqual({ message: 'Deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/storages/stor-uuid',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Delete Backup Execution endpoint
+  // ===========================================================================
+
+  describe('deleteBackupExecution', () => {
+    it('should delete a backup execution', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Deleted.' }));
+      const result = await client.deleteBackupExecution('db-uuid', 'backup-uuid', 'exec-uuid');
+      expect(result).toEqual({ message: 'Deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/backups/backup-uuid/executions/exec-uuid',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Service Environment Variable bulk endpoint
+  // ===========================================================================
+
+  describe('bulkUpdateServiceEnvVars', () => {
+    it('should bulk update service env vars', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Bulk updated.' }));
+      const result = await client.bulkUpdateServiceEnvVars('svc-uuid', {
+        data: [{ key: 'A', value: '1' }],
+      });
+      expect(result).toEqual({ message: 'Bulk updated.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/envs/bulk',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Service Storage endpoints
+  // ===========================================================================
+
+  describe('listServiceStorages', () => {
+    it('should list service storages', async () => {
+      const mockData = { persistent_storages: [], file_storages: [] };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockData));
+      const result = await client.listServiceStorages('svc-uuid');
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/storages',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createServiceStorage', () => {
+    it('should create service storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Created.' }));
+      const result = await client.createServiceStorage('svc-uuid', {
+        type: 'file',
+        mount_path: '/config',
+      });
+      expect(result).toEqual({ message: 'Created.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/storages',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('updateServiceStorage', () => {
+    it('should update service storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Updated.' }));
+      const result = await client.updateServiceStorage('svc-uuid', {
+        type: 'file',
+        content: 'new content',
+      });
+      expect(result).toEqual({ message: 'Updated.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/storages',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('deleteServiceStorage', () => {
+    it('should delete service storage', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Deleted.' }));
+      const result = await client.deleteServiceStorage('svc-uuid', 'stor-uuid');
+      expect(result).toEqual({ message: 'Deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/storages/stor-uuid',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Service Scheduled Task endpoints
+  // ===========================================================================
+
+  describe('listServiceScheduledTasks', () => {
+    it('should list service scheduled tasks', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listServiceScheduledTasks('svc-uuid');
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/scheduled-tasks',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createServiceScheduledTask', () => {
+    it('should create a service scheduled task', async () => {
+      const mockTask = {
+        id: 1,
+        uuid: 'task-1',
+        name: 'cleanup',
+        command: 'rm -rf /tmp/*',
+        frequency: '0 0 * * *',
+        enabled: true,
+        timeout: 300,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockTask));
+      const result = await client.createServiceScheduledTask('svc-uuid', {
+        name: 'cleanup',
+        command: 'rm -rf /tmp/*',
+        frequency: '0 0 * * *',
+      });
+      expect(result).toEqual(mockTask);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/scheduled-tasks',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('updateServiceScheduledTask', () => {
+    it('should update a service scheduled task', async () => {
+      const mockTask = {
+        id: 1,
+        uuid: 'task-1',
+        name: 'cleanup-v2',
+        command: 'rm -rf /tmp/*',
+        frequency: '0 0 * * *',
+        enabled: true,
+        timeout: 600,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockTask));
+      const result = await client.updateServiceScheduledTask('svc-uuid', 'task-1', {
+        timeout: 600,
+      });
+      expect(result).toEqual(mockTask);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/scheduled-tasks/task-1',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+  });
+
+  describe('deleteServiceScheduledTask', () => {
+    it('should delete a service scheduled task', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Deleted.' }));
+      const result = await client.deleteServiceScheduledTask('svc-uuid', 'task-1');
+      expect(result).toEqual({ message: 'Deleted.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/scheduled-tasks/task-1',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  describe('listServiceScheduledTaskExecutions', () => {
+    it('should list service task executions', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listServiceScheduledTaskExecutions('svc-uuid', 'task-1');
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/scheduled-tasks/task-1/executions',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Hetzner Cloud endpoints
+  // ===========================================================================
+
+  describe('listHetznerLocations', () => {
+    it('should list Hetzner locations', async () => {
+      const mockLocs = [
+        {
+          id: 1,
+          name: 'nbg1',
+          description: 'Nuremberg',
+          country: 'DE',
+          city: 'Nuremberg',
+          latitude: 49.45,
+          longitude: 11.08,
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse(mockLocs));
+      const result = await client.listHetznerLocations('token-uuid');
+      expect(result).toEqual(mockLocs);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/hetzner/locations?cloud_provider_token_uuid=token-uuid',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('listHetznerServerTypes', () => {
+    it('should list Hetzner server types', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listHetznerServerTypes('token-uuid');
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/hetzner/server-types?cloud_provider_token_uuid=token-uuid',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('listHetznerImages', () => {
+    it('should list Hetzner images', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listHetznerImages('token-uuid');
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/hetzner/images?cloud_provider_token_uuid=token-uuid',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('listHetznerSSHKeys', () => {
+    it('should list Hetzner SSH keys', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listHetznerSSHKeys('token-uuid');
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/hetzner/ssh-keys?cloud_provider_token_uuid=token-uuid',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('createHetznerServer', () => {
+    it('should create a Hetzner server', async () => {
+      const mockResp = { uuid: 'srv-uuid', hetzner_server_id: 12345, ip: '1.2.3.4' };
+      mockFetch.mockResolvedValueOnce(mockResponse(mockResp));
+      const result = await client.createHetznerServer({
+        location: 'nbg1',
+        server_type: 'cx11',
+        image: 15512617,
+        private_key_uuid: 'key-uuid',
+      });
+      expect(result).toEqual(mockResp);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/servers/hetzner',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // GitHub App Repository endpoints
+  // ===========================================================================
+
+  describe('listGitHubAppRepositories', () => {
+    it('should list GitHub App repositories', async () => {
+      const mockRepos = [
+        {
+          id: 1,
+          name: 'my-repo',
+          full_name: 'org/my-repo',
+          private: true,
+          html_url: 'https://github.com/org/my-repo',
+          default_branch: 'main',
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse({ repositories: mockRepos }));
+      const result = await client.listGitHubAppRepositories(123);
+      expect(result).toEqual(mockRepos);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/github-apps/123/repositories',
+        expect.any(Object),
+      );
+    });
+
+    it('should return empty array when no repositories', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({}));
+      const result = await client.listGitHubAppRepositories(123);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('listGitHubAppBranches', () => {
+    it('should list branches for a repo', async () => {
+      const mockBranches = [{ name: 'main' }, { name: 'develop' }];
+      mockFetch.mockResolvedValueOnce(mockResponse(mockBranches));
+      const result = await client.listGitHubAppBranches(123, 'org', 'my-repo');
+      expect(result).toEqual(mockBranches);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/github-apps/123/repositories/org/my-repo/branches',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Resources endpoint
+  // ===========================================================================
+
+  describe('listResources', () => {
+    it('should list all resources', async () => {
+      const mockData = [{ uuid: 'r1', type: 'application' }];
+      mockFetch.mockResolvedValueOnce(mockResponse(mockData));
+      const result = await client.listResources();
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/resources',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Health endpoint
+  // ===========================================================================
+
+  describe('getHealth', () => {
+    it('should check API health', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'OK' }));
+      const result = await client.getHealth();
+      expect(result).toEqual({ message: 'OK' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/health',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // API Enable/Disable endpoints
+  // ===========================================================================
+
+  describe('enableApi', () => {
+    it('should enable the API', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'API enabled.' }));
+      const result = await client.enableApi();
+      expect(result).toEqual({ message: 'API enabled.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/enable',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+  });
+
+  describe('disableApi', () => {
+    it('should disable the API', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'API disabled.' }));
+      const result = await client.disableApi();
+      expect(result).toEqual({ message: 'API disabled.' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/disable',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+  });
 });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -181,6 +181,75 @@ describe('CoolifyMcpServer v2', () => {
       expect(typeof client.deleteCloudToken).toBe('function');
       expect(typeof client.validateCloudToken).toBe('function');
 
+      // Application storage operations
+      expect(typeof client.listApplicationStorages).toBe('function');
+      expect(typeof client.createApplicationStorage).toBe('function');
+      expect(typeof client.updateApplicationStorage).toBe('function');
+      expect(typeof client.deleteApplicationStorage).toBe('function');
+
+      // Application scheduled task operations
+      expect(typeof client.listApplicationScheduledTasks).toBe('function');
+      expect(typeof client.createApplicationScheduledTask).toBe('function');
+      expect(typeof client.updateApplicationScheduledTask).toBe('function');
+      expect(typeof client.deleteApplicationScheduledTask).toBe('function');
+      expect(typeof client.listApplicationScheduledTaskExecutions).toBe('function');
+
+      // Application preview operations
+      expect(typeof client.deleteApplicationPreview).toBe('function');
+
+      // Database environment variable operations
+      expect(typeof client.listDatabaseEnvVars).toBe('function');
+      expect(typeof client.createDatabaseEnvVar).toBe('function');
+      expect(typeof client.updateDatabaseEnvVar).toBe('function');
+      expect(typeof client.bulkUpdateDatabaseEnvVars).toBe('function');
+      expect(typeof client.deleteDatabaseEnvVar).toBe('function');
+
+      // Database storage operations
+      expect(typeof client.listDatabaseStorages).toBe('function');
+      expect(typeof client.createDatabaseStorage).toBe('function');
+      expect(typeof client.updateDatabaseStorage).toBe('function');
+      expect(typeof client.deleteDatabaseStorage).toBe('function');
+
+      // Delete backup execution
+      expect(typeof client.deleteBackupExecution).toBe('function');
+
+      // Service env var bulk operations
+      expect(typeof client.bulkUpdateServiceEnvVars).toBe('function');
+
+      // Service storage operations
+      expect(typeof client.listServiceStorages).toBe('function');
+      expect(typeof client.createServiceStorage).toBe('function');
+      expect(typeof client.updateServiceStorage).toBe('function');
+      expect(typeof client.deleteServiceStorage).toBe('function');
+
+      // Service scheduled task operations
+      expect(typeof client.listServiceScheduledTasks).toBe('function');
+      expect(typeof client.createServiceScheduledTask).toBe('function');
+      expect(typeof client.updateServiceScheduledTask).toBe('function');
+      expect(typeof client.deleteServiceScheduledTask).toBe('function');
+      expect(typeof client.listServiceScheduledTaskExecutions).toBe('function');
+
+      // Hetzner cloud operations
+      expect(typeof client.listHetznerLocations).toBe('function');
+      expect(typeof client.listHetznerServerTypes).toBe('function');
+      expect(typeof client.listHetznerImages).toBe('function');
+      expect(typeof client.listHetznerSSHKeys).toBe('function');
+      expect(typeof client.createHetznerServer).toBe('function');
+
+      // GitHub App repository operations
+      expect(typeof client.listGitHubAppRepositories).toBe('function');
+      expect(typeof client.listGitHubAppBranches).toBe('function');
+
+      // Resources operations
+      expect(typeof client.listResources).toBe('function');
+
+      // Health operations
+      expect(typeof client.getHealth).toBe('function');
+
+      // API enable/disable operations
+      expect(typeof client.enableApi).toBe('function');
+      expect(typeof client.disableApi).toBe('function');
+
       // Version caching
       expect(typeof client.getCachedVersion).toBe('function');
     });

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -109,6 +109,8 @@ import type {
   InfrastructureIssuesReport,
   // Batch operation types
   BatchOperationResult,
+  // Resource list types
+  ResourceListItem,
 } from '../types/coolify.js';
 
 // =============================================================================
@@ -1646,8 +1648,8 @@ export class CoolifyClient {
   // Resources endpoint
   // ===========================================================================
 
-  async listResources(): Promise<unknown> {
-    return this.request<unknown>('/resources');
+  async listResources(): Promise<ResourceListItem[]> {
+    return this.request<ResourceListItem[]>('/resources');
   }
 
   // ===========================================================================

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -82,6 +82,25 @@ import type {
   CloudTokenValidation,
   // Version types
   Version,
+  // Storage types
+  StorageListResponse,
+  CreateStorageRequest,
+  UpdateStorageRequest,
+  // Scheduled task types
+  ScheduledTask,
+  ScheduledTaskExecution,
+  CreateScheduledTaskRequest,
+  UpdateScheduledTaskRequest,
+  // Hetzner types
+  HetznerLocation,
+  HetznerServerType,
+  HetznerImage,
+  HetznerSSHKey,
+  CreateHetznerServerRequest,
+  CreateHetznerServerResponse,
+  // GitHub repository types
+  GitHubRepository,
+  GitHubBranch,
   // Diagnostic types
   DiagnosticHealthStatus,
   ApplicationDiagnostic,
@@ -1308,6 +1327,347 @@ export class CoolifyClient {
     return this.request<MessageResponse>(`/databases/${databaseUuid}/backups/${backupUuid}`, {
       method: 'DELETE',
     });
+  }
+
+  // ===========================================================================
+  // Application Storage endpoints
+  // ===========================================================================
+
+  async listApplicationStorages(uuid: string): Promise<StorageListResponse> {
+    return this.request<StorageListResponse>(`/applications/${uuid}/storages`);
+  }
+
+  async createApplicationStorage(
+    uuid: string,
+    data: CreateStorageRequest,
+  ): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/applications/${uuid}/storages`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateApplicationStorage(
+    uuid: string,
+    data: UpdateStorageRequest,
+  ): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/applications/${uuid}/storages`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteApplicationStorage(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/applications/${uuid}/storages/${storageUuid}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ===========================================================================
+  // Application Scheduled Task endpoints
+  // ===========================================================================
+
+  async listApplicationScheduledTasks(uuid: string): Promise<ScheduledTask[]> {
+    return this.request<ScheduledTask[]>(`/applications/${uuid}/scheduled-tasks`);
+  }
+
+  async createApplicationScheduledTask(
+    uuid: string,
+    data: CreateScheduledTaskRequest,
+  ): Promise<ScheduledTask> {
+    return this.request<ScheduledTask>(`/applications/${uuid}/scheduled-tasks`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateApplicationScheduledTask(
+    uuid: string,
+    taskUuid: string,
+    data: UpdateScheduledTaskRequest,
+  ): Promise<ScheduledTask> {
+    return this.request<ScheduledTask>(`/applications/${uuid}/scheduled-tasks/${taskUuid}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteApplicationScheduledTask(uuid: string, taskUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/applications/${uuid}/scheduled-tasks/${taskUuid}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async listApplicationScheduledTaskExecutions(
+    uuid: string,
+    taskUuid: string,
+  ): Promise<ScheduledTaskExecution[]> {
+    return this.request<ScheduledTaskExecution[]>(
+      `/applications/${uuid}/scheduled-tasks/${taskUuid}/executions`,
+    );
+  }
+
+  // ===========================================================================
+  // Application Preview endpoints
+  // ===========================================================================
+
+  async deleteApplicationPreview(uuid: string, pullRequestId: number): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/applications/${uuid}/previews/${pullRequestId}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ===========================================================================
+  // Database Environment Variable endpoints
+  // ===========================================================================
+
+  async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
+    return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+  }
+
+  async createDatabaseEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {
+    return this.request<UuidResponse>(`/databases/${uuid}/envs`, {
+      method: 'POST',
+      body: JSON.stringify(cleanRequestData(data)),
+    });
+  }
+
+  async updateDatabaseEnvVar(uuid: string, data: UpdateEnvVarRequest): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/envs`, {
+      method: 'PATCH',
+      body: JSON.stringify(cleanRequestData(data)),
+    });
+  }
+
+  async bulkUpdateDatabaseEnvVars(
+    uuid: string,
+    data: BulkUpdateEnvVarsRequest,
+  ): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/envs/bulk`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteDatabaseEnvVar(uuid: string, envUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/envs/${envUuid}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ===========================================================================
+  // Database Storage endpoints
+  // ===========================================================================
+
+  async listDatabaseStorages(uuid: string): Promise<StorageListResponse> {
+    return this.request<StorageListResponse>(`/databases/${uuid}/storages`);
+  }
+
+  async createDatabaseStorage(uuid: string, data: CreateStorageRequest): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/storages`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateDatabaseStorage(uuid: string, data: UpdateStorageRequest): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/storages`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteDatabaseStorage(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/storages/${storageUuid}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ===========================================================================
+  // Delete Backup Execution endpoint
+  // ===========================================================================
+
+  async deleteBackupExecution(
+    databaseUuid: string,
+    backupUuid: string,
+    executionUuid: string,
+  ): Promise<MessageResponse> {
+    return this.request<MessageResponse>(
+      `/databases/${databaseUuid}/backups/${backupUuid}/executions/${executionUuid}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  // ===========================================================================
+  // Service Environment Variable (bulk) endpoint
+  // ===========================================================================
+
+  async bulkUpdateServiceEnvVars(
+    uuid: string,
+    data: BulkUpdateEnvVarsRequest,
+  ): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/envs/bulk`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  // ===========================================================================
+  // Service Storage endpoints
+  // ===========================================================================
+
+  async listServiceStorages(uuid: string): Promise<StorageListResponse> {
+    return this.request<StorageListResponse>(`/services/${uuid}/storages`);
+  }
+
+  async createServiceStorage(uuid: string, data: CreateStorageRequest): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/storages`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateServiceStorage(uuid: string, data: UpdateStorageRequest): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/storages`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteServiceStorage(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/storages/${storageUuid}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ===========================================================================
+  // Service Scheduled Task endpoints
+  // ===========================================================================
+
+  async listServiceScheduledTasks(uuid: string): Promise<ScheduledTask[]> {
+    return this.request<ScheduledTask[]>(`/services/${uuid}/scheduled-tasks`);
+  }
+
+  async createServiceScheduledTask(
+    uuid: string,
+    data: CreateScheduledTaskRequest,
+  ): Promise<ScheduledTask> {
+    return this.request<ScheduledTask>(`/services/${uuid}/scheduled-tasks`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateServiceScheduledTask(
+    uuid: string,
+    taskUuid: string,
+    data: UpdateScheduledTaskRequest,
+  ): Promise<ScheduledTask> {
+    return this.request<ScheduledTask>(`/services/${uuid}/scheduled-tasks/${taskUuid}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteServiceScheduledTask(uuid: string, taskUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/scheduled-tasks/${taskUuid}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async listServiceScheduledTaskExecutions(
+    uuid: string,
+    taskUuid: string,
+  ): Promise<ScheduledTaskExecution[]> {
+    return this.request<ScheduledTaskExecution[]>(
+      `/services/${uuid}/scheduled-tasks/${taskUuid}/executions`,
+    );
+  }
+
+  // ===========================================================================
+  // Hetzner Cloud endpoints
+  // ===========================================================================
+
+  async listHetznerLocations(tokenUuid: string): Promise<HetznerLocation[]> {
+    return this.request<HetznerLocation[]>(
+      `/hetzner/locations?cloud_provider_token_uuid=${encodeURIComponent(tokenUuid)}`,
+    );
+  }
+
+  async listHetznerServerTypes(tokenUuid: string): Promise<HetznerServerType[]> {
+    return this.request<HetznerServerType[]>(
+      `/hetzner/server-types?cloud_provider_token_uuid=${encodeURIComponent(tokenUuid)}`,
+    );
+  }
+
+  async listHetznerImages(tokenUuid: string): Promise<HetznerImage[]> {
+    return this.request<HetznerImage[]>(
+      `/hetzner/images?cloud_provider_token_uuid=${encodeURIComponent(tokenUuid)}`,
+    );
+  }
+
+  async listHetznerSSHKeys(tokenUuid: string): Promise<HetznerSSHKey[]> {
+    return this.request<HetznerSSHKey[]>(
+      `/hetzner/ssh-keys?cloud_provider_token_uuid=${encodeURIComponent(tokenUuid)}`,
+    );
+  }
+
+  async createHetznerServer(
+    data: CreateHetznerServerRequest,
+  ): Promise<CreateHetznerServerResponse> {
+    return this.request<CreateHetznerServerResponse>('/servers/hetzner', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  // ===========================================================================
+  // GitHub App Repository endpoints
+  // ===========================================================================
+
+  async listGitHubAppRepositories(githubAppId: number): Promise<GitHubRepository[]> {
+    const response = await this.request<{ repositories: GitHubRepository[] }>(
+      `/github-apps/${githubAppId}/repositories`,
+    );
+    return response.repositories ?? [];
+  }
+
+  async listGitHubAppBranches(
+    githubAppId: number,
+    owner: string,
+    repo: string,
+  ): Promise<GitHubBranch[]> {
+    return this.request<GitHubBranch[]>(
+      `/github-apps/${githubAppId}/repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches`,
+    );
+  }
+
+  // ===========================================================================
+  // Resources endpoint
+  // ===========================================================================
+
+  async listResources(): Promise<unknown> {
+    return this.request<unknown>('/resources');
+  }
+
+  // ===========================================================================
+  // Health endpoint
+  // ===========================================================================
+
+  async getHealth(): Promise<MessageResponse> {
+    return this.request<MessageResponse>('/health');
+  }
+
+  // ===========================================================================
+  // API Enable/Disable endpoints
+  // ===========================================================================
+
+  async enableApi(): Promise<MessageResponse> {
+    return this.request<MessageResponse>('/enable', { method: 'GET' });
+  }
+
+  async disableApi(): Promise<MessageResponse> {
+    return this.request<MessageResponse>('/disable', { method: 'GET' });
   }
 
   // ===========================================================================

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1018,7 +1018,18 @@ export class CoolifyMcpServer extends McpServer {
           )
           .optional(),
       },
-      async ({ resource, action, uuid, key, value, env_uuid, is_buildtime, is_runtime, reveal, data }) => {
+      async ({
+        resource,
+        action,
+        uuid,
+        key,
+        value,
+        env_uuid,
+        is_buildtime,
+        is_runtime,
+        reveal,
+        data,
+      }) => {
         if (resource === 'application') {
           switch (action) {
             case 'list':

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -443,7 +443,7 @@ export class CoolifyMcpServer extends McpServer {
 
     this.tool(
       'application',
-      'Manage app: create/update/delete',
+      'Manage app: create/update/delete/delete_preview',
       {
         action: z.enum([
           'create_public',
@@ -452,6 +452,7 @@ export class CoolifyMcpServer extends McpServer {
           'create_dockerimage',
           'update',
           'delete',
+          'delete_preview',
         ]),
         uuid: z.string().optional(),
         // Create fields
@@ -504,6 +505,8 @@ export class CoolifyMcpServer extends McpServer {
         dockerfile_target_build: z.string().optional(),
         // Delete fields
         delete_volumes: z.boolean().optional(),
+        // Preview fields
+        pull_request_id: z.number().optional(),
       },
       async (args) => {
         const { action, uuid, delete_volumes } = args;
@@ -742,6 +745,12 @@ export class CoolifyMcpServer extends McpServer {
             return wrap(() =>
               this.client.deleteApplication(uuid, { deleteVolumes: delete_volumes }),
             );
+          case 'delete_preview':
+            if (!uuid || !args.pull_request_id)
+              return {
+                content: [{ type: 'text' as const, text: 'Error: uuid, pull_request_id required' }],
+              };
+            return wrap(() => this.client.deleteApplicationPreview(uuid, args.pull_request_id!));
         }
       },
     );
@@ -1534,52 +1543,94 @@ export class CoolifyMcpServer extends McpServer {
       },
       async (args) => {
         const { resource, action, uuid, storage_uuid } = args;
-        const createData = {
-          type: args.type!,
-          mount_path: args.mount_path!,
-          name: args.name,
-          host_path: args.host_path,
-          content: args.content,
-          is_directory: args.is_directory,
-          fs_path: args.fs_path,
-          is_preview_suffix_enabled: args.is_preview_suffix_enabled,
-        };
-        const updateData = {
-          uuid: storage_uuid,
-          type: args.type!,
-          is_preview_suffix_enabled: args.is_preview_suffix_enabled,
-          name: args.name,
-          mount_path: args.mount_path,
-          host_path: args.host_path,
-          content: args.content,
-          is_directory: args.is_directory,
-        };
+        if (action === 'create' && (!args.type || !args.mount_path))
+          return { content: [{ type: 'text' as const, text: 'Error: type, mount_path required' }] };
+        if (action === 'update' && (!args.type || !storage_uuid))
+          return {
+            content: [{ type: 'text' as const, text: 'Error: type, storage_uuid required' }],
+          };
+        if (action === 'delete' && !storage_uuid)
+          return { content: [{ type: 'text' as const, text: 'Error: storage_uuid required' }] };
         const methods: Record<string, Record<string, () => Promise<unknown>>> = {
           application: {
             list: () => this.client.listApplicationStorages(uuid),
-            create: () => this.client.createApplicationStorage(uuid, createData),
-            update: () => this.client.updateApplicationStorage(uuid, updateData),
+            create: () =>
+              this.client.createApplicationStorage(uuid, {
+                type: args.type!,
+                mount_path: args.mount_path!,
+                name: args.name,
+                host_path: args.host_path,
+                content: args.content,
+                is_directory: args.is_directory,
+                fs_path: args.fs_path,
+                is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+              }),
+            update: () =>
+              this.client.updateApplicationStorage(uuid, {
+                uuid: storage_uuid!,
+                type: args.type!,
+                mount_path: args.mount_path,
+                name: args.name,
+                host_path: args.host_path,
+                content: args.content,
+                is_directory: args.is_directory,
+                is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+              }),
             delete: () => this.client.deleteApplicationStorage(uuid, storage_uuid!),
           },
           database: {
             list: () => this.client.listDatabaseStorages(uuid),
-            create: () => this.client.createDatabaseStorage(uuid, createData),
-            update: () => this.client.updateDatabaseStorage(uuid, updateData),
+            create: () =>
+              this.client.createDatabaseStorage(uuid, {
+                type: args.type!,
+                mount_path: args.mount_path!,
+                name: args.name,
+                host_path: args.host_path,
+                content: args.content,
+                is_directory: args.is_directory,
+                fs_path: args.fs_path,
+                is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+              }),
+            update: () =>
+              this.client.updateDatabaseStorage(uuid, {
+                uuid: storage_uuid!,
+                type: args.type!,
+                mount_path: args.mount_path,
+                name: args.name,
+                host_path: args.host_path,
+                content: args.content,
+                is_directory: args.is_directory,
+                is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+              }),
             delete: () => this.client.deleteDatabaseStorage(uuid, storage_uuid!),
           },
           service: {
             list: () => this.client.listServiceStorages(uuid),
-            create: () => this.client.createServiceStorage(uuid, createData),
-            update: () => this.client.updateServiceStorage(uuid, updateData),
+            create: () =>
+              this.client.createServiceStorage(uuid, {
+                type: args.type!,
+                mount_path: args.mount_path!,
+                name: args.name,
+                host_path: args.host_path,
+                content: args.content,
+                is_directory: args.is_directory,
+                fs_path: args.fs_path,
+                is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+              }),
+            update: () =>
+              this.client.updateServiceStorage(uuid, {
+                uuid: storage_uuid!,
+                type: args.type!,
+                mount_path: args.mount_path,
+                name: args.name,
+                host_path: args.host_path,
+                content: args.content,
+                is_directory: args.is_directory,
+                is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+              }),
             delete: () => this.client.deleteServiceStorage(uuid, storage_uuid!),
           },
         };
-        if (action === 'create' && (!args.type || !args.mount_path))
-          return { content: [{ type: 'text' as const, text: 'Error: type, mount_path required' }] };
-        if (action === 'update' && !args.type)
-          return { content: [{ type: 'text' as const, text: 'Error: type required' }] };
-        if (action === 'delete' && !storage_uuid)
-          return { content: [{ type: 'text' as const, text: 'Error: storage_uuid required' }] };
         return wrap(() => methods[resource][action]());
       },
     );
@@ -1666,17 +1717,6 @@ export class CoolifyMcpServer extends McpServer {
             );
         }
       },
-    );
-
-    // =========================================================================
-    // Application Previews (1 tool)
-    // =========================================================================
-    this.tool(
-      'delete_preview',
-      'Delete a preview deployment for an application',
-      { uuid: z.string(), pull_request_id: z.number() },
-      async ({ uuid, pull_request_id }) =>
-        wrap(() => this.client.deleteApplicationPreview(uuid, pull_request_id)),
     );
 
     // =========================================================================
@@ -1770,28 +1810,24 @@ export class CoolifyMcpServer extends McpServer {
     );
 
     // =========================================================================
-    // Resources (1 tool)
-    // =========================================================================
-    this.tool('list_resources', 'List all resources across infrastructure', {}, async () =>
-      wrap(() => this.client.listResources()),
-    );
-
-    // =========================================================================
-    // Health (1 tool)
-    // =========================================================================
-    this.tool('health', 'Check Coolify API health', {}, async () =>
-      wrap(() => this.client.getHealth()),
-    );
-
-    // =========================================================================
-    // API Enable/Disable (1 tool)
+    // System (1 tool - health/list_resources/api_control consolidated)
     // =========================================================================
     this.tool(
-      'api_control',
-      'Enable or disable the Coolify API (requires root)',
-      { action: z.enum(['enable', 'disable']) },
-      async ({ action }) =>
-        wrap(() => (action === 'enable' ? this.client.enableApi() : this.client.disableApi())),
+      'system',
+      'System operations: health/list_resources/enable_api/disable_api',
+      { action: z.enum(['health', 'list_resources', 'enable_api', 'disable_api']) },
+      async ({ action }) => {
+        switch (action) {
+          case 'health':
+            return wrap(() => this.client.getHealth());
+          case 'list_resources':
+            return wrap(() => this.client.listResources());
+          case 'enable_api':
+            return wrap(() => this.client.enableApi());
+          case 'disable_api':
+            return wrap(() => this.client.disableApi());
+        }
+      },
     );
 
     // =========================================================================

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -983,10 +983,10 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'env_vars',
-      "Manage env vars for app or service. Values are masked by default (returned as '***') to avoid leaking secrets to MCP clients; pass reveal=true on the list action when the caller explicitly needs the plaintext (e.g. 'what is FOO set to?'). Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.",
+      "Manage env vars for app, service, or database. Values are masked by default (returned as '***') to avoid leaking secrets to MCP clients; pass reveal=true on the list action when the caller explicitly needs the plaintext (e.g. 'what is FOO set to?'). Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.",
       {
-        resource: z.enum(['application', 'service']),
-        action: z.enum(['list', 'create', 'update', 'delete']),
+        resource: z.enum(['application', 'service', 'database']),
+        action: z.enum(['list', 'create', 'update', 'delete', 'bulk_update']),
         uuid: z.string(),
         key: z.string().optional(),
         value: z.string().optional(),
@@ -994,18 +994,22 @@ export class CoolifyMcpServer extends McpServer {
         is_buildtime: z.boolean().optional(),
         is_runtime: z.boolean().optional(),
         reveal: z.boolean().optional(),
+        data: z
+          .array(
+            z.object({
+              key: z.string(),
+              value: z.string(),
+              is_preview: z.boolean().optional(),
+              is_buildtime: z.boolean().optional(),
+              is_runtime: z.boolean().optional(),
+              is_literal: z.boolean().optional(),
+              is_multiline: z.boolean().optional(),
+              is_shown_once: z.boolean().optional(),
+            }),
+          )
+          .optional(),
       },
-      async ({
-        resource,
-        action,
-        uuid,
-        key,
-        value,
-        env_uuid,
-        is_buildtime,
-        is_runtime,
-        reveal,
-      }) => {
+      async ({ resource, action, uuid, key, value, env_uuid, is_buildtime, is_runtime, reveal, data }) => {
         if (resource === 'application') {
           switch (action) {
             case 'list':
@@ -1038,8 +1042,12 @@ export class CoolifyMcpServer extends McpServer {
               if (!env_uuid)
                 return { content: [{ type: 'text' as const, text: 'Error: env_uuid required' }] };
               return wrap(() => this.client.deleteApplicationEnvVar(uuid, env_uuid));
+            case 'bulk_update':
+              if (!data)
+                return { content: [{ type: 'text' as const, text: 'Error: data array required' }] };
+              return wrap(() => this.client.bulkUpdateApplicationEnvVars(uuid, { data }));
           }
-        } else {
+        } else if (resource === 'service') {
           switch (action) {
             case 'list':
               return wrap(() => this.client.listServiceEnvVars(uuid, { reveal }));
@@ -1047,23 +1055,47 @@ export class CoolifyMcpServer extends McpServer {
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
               return wrap(() =>
-                this.client.createServiceEnvVar(uuid, {
-                  key,
-                  value,
-                  is_buildtime,
-                  is_runtime,
-                }),
+                this.client.createServiceEnvVar(uuid, { key, value, is_buildtime, is_runtime }),
               );
             case 'update':
-              return {
-                content: [
-                  { type: 'text' as const, text: 'Error: service env update not supported' },
-                ],
-              };
+              if (!key || !value)
+                return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
+              return wrap(() =>
+                this.client.updateServiceEnvVar(uuid, { key, value, is_buildtime, is_runtime }),
+              );
             case 'delete':
               if (!env_uuid)
                 return { content: [{ type: 'text' as const, text: 'Error: env_uuid required' }] };
               return wrap(() => this.client.deleteServiceEnvVar(uuid, env_uuid));
+            case 'bulk_update':
+              if (!data)
+                return { content: [{ type: 'text' as const, text: 'Error: data array required' }] };
+              return wrap(() => this.client.bulkUpdateServiceEnvVars(uuid, { data }));
+          }
+        } else {
+          switch (action) {
+            case 'list':
+              return wrap(() => this.client.listDatabaseEnvVars(uuid));
+            case 'create':
+              if (!key || !value)
+                return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
+              return wrap(() =>
+                this.client.createDatabaseEnvVar(uuid, { key, value, is_buildtime, is_runtime }),
+              );
+            case 'update':
+              if (!key || !value)
+                return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
+              return wrap(() =>
+                this.client.updateDatabaseEnvVar(uuid, { key, value, is_buildtime, is_runtime }),
+              );
+            case 'delete':
+              if (!env_uuid)
+                return { content: [{ type: 'text' as const, text: 'Error: env_uuid required' }] };
+              return wrap(() => this.client.deleteDatabaseEnvVar(uuid, env_uuid));
+            case 'bulk_update':
+              if (!data)
+                return { content: [{ type: 'text' as const, text: 'Error: data array required' }] };
+              return wrap(() => this.client.bulkUpdateDatabaseEnvVars(uuid, { data }));
           }
         }
       },
@@ -1216,11 +1248,22 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'github_apps',
-      'Manage GitHub Apps: list/get/create/update/delete',
+      'Manage GitHub Apps: list/get/create/update/delete/list_repos/list_branches',
       {
-        action: z.enum(['list', 'get', 'create', 'update', 'delete']),
+        action: z.enum([
+          'list',
+          'get',
+          'create',
+          'update',
+          'delete',
+          'list_repos',
+          'list_branches',
+        ]),
         // GitHub apps use integer id, not uuid
         id: z.number().optional(),
+        // Repo/branch browsing
+        owner: z.string().optional(),
+        repo: z.string().optional(),
         // Create/Update fields
         name: z.string().optional(),
         organization: z.string().optional(),
@@ -1297,6 +1340,15 @@ export class CoolifyMcpServer extends McpServer {
           case 'delete':
             if (!id) return { content: [{ type: 'text' as const, text: 'Error: id required' }] };
             return wrap(() => this.client.deleteGitHubApp(id));
+          case 'list_repos':
+            if (!id) return { content: [{ type: 'text' as const, text: 'Error: id required' }] };
+            return wrap(() => this.client.listGitHubAppRepositories(id));
+          case 'list_branches':
+            if (!id || !args.owner || !args.repo)
+              return {
+                content: [{ type: 'text' as const, text: 'Error: id, owner, repo required' }],
+              };
+            return wrap(() => this.client.listGitHubAppBranches(id, args.owner!, args.repo!));
         }
       },
     );
@@ -1306,7 +1358,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'database_backups',
-      'Manage backups: list_schedules/get_schedule/list_executions/get_execution/create/update/delete',
+      'Manage backups: list_schedules/get_schedule/list_executions/get_execution/create/update/delete/delete_execution',
       {
         action: z.enum([
           'list_schedules',
@@ -1316,6 +1368,7 @@ export class CoolifyMcpServer extends McpServer {
           'create',
           'update',
           'delete',
+          'delete_execution',
         ]),
         database_uuid: z.string(),
         backup_uuid: z.string().optional(),
@@ -1374,6 +1427,16 @@ export class CoolifyMcpServer extends McpServer {
             if (!backup_uuid)
               return { content: [{ type: 'text' as const, text: 'Error: backup_uuid required' }] };
             return wrap(() => this.client.deleteDatabaseBackup(database_uuid, backup_uuid));
+          case 'delete_execution':
+            if (!backup_uuid || !execution_uuid)
+              return {
+                content: [
+                  { type: 'text' as const, text: 'Error: backup_uuid, execution_uuid required' },
+                ],
+              };
+            return wrap(() =>
+              this.client.deleteBackupExecution(database_uuid, backup_uuid, execution_uuid),
+            );
         }
       },
     );
@@ -1447,6 +1510,288 @@ export class CoolifyMcpServer extends McpServer {
             return wrap(() => this.client.validateCloudToken(uuid));
         }
       },
+    );
+
+    // =========================================================================
+    // Storages (1 tool - consolidated for app/db/service)
+    // =========================================================================
+    this.tool(
+      'storages',
+      'Manage persistent/file storages for app, database, or service: list/create/update/delete',
+      {
+        resource: z.enum(['application', 'database', 'service']),
+        action: z.enum(['list', 'create', 'update', 'delete']),
+        uuid: z.string(),
+        storage_uuid: z.string().optional(),
+        type: z.enum(['persistent', 'file']).optional(),
+        mount_path: z.string().optional(),
+        name: z.string().optional(),
+        host_path: z.string().optional(),
+        content: z.string().optional(),
+        is_directory: z.boolean().optional(),
+        fs_path: z.string().optional(),
+        is_preview_suffix_enabled: z.boolean().optional(),
+      },
+      async (args) => {
+        const { resource, action, uuid, storage_uuid } = args;
+        const createData = {
+          type: args.type!,
+          mount_path: args.mount_path!,
+          name: args.name,
+          host_path: args.host_path,
+          content: args.content,
+          is_directory: args.is_directory,
+          fs_path: args.fs_path,
+          is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+        };
+        const updateData = {
+          uuid: storage_uuid,
+          type: args.type!,
+          is_preview_suffix_enabled: args.is_preview_suffix_enabled,
+          name: args.name,
+          mount_path: args.mount_path,
+          host_path: args.host_path,
+          content: args.content,
+          is_directory: args.is_directory,
+        };
+        const methods: Record<string, Record<string, () => Promise<unknown>>> = {
+          application: {
+            list: () => this.client.listApplicationStorages(uuid),
+            create: () => this.client.createApplicationStorage(uuid, createData),
+            update: () => this.client.updateApplicationStorage(uuid, updateData),
+            delete: () => this.client.deleteApplicationStorage(uuid, storage_uuid!),
+          },
+          database: {
+            list: () => this.client.listDatabaseStorages(uuid),
+            create: () => this.client.createDatabaseStorage(uuid, createData),
+            update: () => this.client.updateDatabaseStorage(uuid, updateData),
+            delete: () => this.client.deleteDatabaseStorage(uuid, storage_uuid!),
+          },
+          service: {
+            list: () => this.client.listServiceStorages(uuid),
+            create: () => this.client.createServiceStorage(uuid, createData),
+            update: () => this.client.updateServiceStorage(uuid, updateData),
+            delete: () => this.client.deleteServiceStorage(uuid, storage_uuid!),
+          },
+        };
+        if (action === 'create' && (!args.type || !args.mount_path))
+          return { content: [{ type: 'text' as const, text: 'Error: type, mount_path required' }] };
+        if (action === 'update' && !args.type)
+          return { content: [{ type: 'text' as const, text: 'Error: type required' }] };
+        if (action === 'delete' && !storage_uuid)
+          return { content: [{ type: 'text' as const, text: 'Error: storage_uuid required' }] };
+        return wrap(() => methods[resource][action]());
+      },
+    );
+
+    // =========================================================================
+    // Scheduled Tasks (1 tool - consolidated for app/service)
+    // =========================================================================
+    this.tool(
+      'scheduled_tasks',
+      'Manage scheduled tasks for app or service: list/create/update/delete/list_executions',
+      {
+        resource: z.enum(['application', 'service']),
+        action: z.enum(['list', 'create', 'update', 'delete', 'list_executions']),
+        uuid: z.string(),
+        task_uuid: z.string().optional(),
+        name: z.string().optional(),
+        command: z.string().optional(),
+        frequency: z.string().optional(),
+        container: z.string().optional(),
+        timeout: z.number().optional(),
+        enabled: z.boolean().optional(),
+      },
+      async (args) => {
+        const { resource, action, uuid, task_uuid } = args;
+        const isApp = resource === 'application';
+        switch (action) {
+          case 'list':
+            return wrap(() =>
+              isApp
+                ? this.client.listApplicationScheduledTasks(uuid)
+                : this.client.listServiceScheduledTasks(uuid),
+            );
+          case 'create':
+            if (!args.name || !args.command || !args.frequency)
+              return {
+                content: [
+                  { type: 'text' as const, text: 'Error: name, command, frequency required' },
+                ],
+              };
+            return wrap(() => {
+              const data = {
+                name: args.name!,
+                command: args.command!,
+                frequency: args.frequency!,
+                container: args.container,
+                timeout: args.timeout,
+                enabled: args.enabled,
+              };
+              return isApp
+                ? this.client.createApplicationScheduledTask(uuid, data)
+                : this.client.createServiceScheduledTask(uuid, data);
+            });
+          case 'update':
+            if (!task_uuid)
+              return { content: [{ type: 'text' as const, text: 'Error: task_uuid required' }] };
+            return wrap(() => {
+              const data = {
+                name: args.name,
+                command: args.command,
+                frequency: args.frequency,
+                container: args.container,
+                timeout: args.timeout,
+                enabled: args.enabled,
+              };
+              return isApp
+                ? this.client.updateApplicationScheduledTask(uuid, task_uuid, data)
+                : this.client.updateServiceScheduledTask(uuid, task_uuid, data);
+            });
+          case 'delete':
+            if (!task_uuid)
+              return { content: [{ type: 'text' as const, text: 'Error: task_uuid required' }] };
+            return wrap(() =>
+              isApp
+                ? this.client.deleteApplicationScheduledTask(uuid, task_uuid)
+                : this.client.deleteServiceScheduledTask(uuid, task_uuid),
+            );
+          case 'list_executions':
+            if (!task_uuid)
+              return { content: [{ type: 'text' as const, text: 'Error: task_uuid required' }] };
+            return wrap(() =>
+              isApp
+                ? this.client.listApplicationScheduledTaskExecutions(uuid, task_uuid)
+                : this.client.listServiceScheduledTaskExecutions(uuid, task_uuid),
+            );
+        }
+      },
+    );
+
+    // =========================================================================
+    // Application Previews (1 tool)
+    // =========================================================================
+    this.tool(
+      'delete_preview',
+      'Delete a preview deployment for an application',
+      { uuid: z.string(), pull_request_id: z.number() },
+      async ({ uuid, pull_request_id }) =>
+        wrap(() => this.client.deleteApplicationPreview(uuid, pull_request_id)),
+    );
+
+    // =========================================================================
+    // Hetzner Cloud (1 tool - consolidated)
+    // =========================================================================
+    this.tool(
+      'hetzner',
+      'Hetzner cloud: list_locations/list_server_types/list_images/list_ssh_keys/create_server',
+      {
+        action: z.enum([
+          'list_locations',
+          'list_server_types',
+          'list_images',
+          'list_ssh_keys',
+          'create_server',
+        ]),
+        cloud_provider_token_uuid: z.string().optional(),
+        location: z.string().optional(),
+        server_type: z.string().optional(),
+        image: z.number().optional(),
+        name: z.string().optional(),
+        private_key_uuid: z.string().optional(),
+        enable_ipv4: z.boolean().optional(),
+        enable_ipv6: z.boolean().optional(),
+        hetzner_ssh_key_ids: z.array(z.number()).optional(),
+        cloud_init_script: z.string().optional(),
+        instant_validate: z.boolean().optional(),
+      },
+      async (args) => {
+        const { action, cloud_provider_token_uuid: tokenUuid } = args;
+        switch (action) {
+          case 'list_locations':
+            if (!tokenUuid)
+              return {
+                content: [
+                  { type: 'text' as const, text: 'Error: cloud_provider_token_uuid required' },
+                ],
+              };
+            return wrap(() => this.client.listHetznerLocations(tokenUuid));
+          case 'list_server_types':
+            if (!tokenUuid)
+              return {
+                content: [
+                  { type: 'text' as const, text: 'Error: cloud_provider_token_uuid required' },
+                ],
+              };
+            return wrap(() => this.client.listHetznerServerTypes(tokenUuid));
+          case 'list_images':
+            if (!tokenUuid)
+              return {
+                content: [
+                  { type: 'text' as const, text: 'Error: cloud_provider_token_uuid required' },
+                ],
+              };
+            return wrap(() => this.client.listHetznerImages(tokenUuid));
+          case 'list_ssh_keys':
+            if (!tokenUuid)
+              return {
+                content: [
+                  { type: 'text' as const, text: 'Error: cloud_provider_token_uuid required' },
+                ],
+              };
+            return wrap(() => this.client.listHetznerSSHKeys(tokenUuid));
+          case 'create_server':
+            if (!args.location || !args.server_type || !args.image || !args.private_key_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: location, server_type, image, private_key_uuid required',
+                  },
+                ],
+              };
+            return wrap(() =>
+              this.client.createHetznerServer({
+                cloud_provider_token_uuid: tokenUuid,
+                location: args.location!,
+                server_type: args.server_type!,
+                image: args.image!,
+                name: args.name,
+                private_key_uuid: args.private_key_uuid!,
+                enable_ipv4: args.enable_ipv4,
+                enable_ipv6: args.enable_ipv6,
+                hetzner_ssh_key_ids: args.hetzner_ssh_key_ids,
+                cloud_init_script: args.cloud_init_script,
+                instant_validate: args.instant_validate,
+              }),
+            );
+        }
+      },
+    );
+
+    // =========================================================================
+    // Resources (1 tool)
+    // =========================================================================
+    this.tool('list_resources', 'List all resources across infrastructure', {}, async () =>
+      wrap(() => this.client.listResources()),
+    );
+
+    // =========================================================================
+    // Health (1 tool)
+    // =========================================================================
+    this.tool('health', 'Check Coolify API health', {}, async () =>
+      wrap(() => this.client.getHealth()),
+    );
+
+    // =========================================================================
+    // API Enable/Disable (1 tool)
+    // =========================================================================
+    this.tool(
+      'api_control',
+      'Enable or disable the Coolify API (requires root)',
+      { action: z.enum(['enable', 'disable']) },
+      async ({ action }) =>
+        wrap(() => (action === 'enable' ? this.client.enableApi() : this.client.disableApi())),
     );
 
     // =========================================================================

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -1129,6 +1129,176 @@ export interface BatchOperationResult {
 }
 
 // =============================================================================
+// Storage Types (Persistent & File Storages)
+// =============================================================================
+
+export interface Storage {
+  id: number;
+  uuid: string;
+  name?: string;
+  mount_path: string;
+  host_path?: string;
+  content?: string;
+  is_directory?: boolean;
+  fs_path?: string;
+  type: 'persistent' | 'file';
+  is_preview_suffix_enabled?: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StorageListResponse {
+  persistent_storages: Storage[];
+  file_storages: Storage[];
+}
+
+export interface CreateStorageRequest {
+  type: 'persistent' | 'file';
+  mount_path: string;
+  name?: string;
+  host_path?: string;
+  content?: string;
+  is_directory?: boolean;
+  fs_path?: string;
+  is_preview_suffix_enabled?: boolean;
+}
+
+export interface UpdateStorageRequest {
+  uuid?: string;
+  id?: number;
+  type: 'persistent' | 'file';
+  is_preview_suffix_enabled?: boolean;
+  name?: string;
+  mount_path?: string;
+  host_path?: string;
+  content?: string;
+  is_directory?: boolean;
+}
+
+// =============================================================================
+// Scheduled Task Types
+// =============================================================================
+
+export interface ScheduledTask {
+  id: number;
+  uuid: string;
+  enabled: boolean;
+  name: string;
+  command: string;
+  frequency: string;
+  container?: string;
+  timeout: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ScheduledTaskExecution {
+  uuid: string;
+  status: 'success' | 'failed' | 'running';
+  message?: string;
+  retry_count: number;
+  duration?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateScheduledTaskRequest {
+  name: string;
+  command: string;
+  frequency: string;
+  container?: string;
+  timeout?: number;
+  enabled?: boolean;
+}
+
+export interface UpdateScheduledTaskRequest {
+  name?: string;
+  command?: string;
+  frequency?: string;
+  container?: string;
+  timeout?: number;
+  enabled?: boolean;
+}
+
+// =============================================================================
+// Hetzner Cloud Types
+// =============================================================================
+
+export interface HetznerLocation {
+  id: number;
+  name: string;
+  description: string;
+  country: string;
+  city: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface HetznerServerType {
+  id: number;
+  name: string;
+  description: string;
+  cores: number;
+  memory: number;
+  disk: number;
+  architecture: string;
+}
+
+export interface HetznerImage {
+  id: number;
+  name: string;
+  description: string;
+  type: string;
+  os_flavor: string;
+  os_version: string;
+  architecture: string;
+}
+
+export interface HetznerSSHKey {
+  id: number;
+  name: string;
+  fingerprint: string;
+  public_key: string;
+}
+
+export interface CreateHetznerServerRequest {
+  cloud_provider_token_uuid?: string;
+  location: string;
+  server_type: string;
+  image: number;
+  name?: string;
+  private_key_uuid: string;
+  enable_ipv4?: boolean;
+  enable_ipv6?: boolean;
+  hetzner_ssh_key_ids?: number[];
+  cloud_init_script?: string;
+  instant_validate?: boolean;
+}
+
+export interface CreateHetznerServerResponse {
+  uuid: string;
+  hetzner_server_id: number;
+  ip: string;
+}
+
+// =============================================================================
+// GitHub App Repository Types
+// =============================================================================
+
+export interface GitHubRepository {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  html_url: string;
+  default_branch: string;
+}
+
+export interface GitHubBranch {
+  name: string;
+}
+
+// =============================================================================
 // Response Enhancement Types (HATEOAS-style actions)
 // =============================================================================
 

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -1299,6 +1299,17 @@ export interface GitHubBranch {
 }
 
 // =============================================================================
+// Resource List Types
+// =============================================================================
+
+export interface ResourceListItem {
+  uuid: string;
+  name: string;
+  type: 'server' | 'application' | 'database' | 'service' | string;
+  status?: string;
+}
+
+// =============================================================================
 // Response Enhancement Types (HATEOAS-style actions)
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds **7 new MCP tools**: `storages`, `scheduled_tasks`, `delete_preview`, `hetzner`, `list_resources`, `health`, `api_control`
- Expands **3 existing tools**: `env_vars` (database support + bulk_update), `github_apps` (list_repos + list_branches), `database_backups` (delete_execution)
- Covers **42 previously missing Coolify API endpoints**, identified by comparing the OpenAPI spec from the v4.x branch against the existing implementation

## Changes

**`src/types/coolify.ts`** — New types for storages, scheduled tasks, Hetzner cloud, and GitHub App repositories

**`src/lib/coolify-client.ts`** — 40 new client methods:
- Application/database/service persistent storage CRUD
- Application/service scheduled task CRUD + execution listing
- Application preview deletion
- Database env var CRUD + bulk update
- Backup execution deletion
- Service env var bulk update
- Hetzner cloud (locations, server types, images, SSH keys, create server)
- GitHub App repo/branch listing
- Resource listing, health check, API enable/disable

**`src/lib/mcp-server.ts`** — 7 new tools + 3 expanded tools following the project's consolidated action-parameter pattern to minimize token usage

**`README.md`** / **`CLAUDE.md`** — Updated tool count (38 → 45) and tool tables

## Tests

- **42 new test cases** (279 → 321 total)
- All client methods covered in `coolify-client.test.ts` (HTTP method, URL, body, return value)
- All methods verified in `mcp-server.test.ts` (existence checks)
- Coverage: **97.98% statements**, 84.61% branches, 99.52% functions, 98.84% lines

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 321 passed, 0 failed
- [x] `npm run lint` — clean (pre-commit hooks passed)
- [ ] Live smoke test against Coolify instance (deferred — no access to live server in this environment)