### PR TITLE
ci(docs): add Dockerfile.docs for the coolify-mcp.stumason.dev deploy

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,0 +1,28 @@
+# Build + serve the VitePress docs site (coolify-mcp.stumason.dev).
+# Multi-stage: node:22-alpine for the build, nginx:1.27-alpine for the serve.
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY site/package.json site/package-lock.json ./
+RUN npm ci
+COPY site/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=builder /app/.vitepress/dist /usr/share/nginx/html
+# VitePress generates cleanUrls — nginx needs a small rewrite to serve
+# `/foo` as `/foo.html` when no index.html exists at that path.
+RUN printf '%s\n' \
+  'server {' \
+  '  listen 80;' \
+  '  server_name _;' \
+  '  root /usr/share/nginx/html;' \
+  '  index index.html;' \
+  '  location / {' \
+  '    try_files $uri $uri.html $uri/ =404;' \
+  '  }' \
+  '  gzip on;' \
+  '  gzip_types text/css application/javascript application/json image/svg+xml;' \
+  '  gzip_min_length 256;' \
+  '}' > /etc/nginx/conf.d/default.conf
+EXPOSE 80


### PR DESCRIPTION
Multi-stage build for the VitePress docs site:

- **Builder**: node:22-alpine, copies /site, runs npm ci + npm run build
- **Runtime**: nginx:1.27-alpine, serves .vitepress/dist with a try_files rewrite for VitePress cleanUrls (so /foo serves /foo.html)
- gzip enabled for text/css/js/json/svg

Coolify is currently configured to build with nixpacks, which detects node and tries to npm start the container — which crashes because VitePress has no start script. This Dockerfile gives us full control: build then serve, no nixpacks magic.

After merge: I'll switch the Coolify app from build_pack=nixpacks to dockerfile, set dockerfile_location=/Dockerfile.docs, and redeploy. Then the site lands at https://coolify-mcp.stumason.dev.