### PR TITLE
chore(dependabot): pin TypeScript to minor/patch only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    # TypeScript majors regularly ship breaking type changes (e.g. 6.0.3 broke
+    # the build (24.x) matrix in #171). Pin to minors until we explicitly migrate.
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
     commit-message:
       prefix: 'chore(deps)'
     labels:


### PR DESCRIPTION
## Summary

- TypeScript 6.0.3 (#171) failed the build (24.x) matrix
- TS majors regularly ship breaking type changes that need deliberate migration, not auto-merge
- Adds an ignore rule so dependabot won't keep reopening TS major bumps

## Test plan

- [ ] Confirm next dependabot run doesn't include a TS major bump
- [ ] We can still take the next TS major as a standalone PR when ready