### PR TITLE
chore: scope root lint to MCP source + ignore Playwright artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,7 @@ coverage/
 *.tgz
 
 # Yarn Integrity file
-.yarn-integrity 
+.yarn-integrity
+
+# Playwright MCP runtime artefacts (screenshots, snapshots)
+.playwright-mcp/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,9 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/', 'node_modules/', 'coverage/'],
+    // site/ is the VitePress docs mini-project — has its own deps and
+    // doesn't share the root toolchain. Ignored to keep the root lint
+    // scoped to the MCP source.
+    ignores: ['dist/', 'node_modules/', 'coverage/', 'site/'],
   },
 );


### PR DESCRIPTION
Two repo-hygiene fixes surfaced during the post-docs-site audit:

- **eslint.config.js** — ignore `site/` (the VitePress mini-project). Without this, running `npm run lint` locally after `npm install` in /site crawls the 100s of MB of VitePress node_modules and explodes with thousands of meaningless errors. CI is unaffected (it never installs site deps), but local DX is bad.
- **.gitignore** — add `.playwright-mcp/` so Playwright MCP runtime screenshots don't end up tracked.

Both are local-only effects — `npm pack --dry-run` confirms only `dist/` ships to npm (no `site/`, no `Dockerfile.docs`, no docs leakage), and CI on main is green across all builds.