### PR TITLE
docs: factual fixes surfaced by tech-writer review

### DIFF
--- a/site/contributing/adding-tools.md
+++ b/site/contributing/adding-tools.md
@@ -16,7 +16,7 @@ The order matters. Follow it.
 
 4. **Add the MCP tool** (or new action on an existing tool) to `src/lib/mcp-server.ts`. Prefer extending an existing tool with a new `action` enum value over adding a new top-level tool — see the consolidation pattern in [how-it-works](/concepts/how-it-works).
 5. **Add tests** — both client-level and method-existence (see [Testing](/contributing/testing)).
-6. **Update docs** — CHANGELOG entry under `[Unreleased]`, README if tool count changed.
+6. **Update docs** — CHANGELOG entry under `[Unreleased]`, README tool count if it changed, and the [Tools reference](/tools/) on this docs site if you've added a new tool or new action.
 
 ## Code-style rules
 

--- a/site/contributing/testing.md
+++ b/site/contributing/testing.md
@@ -82,6 +82,6 @@ npm run test:coverage       # coverage report
 npm run test:integration    # hit live Coolify (~30-60s)
 npm run lint                # eslint
 npm run format              # prettier
-npm run types               # tsc --noEmit
+npx tsc --noEmit            # type-check only (no emit)
 npm run build               # produces dist/
 ```

--- a/site/guide/quickstart.md
+++ b/site/guide/quickstart.md
@@ -44,7 +44,12 @@ The model uses `deploy` with the application UUID. Currently blocks until the de
 
 - All `create_*` / `update_*` / `delete_*` actions
 - `deploy`, `redeploy_project`, `restart_*`
-- `stop_all_apps` (the nuke button)
-- `bulk_env_update`, `bulk_env_delete`
+- `stop_all_apps` (the emergency-stop button)
+- `bulk_env_update`
 
-The v2.x tools don't yet declare `destructiveHint` / `readOnlyHint` annotations to drive client confirmation UX — that's a v3 add (see [v3 vision](/roadmap/v3-vision)).
+The v2.x tools don't yet declare `destructiveHint` / `readOnlyHint` annotations to drive client confirmation UX. That's a v3 add (see [v3 vision](/roadmap/v3-vision)).
+
+## What next?
+
+- [Tools reference](/tools/) — every one of the 42 tools, grouped by concern, marked read or destructive.
+- [How coolify-mcp works](/concepts/how-it-works) — the architecture, the file structure, the security model.

--- a/site/index.md
+++ b/site/index.md
@@ -25,7 +25,7 @@ features:
     details: One env var, you're running. Works in Claude Desktop, Claude Code, Cursor, and any other MCP-aware client.
   - icon: 🎯
     title: 42 consolidated tools
-    details: v2.0 cut tool count from 60+ to 38 by routing related ops through action parameters. LLM tool-list tokens dropped ~85% (43k → 6.6k).
+    details: v2.0 collapsed 60+ tools into a small set of action-driven tools. The count is at 42 today after new tool families landed in v2.11. LLM tool-list tokens dropped ~85% (43k → 6.6k).
   - icon: 🔒
     title: Secure by default
     details: env_vars list responses mask secrets. Opt-in reveal. Bulk-update doesn't echo values back. Token never leaves your machine.

--- a/site/roadmap/index.md
+++ b/site/roadmap/index.md
@@ -8,8 +8,8 @@ coolify-mcp v2.11.0 is firmly in MCP's "tools-only" era. 42 consolidated tools c
 
 Recent landings:
 
-- v2.11.0 — `system` tool consolidation + 4 new tool families (storages, scheduled_tasks, hetzner, system)
-- v2.10.0 — application build-config + health*check fields wired through `create*\*`
+- v2.11.0 — 3 new tool families (`storages`, `scheduled_tasks`, `hetzner`) plus the `system` consolidation of `health` / `list_resources` / `api_control`
+- v2.10.0 — application build-config and `health_check_*` fields wired through `create_*`
 - v2.9.0 — env_vars masking by default, defensive non-JSON parsing
 - v2.8.x — `--header` flag, application params, env_vars field rename
 


### PR DESCRIPTION
Six small corrections that align the docs with what the code actually does. Surfaced by an internal staff-tech-writer review of the site against the source.

- **tools/index.md**: add missing `list_deployments` row (registered at src/lib/mcp-server.ts:1128 as a top-level tool, separate from the consolidated `deployment` action tool)
- **guide/quickstart.md**: remove non-existent `bulk_env_delete` reference; drop "nuke button" metaphor; add a What next? footer
- **roadmap/index.md**: fix broken markdown rendering at v2.10.0 bullet (unescaped underscores in `health_check_*` and `create_*`); rewrite v2.11.0 bullet to stop double-counting `system` as both consolidation AND new tool family
- **index.md**: align hero "42 consolidated tools" with body text (was saying "v2.0 cut to 38" without explaining the climb to 42)
- **contributing/testing.md**: replace `npm run types` with the actual command `npx tsc --noEmit` (no `types` script exists in package.json)
- **contributing/adding-tools.md**: step 6 now also requires updating the docs site's Tools reference when new tools/actions ship

Next PRs (separate) will address: security deep-dive page, troubleshooting/FAQ page, EAL accessibility sweep.