### PR TITLE
chore: release v2.10.0 — application build-config + health_check fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-05-14
+
+### Added
+
+- **Application build-config and `health_check_*` fields now wired through `create_*`** (#185 / #178, thanks @kashik0i) — eight build-config fields (`dockerfile_location`, `dockerfile_target_build`, `base_directory`, `publish_directory`, `install_command`, `build_command`, `start_command`, `watch_paths`) added to the `application` tool's zod schema; all twelve `health_check_*` fields plus the build-config fields now forwarded by `create_public`, `create_github`, `create_key`, and `create_dockerimage` handlers. Previously these were silently stripped, so e.g. `create_key` with `health_check_enabled: true, health_check_path: '/health'` produced an app with healthcheck off and default `/` path. Live-tested against Coolify v4 with GET round-trip verification of every field.
+
+### Fixed
+
+- **`dockerfile_target_build` accepted on `update`** (#185) — verified against Coolify's `ApplicationsController.php` allowlists that this field is UPDATE-only (present on the update allowlist at line 2497, absent from create allowlist at line 1014). Now correctly forwarded on the `update` action; intentionally not forwarded on any `create_*` action (Coolify would silently drop it).
+
+### Internal
+
+- **CLAUDE.md gotcha** (#185) — documented the CREATE vs UPDATE `$allowedFields` asymmetry in Coolify's `ApplicationsController.php`, with concrete examples for `dockerfile_target_build` and `create_dockerimage`. Captures the practical reality that Coolify's `openapi.yaml` is an incomplete projection of the real allowlists — always check the controller source before trusting the spec.
+
 ## [2.9.0] - 2026-05-11
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masonator/coolify-mcp",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@masonator/coolify-mcp",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "mcpName": "io.github.StuMason/coolify",
   "description": "MCP server for Coolify — 38 optimized tools for infrastructure management, diagnostics, and documentation search",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts v2.10.0 bundling #185 (closes #178). Minor bump for new schema surface area on the `application` tool — follows the v2.8.0 precedent for analogous application-field additions (#161 / #162).

### What's in it

- **Build-config wired through `create_*`**: `dockerfile_location`, `dockerfile_target_build`, `base_directory`, `publish_directory`, `install_command`, `build_command`, `start_command`, `watch_paths` — previously declared in types but silently stripped on every create. Now forwarded by `create_public`, `create_github`, `create_key`. Intentionally excluded from `create_dockerimage` (pre-built images, no build step) per Coolify's controller allowlist.
- **All 12 `health_check_*` fields wired through `create_*`**: forwarded by all four `create_*` actions including dockerimage.
- **`dockerfile_target_build` accepted on `update`**: verified UPDATE-only via Coolify's `ApplicationsController.php` allowlists (`update_by_uuid` line 2497 includes it, `create_application` line 1014 does not).
- **CLAUDE.md gotcha**: documented the CREATE vs UPDATE `\$allowedFields` asymmetry and the fact that Coolify's `openapi.yaml` is an incomplete projection of the real controller allowlists. Live-verified against `coollabsio/coolify` `main`.

### Verification

- 307 tests passing
- Codecov green
- Live-tested against Coolify v4 by @kashik0i on #185 (round-trip GET on every new field)

### Triggers npm publish

Merging this changes `package.json` on `main` → `publish.yml` runs → `@masonator/coolify-mcp@2.10.0` publishes to npm via trusted publishing.

## Test plan

- [x] All 307 tests pass
- [x] Prettier check clean on CHANGELOG / package.json / package-lock.json
- [ ] Confirm npm publish succeeds after merge