### PR TITLE
fix: parse non-json Coolify responses defensively

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -3,12 +3,19 @@ import { CoolifyClient } from '../lib/coolify-client.js';
 import type { ServiceType, CreateServiceRequest } from '../types/coolify.js';
 
 // Helper to create mock response
-function mockResponse(data: unknown, ok = true, status = 200): Response {
+function mockResponse(
+  data: unknown,
+  ok = true,
+  status = 200,
+  contentType = 'application/json',
+): Response {
+  const body = contentType.includes('application/json') ? JSON.stringify(data) : String(data);
   return {
     ok,
     status,
     statusText: ok ? 'OK' : 'Error',
-    text: async () => JSON.stringify(data),
+    headers: new Headers({ 'Content-Type': contentType }),
+    text: async () => body,
   } as Response;
 }
 
@@ -715,6 +722,29 @@ describe('CoolifyClient', () => {
 
       const result = await client.deleteServer('test-uuid');
       expect(result).toEqual({});
+    });
+
+    it('should return plain text responses without JSON parsing', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse('log line 1\nlog line 2', true, 200, 'text/plain; charset=utf-8'),
+      );
+
+      const result = await client.getApplicationLogs('app-uuid', 50);
+
+      expect(result).toBe('log line 1\nlog line 2');
+    });
+
+    it('should fall back to raw text when JSON responses are malformed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        text: async () => 'not valid json',
+      } as Response);
+
+      const result = await client.getApplicationLogs('app-uuid', 50);
+
+      expect(result).toBe('not valid json');
     });
 
     it('should handle API errors without message', async () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -378,7 +378,21 @@ export class CoolifyClient {
 
       // Handle empty responses (204 No Content, etc.)
       const text = await response.text();
-      const data = text ? JSON.parse(text) : {};
+      const contentType = response.headers?.get('Content-Type')?.toLowerCase() ?? '';
+      const isJsonResponse =
+        !contentType || contentType.includes('application/json') || contentType.includes('+json');
+      let data: unknown = {};
+      if (text) {
+        if (isJsonResponse) {
+          try {
+            data = JSON.parse(text);
+          } catch {
+            data = text;
+          }
+        } else {
+          data = text;
+        }
+      }
 
       if (!response.ok) {
         const error = data as ErrorResponse;


### PR DESCRIPTION
## Summary

Fixes #163.

## Changes

- Parse `request<T>` responses based on the response `Content-Type` instead of unconditionally calling `JSON.parse`.
- Fall back to raw text for `text/plain` responses and malformed JSON bodies while preserving JSON parsing for JSON and `+json` content types.
- Add regression coverage for plain-text application logs and malformed JSON responses.

## Test plan

- [x] Tests added/updated
- [x] Manually tested locally

Validation run locally:

- `$env:NODE_OPTIONS='--experimental-vm-modules'; npx jest --testPathIgnorePatterns=integration --runInBand`
- `$env:NODE_OPTIONS='--experimental-vm-modules'; npx jest --testPathIgnorePatterns=integration --runTestsByPath src/__tests__/coolify-client.test.ts --runInBand --coverage=false`
- `npm run build`
- `npm run lint`
- `npm run format:check`

`npm run lint` passes with the repository's existing warning-only `no-explicit-any` reports.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed