### PR TITLE
fix(docker): allow CHANGELOG.md through .dockerignore for docs build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ dist
 docs
 *.md
 !README.md
+!CHANGELOG.md
 .env*
 .DS_Store
 coverage


### PR DESCRIPTION
Tiny one-liner. The root .dockerignore had `*.md` with only `!README.md` allowlist, so CHANGELOG.md was filtered out before Dockerfile.docs could COPY it, breaking the docs build's `<!--@include: ../CHANGELOG.md-->` directive. Adding `!CHANGELOG.md` to the allowlist.