### PR TITLE
fix(env_vars): mask value and real_value by default, opt-in reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`env_vars` list now masks values by default** (#159, thanks @daniel-rudaev for reporting) — `value` (and `real_value` on the full projection) on `env_vars` list responses is now replaced with `'***'` so plaintext secrets are not leaked to MCP clients / LLMs. Metadata (uuid, key, `is_buildtime`, `is_runtime`, timestamps, ids) is untouched. Applied at the API boundary in `listApplicationEnvVars` and `listServiceEnvVars` so both the summary and full projections are protected. `bulk_env_update` continues to return `MessageResponse`-shape data with no values echoed.
+
+### Changed (behavioural, may surprise existing callers)
+
+- **`env_vars` list `value` field is now `'\***'`by default.** Callers that need the plaintext value must pass`reveal: true`on the`env_vars`list action (e.g. "what is FOO set to right now?"). If you were relying on`value`being present in list responses, add`reveal: true`to your call. The underlying client methods`listApplicationEnvVars(uuid, options)`and`listServiceEnvVars(uuid, options)`now accept`reveal?: boolean` on the options object.
+
 ## [2.8.1] - 2026-04-28
 
 ### Added

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1646,19 +1646,74 @@ describe('CoolifyClient', () => {
       is_runtime: true,
     };
 
-    it('should list application env vars', async () => {
+    it('should list application env vars with values masked by default (#159)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse([mockEnvVar]));
 
       const result = await client.listApplicationEnvVars('app-uuid');
 
-      expect(result).toEqual([mockEnvVar]);
+      // value masked, metadata preserved
+      expect(result).toEqual([
+        {
+          uuid: 'env-var-uuid',
+          key: 'API_KEY',
+          value: '***',
+          is_buildtime: false,
+          is_runtime: true,
+        },
+      ]);
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/applications/app-uuid/envs',
         expect.any(Object),
       );
     });
 
-    it('should list application env vars with summary', async () => {
+    it('should list application env vars with real_value also masked on the full projection (#159)', async () => {
+      const fullEnvVar = {
+        id: 1,
+        uuid: 'env-var-uuid',
+        key: 'API_KEY',
+        value: 'secret123',
+        real_value: 'secret123',
+        is_buildtime: false,
+        is_runtime: true,
+        is_literal: true,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        application_id: 1,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse([fullEnvVar]));
+
+      const result = (await client.listApplicationEnvVars('app-uuid')) as EnvironmentVariable[];
+
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      // Metadata stays intact
+      expect(result[0]).toMatchObject({
+        uuid: 'env-var-uuid',
+        key: 'API_KEY',
+        is_buildtime: false,
+        is_runtime: true,
+        is_literal: true,
+        is_preview: false,
+        application_id: 1,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      });
+    });
+
+    it('should list application env vars with real values when reveal=true (#159)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([mockEnvVar]));
+
+      const result = await client.listApplicationEnvVars('app-uuid', { reveal: true });
+
+      expect(result).toEqual([mockEnvVar]);
+    });
+
+    it('should list application env vars with summary, masked by default (#159)', async () => {
       const fullEnvVar = {
         id: 1,
         uuid: 'env-var-uuid',
@@ -1679,7 +1734,42 @@ describe('CoolifyClient', () => {
 
       const result = await client.listApplicationEnvVars('app-uuid', { summary: true });
 
-      // Summary should only include uuid, key, value, is_buildtime, is_runtime
+      // Summary should only include uuid, key, value, is_buildtime, is_runtime — and value masked
+      expect(result).toEqual([
+        {
+          uuid: 'env-var-uuid',
+          key: 'API_KEY',
+          value: '***',
+          is_buildtime: false,
+          is_runtime: true,
+        },
+      ]);
+    });
+
+    it('should list application env vars with summary and reveal=true returning real values (#159)', async () => {
+      const fullEnvVar = {
+        id: 1,
+        uuid: 'env-var-uuid',
+        key: 'API_KEY',
+        value: 'secret123',
+        is_buildtime: false,
+        is_runtime: true,
+        is_literal: true,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        application_id: 1,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse([fullEnvVar]));
+
+      const result = await client.listApplicationEnvVars('app-uuid', {
+        summary: true,
+        reveal: true,
+      });
+
       expect(result).toEqual([
         {
           uuid: 'env-var-uuid',
@@ -2207,16 +2297,64 @@ describe('CoolifyClient', () => {
       value: 'svc-value',
     };
 
-    it('should list service env vars', async () => {
+    it('should list service env vars with values masked by default (#159)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse([mockEnvVar]));
 
       const result = await client.listServiceEnvVars('test-uuid');
 
-      expect(result).toEqual([mockEnvVar]);
+      // value masked, metadata (uuid, key) preserved
+      expect(result).toEqual([
+        {
+          uuid: 'svc-env-uuid',
+          key: 'SVC_KEY',
+          value: '***',
+        },
+      ]);
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/services/test-uuid/envs',
         expect.any(Object),
       );
+    });
+
+    it('should list service env vars with real_value masked on the full projection (#159)', async () => {
+      const fullEnvVar = {
+        id: 1,
+        uuid: 'svc-env-uuid',
+        key: 'SVC_KEY',
+        value: 'svc-value',
+        real_value: 'svc-value',
+        is_buildtime: false,
+        is_runtime: true,
+        is_literal: true,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        service_id: 42,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse([fullEnvVar]));
+
+      const result = await client.listServiceEnvVars('test-uuid');
+
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      expect(result[0]).toMatchObject({
+        uuid: 'svc-env-uuid',
+        key: 'SVC_KEY',
+        is_buildtime: false,
+        is_runtime: true,
+        service_id: 42,
+      });
+    });
+
+    it('should list service env vars with real values when reveal=true (#159)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([mockEnvVar]));
+
+      const result = await client.listServiceEnvVars('test-uuid', { reveal: true });
+
+      expect(result).toEqual([mockEnvVar]);
     });
 
     it('should create service env var', async () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -328,6 +328,43 @@ function toEnvVarSummary(envVar: EnvironmentVariable): EnvVarSummary {
 }
 
 /**
+ * Sentinel string used to replace plaintext env var values when masking.
+ * Exported via behaviour, not as a public API — clients should treat any
+ * non-real string as "value not returned".
+ */
+const MASKED_VALUE = '***';
+
+/**
+ * Mask the `value` and `real_value` fields on a full {@link EnvironmentVariable}.
+ * All other metadata (uuid, key, flags, timestamps, ids) is preserved verbatim.
+ *
+ * Applied at the API boundary so callers cannot accidentally leak secrets to
+ * an LLM client by forgetting to strip values downstream. Pair with the
+ * `reveal: true` opt-in on list methods when the caller genuinely needs the
+ * plaintext (e.g. "what is FOO set to right now?").
+ */
+function maskEnvVar(envVar: EnvironmentVariable): EnvironmentVariable {
+  const masked: EnvironmentVariable = {
+    ...envVar,
+    value: MASKED_VALUE,
+  };
+  if (envVar.real_value !== undefined) {
+    masked.real_value = MASKED_VALUE;
+  }
+  return masked;
+}
+
+/**
+ * Mask the `value` field on an {@link EnvVarSummary}. Metadata is preserved.
+ */
+function maskEnvVarSummary(envVar: EnvVarSummary): EnvVarSummary {
+  return {
+    ...envVar,
+    value: MASKED_VALUE,
+  };
+}
+
+/**
  * HTTP client for the Coolify API
  */
 export class CoolifyClient {
@@ -768,12 +805,24 @@ export class CoolifyClient {
   // Application Environment Variables
   // ===========================================================================
 
+  /**
+   * List env vars for an application.
+   *
+   * Default behaviour masks `value` (and `real_value` on the full projection)
+   * with a sentinel string so secrets are not leaked to MCP clients. Pass
+   * `reveal: true` when the caller explicitly needs the plaintext value.
+   */
   async listApplicationEnvVars(
     uuid: string,
-    options?: { summary?: boolean },
+    options?: { summary?: boolean; reveal?: boolean },
   ): Promise<EnvironmentVariable[] | EnvVarSummary[]> {
     const envVars = await this.request<EnvironmentVariable[]>(`/applications/${uuid}/envs`);
-    return options?.summary ? envVars.map(toEnvVarSummary) : envVars;
+    const reveal = options?.reveal === true;
+    if (options?.summary) {
+      const summaries = envVars.map(toEnvVarSummary);
+      return reveal ? summaries : summaries.map(maskEnvVarSummary);
+    }
+    return reveal ? envVars : envVars.map(maskEnvVar);
   }
 
   async createApplicationEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {
@@ -990,8 +1039,19 @@ export class CoolifyClient {
   // Service Environment Variables
   // ===========================================================================
 
-  async listServiceEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
-    return this.request<EnvironmentVariable[]>(`/services/${uuid}/envs`);
+  /**
+   * List env vars for a service.
+   *
+   * Default behaviour masks `value` (and `real_value`) with a sentinel string
+   * so secrets are not leaked to MCP clients. Pass `reveal: true` when the
+   * caller explicitly needs the plaintext value.
+   */
+  async listServiceEnvVars(
+    uuid: string,
+    options?: { reveal?: boolean },
+  ): Promise<EnvironmentVariable[]> {
+    const envVars = await this.request<EnvironmentVariable[]>(`/services/${uuid}/envs`);
+    return options?.reveal === true ? envVars : envVars.map(maskEnvVar);
   }
 
   async createServiceEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -899,7 +899,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'env_vars',
-      'Manage env vars for app or service. Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.',
+      "Manage env vars for app or service. Values are masked by default (returned as '***') to avoid leaking secrets to MCP clients; pass reveal=true on the list action when the caller explicitly needs the plaintext (e.g. 'what is FOO set to?'). Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.",
       {
         resource: z.enum(['application', 'service']),
         action: z.enum(['list', 'create', 'update', 'delete']),
@@ -909,12 +909,25 @@ export class CoolifyMcpServer extends McpServer {
         env_uuid: z.string().optional(),
         is_buildtime: z.boolean().optional(),
         is_runtime: z.boolean().optional(),
+        reveal: z.boolean().optional(),
       },
-      async ({ resource, action, uuid, key, value, env_uuid, is_buildtime, is_runtime }) => {
+      async ({
+        resource,
+        action,
+        uuid,
+        key,
+        value,
+        env_uuid,
+        is_buildtime,
+        is_runtime,
+        reveal,
+      }) => {
         if (resource === 'application') {
           switch (action) {
             case 'list':
-              return wrap(() => this.client.listApplicationEnvVars(uuid, { summary: true }));
+              return wrap(() =>
+                this.client.listApplicationEnvVars(uuid, { summary: true, reveal }),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
@@ -945,7 +958,7 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(() => this.client.listServiceEnvVars(uuid));
+              return wrap(() => this.client.listServiceEnvVars(uuid, { reveal }));
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
## Summary

Closes #159.

`env_vars list` responses previously included plaintext `value` (and `real_value` on the full projection), exposing secrets to any MCP client / LLM that called the tool. Now masked with `'***'` by default; callers opt in with `reveal: true` on the list action when they explicitly need the value (e.g. "what is FOO set to right now?").

Per @daniel-rudaev's option 1 in #159 and @StuMason's scope notes (masking at the boundary, both `EnvVarSummary` and `EnvironmentVariable` shapes, opt-in reveal on list, metadata untouched).

## Changes

- Added `MASKED_VALUE` sentinel + `maskEnvVar()` / `maskEnvVarSummary()` helpers in `coolify-client.ts`. Applied at the boundary on the list endpoints — masking doesn't run inside the projection step, so both summary and full projections share one default policy.
- `listApplicationEnvVars(uuid, { summary?, reveal? })` and `listServiceEnvVars(uuid, { reveal? })` — `reveal` defaults `false`.
- `env_vars` MCP tool: added `reveal: z.boolean().optional()` to the schema and plumbed through to both `list` branches. Updated tool description.
- `bulkEnvUpdate` was **already safe** — returns `BatchOperationResult` with `{ uuid, name, error? }` only, never echoed env var values. No code change there, noted in CHANGELOG for completeness.
- `diagnoseApplication` calls `listApplicationEnvVars` without options, so its env-var aggregator now consumes masked data — but the diagnostic only projects `key` / `is_buildtime` / `is_runtime` (never `value`), so user-visible output is identical.
- Tests:
  - 5 new tests covering masked default + reveal=true paths for both list methods, on both summary and full projections, plus `real_value` masking.
  - 2 existing tests rewritten — they asserted the leaked plaintext `value`. Those assertions were the bug surface.

## Breaking (behavioural)

Callers that relied on `value` being present in `env_vars` list responses must now pass `reveal: true`. This is documented as a Security entry in CHANGELOG.

## Test plan

- [x] `npm test` — 297/297 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Client coverage: 98.79% lines, 86.74% branches
- [x] Both `reveal: true` and `reveal: false` paths exercised for codecov patch coverage