### PR TITLE
docs(readme): link to the new coolify-mcp.stumason.dev docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 > **The most comprehensive MCP server for Coolify** - 42 optimized tools, smart diagnostics, documentation search, and batch operations for managing your self-hosted PaaS through AI assistants.
 
+📖 **Docs**: [**coolify-mcp.stumason.dev**](https://coolify-mcp.stumason.dev) — install guide, quickstart, full tools reference, MCP primer, Coolify API gotchas, contributing guide, and the public v3 roadmap.
+
 A Model Context Protocol (MCP) server for [Coolify](https://coolify.io/), enabling AI assistants to manage and debug your Coolify instances through natural language.
 
 ## Features


### PR DESCRIPTION
Adds a prominent docs callout near the top of the README, right after the tagline:

> 📖 **Docs**: [**coolify-mcp.stumason.dev**](https://coolify-mcp.stumason.dev) — install guide, quickstart, full tools reference, MCP primer, Coolify API gotchas, contributing guide, and the public v3 roadmap.

Trivial one-liner. The README's feature table stays as the structured reference; the docs site is for everything else (concepts, contribution flow, v3 roadmap, etc).