### PR TITLE
fix(docs): preserve site/CHANGELOG layout in Dockerfile + disable lastUpdated

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,15 +1,23 @@
 # Build + serve the VitePress docs site (coolify-mcp.stumason.dev).
 # Multi-stage: node:22-alpine for the build, nginx:1.27-alpine for the serve.
+#
+# Preserves the repo layout (/app/site + /app/CHANGELOG.md) so the
+# `<!--@include: ../CHANGELOG.md-->` directive in site/changelog.md resolves.
 
 FROM node:22-alpine AS builder
-WORKDIR /app
+WORKDIR /app/site
 COPY site/package.json site/package-lock.json ./
 RUN npm ci
-COPY site/ ./
+
+WORKDIR /app
+COPY CHANGELOG.md ./CHANGELOG.md
+COPY site/ ./site/
+
+WORKDIR /app/site
 RUN npm run build
 
 FROM nginx:1.27-alpine
-COPY --from=builder /app/.vitepress/dist /usr/share/nginx/html
+COPY --from=builder /app/site/.vitepress/dist /usr/share/nginx/html
 # VitePress generates cleanUrls — nginx needs a small rewrite to serve
 # `/foo` as `/foo.html` when no index.html exists at that path.
 RUN printf '%s\n' \

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -7,7 +7,9 @@ export default withMermaid(
     description: 'MCP server for Coolify — 42 token-optimized tools for AI assistants',
 
     cleanUrls: true,
-    lastUpdated: true,
+    // lastUpdated needs git available at build time; disabled until we wire
+    // .git into the Dockerfile build stage (or move to a build that has it).
+    lastUpdated: false,
     ignoreDeadLinks: 'localhostLinks',
 
     head: [


### PR DESCRIPTION
First containerised deploy of the docs site hit two issues. Both fixed here:

**1. `[vitepress] spawn git ENOENT` on /app/changelog.md** — `lastUpdated: true` uses git for last-modified timestamps but the build stage has neither git nor .git. Disabled for now; will wire .git into the build later if we want the timestamps back.

**2. Include directive `../CHANGELOG.md` couldn't resolve** — the prior Dockerfile flattened /site onto /app, so site/changelog.md's `../CHANGELOG.md` pointed at /CHANGELOG.md which didn't exist. Fixed by preserving the repo layout: COPY site/ to /app/site/ and CHANGELOG.md to /app/CHANGELOG.md, build from /app/site.

Local `npm run build` clean after the changes. Once merged I'll redeploy on Coolify.