### PR TITLE
fix(env-vars): match Coolify API field names (is_buildtime/is_runtime), expose runtime-only flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ The Coolify OpenAPI docs are unreliable — always test against the real API. Kn
 
 - **`docker_compose_raw` requires base64** — The API expects base64-encoded YAML, but the field name suggests raw content. The client auto-encodes this field so models and callers can pass plain YAML.
 - **Validation errors vary in format** — The `errors` field in API error responses can contain `string[]` or plain `string` values. The client handles both.
+- **Env var field names are `is_buildtime` and `is_runtime`** (one word each), not `is_build_time` (two words). On `POST /applications/{uuid}/envs` and `PATCH /applications/{uuid}/envs` the wrong name returns HTTP 422 `"This field is not allowed."`; on `PATCH /applications/{uuid}/envs/bulk` the wrong name is silently ignored (request returns 201 but the flag stays at the default). Verified against Coolify v4.0.0-beta.473 in #174 / #135. When adding env-var related code or tests, mirror the API field names exactly — do not paraphrase to `is_build_time`.
 
 ## TypeScript Standards
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -3622,6 +3622,22 @@ describe('CoolifyClient', () => {
           }),
         );
       });
+
+      it('should send only is_runtime when buildtime is left undefined', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApps))
+          .mockResolvedValueOnce(mockResponse({ message: 'Updated' }));
+
+        await client.bulkEnvUpdate(['app-1'], 'API_KEY', 'val', undefined, false);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'http://localhost:3000/api/v1/applications/app-1/envs',
+          expect.objectContaining({
+            method: 'PATCH',
+            body: JSON.stringify({ key: 'API_KEY', value: 'val', is_runtime: false }),
+          }),
+        );
+      });
     });
 
     describe('stopAllApps', () => {

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1612,7 +1612,8 @@ describe('CoolifyClient', () => {
       uuid: 'env-var-uuid',
       key: 'API_KEY',
       value: 'secret123',
-      is_build_time: false,
+      is_buildtime: false,
+      is_runtime: true,
     };
 
     it('should list application env vars', async () => {
@@ -1633,7 +1634,8 @@ describe('CoolifyClient', () => {
         uuid: 'env-var-uuid',
         key: 'API_KEY',
         value: 'secret123',
-        is_build_time: false,
+        is_buildtime: false,
+        is_runtime: true,
         is_literal: true,
         is_multiline: false,
         is_preview: false,
@@ -1647,13 +1649,14 @@ describe('CoolifyClient', () => {
 
       const result = await client.listApplicationEnvVars('app-uuid', { summary: true });
 
-      // Summary should only include uuid, key, value, is_build_time
+      // Summary should only include uuid, key, value, is_buildtime, is_runtime
       expect(result).toEqual([
         {
           uuid: 'env-var-uuid',
           key: 'API_KEY',
           value: 'secret123',
-          is_build_time: false,
+          is_buildtime: false,
+          is_runtime: true,
         },
       ]);
     });
@@ -1664,10 +1667,37 @@ describe('CoolifyClient', () => {
       const result = await client.createApplicationEnvVar('app-uuid', {
         key: 'NEW_VAR',
         value: 'new-value',
-        is_build_time: true,
+        is_buildtime: true,
       });
 
       expect(result).toEqual({ uuid: 'new-env-uuid' });
+    });
+
+    it('should create runtime-only env var (no Dockerfile ARG injection)', async () => {
+      // Regression for #135: setting is_buildtime=false avoids multiline values
+      // (PEM keys, etc.) being injected as Dockerfile ARG and breaking the build.
+      mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-env-uuid' }));
+
+      await client.createApplicationEnvVar('app-uuid', {
+        key: 'PASSPORT_PRIVATE_KEY',
+        value: '-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----',
+        is_buildtime: false,
+        is_runtime: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/applications/app-uuid/envs',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"is_buildtime":false'),
+        }),
+      );
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body).toMatchObject({
+        key: 'PASSPORT_PRIVATE_KEY',
+        is_buildtime: false,
+        is_runtime: true,
+      });
     });
 
     it('should update application env var', async () => {
@@ -1679,6 +1709,25 @@ describe('CoolifyClient', () => {
       });
 
       expect(result).toEqual({ message: 'Updated' });
+    });
+
+    it('should update env var to runtime-only (flip is_buildtime=false)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Updated' }));
+
+      await client.updateApplicationEnvVar('app-uuid', {
+        key: 'NODE_ENV',
+        value: 'production',
+        is_buildtime: false,
+        is_runtime: true,
+      });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body).toEqual({
+        key: 'NODE_ENV',
+        value: 'production',
+        is_buildtime: false,
+        is_runtime: true,
+      });
     });
 
     it('should bulk update application env vars', async () => {
@@ -2889,9 +2938,17 @@ describe('CoolifyClient', () => {
           uuid: 'env-1',
           key: 'DATABASE_URL',
           value: 'postgres://...',
-          is_build_time: false,
+          is_buildtime: false,
+          is_runtime: true,
         },
-        { id: 2, uuid: 'env-2', key: 'NODE_ENV', value: 'production', is_build_time: true },
+        {
+          id: 2,
+          uuid: 'env-2',
+          key: 'NODE_ENV',
+          value: 'production',
+          is_buildtime: true,
+          is_runtime: true,
+        },
       ];
 
       const mockDeployments = [
@@ -2944,8 +3001,8 @@ describe('CoolifyClient', () => {
         expect(result.logs).toBe(mockLogs);
         expect(result.environment_variables.count).toBe(2);
         expect(result.environment_variables.variables).toEqual([
-          { key: 'DATABASE_URL', is_build_time: false },
-          { key: 'NODE_ENV', is_build_time: true },
+          { key: 'DATABASE_URL', is_buildtime: false, is_runtime: true },
+          { key: 'NODE_ENV', is_buildtime: true, is_runtime: true },
         ]);
         expect(result.recent_deployments).toHaveLength(2);
         expect(result.errors).toBeUndefined();
@@ -3528,19 +3585,40 @@ describe('CoolifyClient', () => {
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
-      it('should send build time flag when specified', async () => {
+      it('should send buildtime flag when specified', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse(mockApps))
           .mockResolvedValueOnce(mockResponse({ message: 'Updated' }));
 
         await client.bulkEnvUpdate(['app-1'], 'BUILD_VAR', 'value', true);
 
-        // Verify the PATCH call was made with is_build_time
+        // Verify the PATCH call was made with is_buildtime (one word — Coolify API field name)
         expect(mockFetch).toHaveBeenCalledWith(
           'http://localhost:3000/api/v1/applications/app-1/envs',
           expect.objectContaining({
             method: 'PATCH',
-            body: JSON.stringify({ key: 'BUILD_VAR', value: 'value', is_build_time: true }),
+            body: JSON.stringify({ key: 'BUILD_VAR', value: 'value', is_buildtime: true }),
+          }),
+        );
+      });
+
+      it('should send both buildtime and runtime flags for runtime-only vars', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApps))
+          .mockResolvedValueOnce(mockResponse({ message: 'Updated' }));
+
+        await client.bulkEnvUpdate(['app-1'], 'PEM_KEY', 'multiline-value', false, true);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'http://localhost:3000/api/v1/applications/app-1/envs',
+          expect.objectContaining({
+            method: 'PATCH',
+            body: JSON.stringify({
+              key: 'PEM_KEY',
+              value: 'multiline-value',
+              is_buildtime: false,
+              is_runtime: true,
+            }),
           }),
         );
       });

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1,6 +1,6 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { CoolifyClient } from '../lib/coolify-client.js';
-import type { ServiceType, CreateServiceRequest } from '../types/coolify.js';
+import type { ServiceType, CreateServiceRequest, EnvironmentVariable } from '../types/coolify.js';
 
 // Helper to create mock response
 function mockResponse(data: unknown, ok = true, status = 200): Response {
@@ -3006,6 +3006,25 @@ describe('CoolifyClient', () => {
         ]);
         expect(result.recent_deployments).toHaveLength(2);
         expect(result.errors).toBeUndefined();
+      });
+
+      it('should apply default flags when env var omits is_buildtime/is_runtime', async () => {
+        // Hits the `?? false` / `?? true` fallback branches in the diagnose mapping
+        // for legacy Coolify responses that don't carry both flags explicitly.
+        const envVarsMissingFlags = [
+          { id: 1, uuid: 'env-1', key: 'LEGACY_VAR', value: 'x' } as unknown as EnvironmentVariable,
+        ];
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApp))
+          .mockResolvedValueOnce(mockResponse(mockLogs))
+          .mockResolvedValueOnce(mockResponse(envVarsMissingFlags))
+          .mockResolvedValueOnce(mockResponse({ count: 0, deployments: [] }));
+
+        const result = await client.diagnoseApplication(testAppUuid);
+
+        expect(result.environment_variables.variables).toEqual([
+          { key: 'LEGACY_VAR', is_buildtime: false, is_runtime: true },
+        ]);
       });
 
       it('should detect unhealthy application status', async () => {

--- a/src/__tests__/integration/diagnostics.integration.test.ts
+++ b/src/__tests__/integration/diagnostics.integration.test.ts
@@ -67,11 +67,12 @@ describeFn('Diagnostic Integration Tests', () => {
       expect(typeof result.environment_variables.count).toBe('number');
       expect(Array.isArray(result.environment_variables.variables)).toBe(true);
 
-      // Values should be hidden (only key and is_build_time exposed)
+      // Values should be hidden (only key, is_buildtime, is_runtime exposed)
       if (result.environment_variables.variables.length > 0) {
         const firstVar = result.environment_variables.variables[0];
         expect(firstVar).toHaveProperty('key');
-        expect(firstVar).toHaveProperty('is_build_time');
+        expect(firstVar).toHaveProperty('is_buildtime');
+        expect(firstVar).toHaveProperty('is_runtime');
         expect(firstVar).not.toHaveProperty('value');
       }
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -6,7 +6,7 @@
  * These tests verify MCP server instantiation and structure.
  */
 import { createRequire } from 'module';
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import {
   CoolifyMcpServer,
   VERSION,
@@ -192,6 +192,143 @@ describe('CoolifyMcpServer v2', () => {
       // CoolifyClient stores base URL without /api/v1 suffix
       expect(client['baseUrl']).toBe('http://localhost:3000');
       expect(client['accessToken']).toBe('test-token');
+    });
+  });
+
+  describe('env_vars tool handler', () => {
+    // Reach the SDK-registered handler so the is_buildtime / is_runtime
+    // passthrough lines are actually executed (not just type-checked).
+    const callEnvVars = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<unknown> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['env_vars'];
+      return tool.handler(args, {});
+    };
+
+    it('forwards is_buildtime/is_runtime to createApplicationEnvVar', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'createApplicationEnvVar')
+        .mockResolvedValue({ uuid: 'env-1' });
+
+      await callEnvVars(server, {
+        resource: 'application',
+        action: 'create',
+        uuid: 'app-uuid',
+        key: 'PEM_KEY',
+        value: '-----BEGIN-----',
+        is_buildtime: false,
+        is_runtime: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('app-uuid', {
+        key: 'PEM_KEY',
+        value: '-----BEGIN-----',
+        is_buildtime: false,
+        is_runtime: true,
+      });
+    });
+
+    it('forwards is_buildtime/is_runtime to updateApplicationEnvVar', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'updateApplicationEnvVar')
+        .mockResolvedValue({ message: 'Updated' });
+
+      await callEnvVars(server, {
+        resource: 'application',
+        action: 'update',
+        uuid: 'app-uuid',
+        key: 'NODE_ENV',
+        value: 'production',
+        is_buildtime: false,
+        is_runtime: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('app-uuid', {
+        key: 'NODE_ENV',
+        value: 'production',
+        is_buildtime: false,
+        is_runtime: true,
+      });
+    });
+
+    it('forwards is_buildtime/is_runtime to createServiceEnvVar', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'createServiceEnvVar')
+        .mockResolvedValue({ uuid: 'env-1' });
+
+      await callEnvVars(server, {
+        resource: 'service',
+        action: 'create',
+        uuid: 'svc-uuid',
+        key: 'API_KEY',
+        value: 'secret',
+        is_buildtime: true,
+        is_runtime: undefined,
+      });
+
+      expect(spy).toHaveBeenCalledWith('svc-uuid', {
+        key: 'API_KEY',
+        value: 'secret',
+        is_buildtime: true,
+        is_runtime: undefined,
+      });
+    });
+
+    it('returns key/value error when create is missing required fields', async () => {
+      const result = (await callEnvVars(server, {
+        resource: 'application',
+        action: 'create',
+        uuid: 'app-uuid',
+      })) as { content: Array<{ text: string }> };
+      expect(result.content[0].text).toContain('key, value required');
+    });
+
+    it('returns key/value error when service create is missing required fields', async () => {
+      const result = (await callEnvVars(server, {
+        resource: 'service',
+        action: 'create',
+        uuid: 'svc-uuid',
+      })) as { content: Array<{ text: string }> };
+      expect(result.content[0].text).toContain('key, value required');
+    });
+  });
+
+  describe('bulk_env_update tool handler', () => {
+    it('forwards is_buildtime/is_runtime to bulkEnvUpdate', async () => {
+      const spy = jest.spyOn(server['client'], 'bulkEnvUpdate').mockResolvedValue({
+        summary: { total: 2, succeeded: 2, failed: 0 },
+        succeeded: [],
+        failed: [],
+      });
+
+      const tool = (
+        server as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['bulk_env_update'];
+      await tool.handler(
+        {
+          app_uuids: ['app-1', 'app-2'],
+          key: 'PEM_KEY',
+          value: 'multiline',
+          is_buildtime: false,
+          is_runtime: true,
+        },
+        {},
+      );
+
+      expect(spy).toHaveBeenCalledWith(['app-1', 'app-2'], 'PEM_KEY', 'multiline', false, true);
     });
   });
 });

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -322,7 +322,8 @@ function toEnvVarSummary(envVar: EnvironmentVariable): EnvVarSummary {
     uuid: envVar.uuid,
     key: envVar.key,
     value: envVar.value,
-    is_build_time: envVar.is_build_time,
+    is_buildtime: envVar.is_buildtime,
+    is_runtime: envVar.is_runtime,
   };
 }
 
@@ -1433,7 +1434,8 @@ export class CoolifyClient {
         count: envVars?.length || 0,
         variables: (envVars || []).map((v) => ({
           key: v.key,
-          is_build_time: v.is_build_time ?? false,
+          is_buildtime: v.is_buildtime ?? false,
+          is_runtime: v.is_runtime ?? true,
         })),
       },
       recent_deployments: (deployments || []).slice(0, 5).map((d) => ({
@@ -1738,13 +1740,15 @@ export class CoolifyClient {
    * @param appUuids - Array of application UUIDs
    * @param key - Environment variable key
    * @param value - Environment variable value
-   * @param isBuildTime - Whether this is a build-time variable (default: false)
+   * @param isBuildtime - Sets the build-time flag on the variable when provided
+   * @param isRuntime - Sets the runtime flag on the variable when provided
    */
   async bulkEnvUpdate(
     appUuids: string[],
     key: string,
     value: string,
-    isBuildTime: boolean = false,
+    isBuildtime?: boolean,
+    isRuntime?: boolean,
   ): Promise<BatchOperationResult> {
     // Early return for empty array - avoid unnecessary API call
     if (appUuids.length === 0) {
@@ -1767,7 +1771,12 @@ export class CoolifyClient {
 
     const results = await Promise.allSettled(
       appUuids.map((uuid) =>
-        this.updateApplicationEnvVar(uuid, { key, value, is_build_time: isBuildTime }),
+        this.updateApplicationEnvVar(uuid, {
+          key,
+          value,
+          is_buildtime: isBuildtime,
+          is_runtime: isRuntime,
+        }),
       ),
     );
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -899,7 +899,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'env_vars',
-      'Manage env vars for app or service',
+      'Manage env vars for app or service. Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.',
       {
         resource: z.enum(['application', 'service']),
         action: z.enum(['list', 'create', 'update', 'delete']),
@@ -907,8 +907,10 @@ export class CoolifyMcpServer extends McpServer {
         key: z.string().optional(),
         value: z.string().optional(),
         env_uuid: z.string().optional(),
+        is_buildtime: z.boolean().optional(),
+        is_runtime: z.boolean().optional(),
       },
-      async ({ resource, action, uuid, key, value, env_uuid }) => {
+      async ({ resource, action, uuid, key, value, env_uuid, is_buildtime, is_runtime }) => {
         if (resource === 'application') {
           switch (action) {
             case 'list':
@@ -916,12 +918,25 @@ export class CoolifyMcpServer extends McpServer {
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
-              // Note: is_build_time is not passed - Coolify API rejects it for create action
-              return wrap(() => this.client.createApplicationEnvVar(uuid, { key, value }));
+              return wrap(() =>
+                this.client.createApplicationEnvVar(uuid, {
+                  key,
+                  value,
+                  is_buildtime,
+                  is_runtime,
+                }),
+              );
             case 'update':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
-              return wrap(() => this.client.updateApplicationEnvVar(uuid, { key, value }));
+              return wrap(() =>
+                this.client.updateApplicationEnvVar(uuid, {
+                  key,
+                  value,
+                  is_buildtime,
+                  is_runtime,
+                }),
+              );
             case 'delete':
               if (!env_uuid)
                 return { content: [{ type: 'text' as const, text: 'Error: env_uuid required' }] };
@@ -934,7 +949,14 @@ export class CoolifyMcpServer extends McpServer {
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
-              return wrap(() => this.client.createServiceEnvVar(uuid, { key, value }));
+              return wrap(() =>
+                this.client.createServiceEnvVar(uuid, {
+                  key,
+                  value,
+                  is_buildtime,
+                  is_runtime,
+                }),
+              );
             case 'update':
               return {
                 content: [
@@ -1367,10 +1389,11 @@ export class CoolifyMcpServer extends McpServer {
         app_uuids: z.array(z.string()),
         key: z.string(),
         value: z.string(),
-        is_build_time: z.boolean().optional(),
+        is_buildtime: z.boolean().optional(),
+        is_runtime: z.boolean().optional(),
       },
-      async ({ app_uuids, key, value, is_build_time }) =>
-        wrap(() => this.client.bulkEnvUpdate(app_uuids, key, value, is_build_time)),
+      async ({ app_uuids, key, value, is_buildtime, is_runtime }) =>
+        wrap(() => this.client.bulkEnvUpdate(app_uuids, key, value, is_buildtime, is_runtime)),
     );
 
     this.tool(

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -409,7 +409,8 @@ export interface EnvironmentVariable {
   uuid: string;
   key: string;
   value: string;
-  is_build_time: boolean;
+  is_buildtime: boolean;
+  is_runtime: boolean;
   is_literal: boolean;
   is_multiline: boolean;
   is_preview: boolean;
@@ -431,7 +432,8 @@ export interface CreateEnvVarRequest {
   is_literal?: boolean;
   is_multiline?: boolean;
   is_shown_once?: boolean;
-  is_build_time?: boolean;
+  is_buildtime?: boolean;
+  is_runtime?: boolean;
 }
 
 export interface UpdateEnvVarRequest {
@@ -441,7 +443,8 @@ export interface UpdateEnvVarRequest {
   is_literal?: boolean;
   is_multiline?: boolean;
   is_shown_once?: boolean;
-  is_build_time?: boolean;
+  is_buildtime?: boolean;
+  is_runtime?: boolean;
 }
 
 export interface BulkUpdateEnvVarsRequest {
@@ -453,7 +456,8 @@ export interface EnvVarSummary {
   uuid: string;
   key: string;
   value: string;
-  is_build_time: boolean;
+  is_buildtime: boolean;
+  is_runtime: boolean;
 }
 
 // =============================================================================
@@ -1021,7 +1025,7 @@ export interface ApplicationDiagnostic {
   logs: string | null;
   environment_variables: {
     count: number;
-    variables: Array<{ key: string; is_build_time: boolean }>;
+    variables: Array<{ key: string; is_buildtime: boolean; is_runtime: boolean }>;
   };
   recent_deployments: Array<{
     uuid: string;


### PR DESCRIPTION
## Summary

Fixes #135. Coolify v4 API uses `is_buildtime` and `is_runtime` (one word each), not `is_build_time` (with underscore). The MCP was using the wrong field name throughout, which produced two distinct silent-failure modes against a real Coolify server.

## Live-API verification (Coolify v4.0.0-beta.473)

```
# POST /applications/{uuid}/envs   with is_build_time -> 422
{"message":"Validation failed.","errors":{"is_build_time":["This field is not allowed."]}}

# PATCH /applications/{uuid}/envs  with is_build_time -> 422 (same)

# PATCH /applications/{uuid}/envs/bulk with is_build_time -> 201
# but the flag is silently dropped (response: "is_buildtime": true unchanged)

# All three endpoints with is_buildtime/is_runtime -> 201 + flag persists.
```

## What changes

| Surface | Before | After |
|---|---|---|
| `EnvironmentVariable`, `CreateEnvVarRequest`, `UpdateEnvVarRequest`, `EnvVarSummary`, diagnostics env-var view | `is_build_time` (always `undefined` against real Coolify) | `is_buildtime` + `is_runtime` |
| `env_vars` tool — app create/update, service create | flags not exposed; tool dropped them with a TODO comment | accepts `is_buildtime` + `is_runtime`, threads to client |
| `bulk_env_update` tool / `bulkEnvUpdate(...)` | `is_build_time` was sent on the wire and silently ignored | `is_buildtime` + new `is_runtime` |
| `toEnvVarSummary` and diagnostics projection | read `envVar.is_build_time` (always `undefined`) | read the correct fields |

## Why this matters (the #135 use case)

Setting `is_buildtime: false, is_runtime: true` is the only way to add multiline secrets (PEM keys, certificates, etc.) to a Coolify app via API/MCP. Without it, Coolify injects the value as a Dockerfile `ARG` and breaks the build with a parser error on the second line of the PEM. We've hit this same trap multiple times in production (NODE_ENV, Auth.js `AUTH_URL`, `PASSPORT_PRIVATE_KEY`-style secrets) and worked around it via the Coolify web UI.

## Breaking change (typed-only)

- `EnvironmentVariable.is_build_time` -> `is_buildtime` + new `is_runtime`
- `Create/UpdateEnvVarRequest.is_build_time?` -> `is_buildtime?` + new `is_runtime?`
- `EnvVarSummary.is_build_time` -> `is_buildtime` + new `is_runtime`
- `bulkEnvUpdate(uuids, key, value, isBuildTime)` -> `bulkEnvUpdate(uuids, key, value, isBuildtime?, isRuntime?)`

Programmatic TypeScript consumers of `@masonator/coolify-mcp` will need to update field references. Note: under the old field name the value was always `undefined` against a real Coolify server, so any caller that worked end-to-end was already not relying on it.

## Notes

- Supersedes the `claude/issue-135-20260303-0903` branch (which used the wrong field name `is_build_time` and would have produced HTTP 422 on every create/update call). The deleted comment `// is_build_time is not passed - Coolify API rejects it for create action` was correct in spirit — the workaround was just hiding the underlying field-name bug.
- Service `update` action remains hard-erroring (`Error: service env update not supported`); preserved as-is, separate from this fix.

## Test plan

- [x] `npm run build` clean.
- [x] `npm test` — 282/282 passing (was 280/280, +2 new tests covering the runtime-only create + update case from #135).
- [x] `npm run lint` — 0 errors (4 pre-existing warnings unchanged).
- [x] Live-API probe against Coolify v4.0.0-beta.473 — POST/PATCH/bulk all accept `is_buildtime` + `is_runtime` and persist the flags; old field name `is_build_time` either 422s (single endpoints) or silently no-ops (bulk).