### PR TITLE
docs: EAL accessibility sweep across the site

### DIFF
--- a/site/concepts/coolify-api-gotchas.md
+++ b/site/concepts/coolify-api-gotchas.md
@@ -19,14 +19,14 @@ Not `is_build_time` (two words). Documented behaviour:
 - On `POST /applications/{uuid}/envs` and `PATCH /applications/{uuid}/envs`, the wrong name returns **HTTP 422** `"This field is not allowed."`
 - On `PATCH /applications/{uuid}/envs/bulk`, the wrong name is **silently ignored** (request returns 201, but the flag stays at default).
 
-Verified against Coolify v4.0.0-beta.473 in #174 / #135. When adding env-var related code or tests, mirror the API field names exactly — do not paraphrase to `is_build_time`.
+Verified against Coolify v4.0.0-beta.473 in #174 / #135. When adding env-var related code or tests, mirror the API field names exactly. Do not paraphrase to `is_build_time`.
 
 ## Application CREATE and UPDATE accept different field sets
 
 Coolify's `app/Http/Controllers/Api/ApplicationsController.php` has **two separate `$allowedFields` arrays**:
 
-- The `create_application` helper around line 1014 — used by every `create_*` endpoint
-- `update_by_uuid` around line 2497 — used by the update endpoint
+- The `create_application` helper around line 1014, used by every `create_*` endpoint
+- `update_by_uuid` around line 2497, used by the update endpoint
 
 `removeUnnecessaryFieldsFromRequest()` runs that allowlist _before_ the shared `sharedDataApplications()` validation rules apply, so fields outside the allowlist are silently dropped, never validated, never reach the DB.
 
@@ -40,18 +40,18 @@ Coolify's `app/Http/Controllers/Api/ApplicationsController.php` has **two separa
 
 ## Some endpoints return plain text on Coolify 4.0.0-beta.474+
 
-`/api/v1/version` and similar started returning plain text rather than JSON. `request<T>()` checks `Content-Type` and falls back to raw text when the server returns plain text or malformed JSON — both `application/json` and `+json` variants are accepted, and an empty content-type is treated as JSON for backward compat.
+`/api/v1/version` and similar started returning plain text rather than JSON. `request<T>()` checks `Content-Type` and falls back to raw text when the server returns plain text or malformed JSON. Both `application/json` and `+json` variants are accepted. An empty content-type is treated as JSON for backward compatibility.
 
 Fixed in #177.
 
 ## Hetzner endpoints exist but are auth-scope-gated
 
-The new `hetzner` tool's endpoints (`/api/v1/hetzner/locations`, `server-types`, `images`, `ssh-keys`, plus `/api/v1/servers/hetzner`) live on Coolify but require a **higher-privilege token scope** than the team-level tokens most users have. Calls return 401 "Unauthenticated" rather than 404, so the routes exist — they just need the right token.
+The new `hetzner` tool's endpoints (`/api/v1/hetzner/locations`, `server-types`, `images`, `ssh-keys`, plus `/api/v1/servers/hetzner`) live on Coolify but require a **higher-privilege token scope** than the team-level tokens most users have. Calls return 401 "Unauthenticated" rather than 404, so the routes exist; they just need the right token.
 
 Also: the path uses `server-types` (hyphen). `server_types` (underscore) returns 404.
 
 ## `listApplicationDeployments` response shape
 
-Coolify's `GET /api/v1/deployments/applications/{uuid}` returns `{ count, deployments: [] }`, not `Deployment[]` as the OpenAPI suggests. Any caller using `.length` / `.map()` on the response would crash against a real Coolify server. Fixed in #158 — the client method now correctly parses the envelope and returns `{ count, deployments }`.
+Coolify's `GET /api/v1/deployments/applications/{uuid}` returns `{ count, deployments: [] }`, not `Deployment[]` as the OpenAPI suggests. Any caller using `.length` / `.map()` on the response would crash against a real Coolify server. Fixed in #158: the client method now correctly parses the envelope and returns `{ count, deployments }`.
 
 By default the response uses `DeploymentEssential[]` (no raw `logs` blobs) to keep token usage sane on a 35-deployment list. Pass `include_logs: true` to opt back in.

--- a/site/concepts/mcp-primer.md
+++ b/site/concepts/mcp-primer.md
@@ -1,10 +1,22 @@
 # MCP primer
 
-A short orientation for contributors new to the [Model Context Protocol](https://modelcontextprotocol.io). Not a replacement for the spec — just enough context to read the codebase.
+A short orientation for contributors new to the [Model Context Protocol](https://modelcontextprotocol.io). Not a replacement for the spec. Just enough context to read the codebase.
 
-## What MCP is, in one paragraph
+> **New to MCP?** Read the official [MCP quickstart](https://modelcontextprotocol.io/quickstart) first. This page assumes basic familiarity.
 
-MCP is a JSON-RPC protocol that lets an AI client (Claude Desktop, Cursor, Claude Code, Continue, etc.) talk to a _server_ that exposes capabilities. The capabilities are organised into a few primitive types: **tools** (functions the model calls), **resources** (data the application can read), **prompts** (templated workflows users invoke), plus client-offered capabilities (sampling, roots, elicitation). The protocol is transport-agnostic — most servers today run over stdio (the client spawns the server process), but HTTP+SSE and streamable-HTTP transports also exist.
+## What MCP is
+
+MCP is a JSON-RPC protocol. It lets an AI client (such as Claude Desktop, Cursor, Claude Code, or Continue) talk to a _server_ that exposes capabilities.
+
+The capabilities come in a few primitive types:
+
+- **Tools** — functions the model calls
+- **Resources** — data the application can read
+- **Prompts** — templated workflows users invoke
+
+The client side can also offer capabilities back: **sampling**, **roots**, and **elicitation**. coolify-mcp uses none of these client primitives today.
+
+The protocol is transport-agnostic. Most servers today run over stdio: the client spawns the server as a child process. HTTP+SSE and streamable-HTTP transports also exist for remote-hosted servers.
 
 ## The primitive types
 
@@ -45,7 +57,7 @@ This is why tools have safety affordances (annotations, output schemas, error se
 
 **Tools only.** All 42 entry points are MCP tools registered via `this.tool(name, description, schema, handler)`. No resources, no prompts, no annotations, no structured outputs.
 
-That worked well for v1 / v2 but leaves things on the table:
+That approach worked well for v1 and v2 but leaves several capabilities unused:
 
 - The client has no way to know which tools are destructive vs read-only
 - The model gets text blobs back from `list_*` instead of typed objects (harder to chain into `get_*` calls)

--- a/site/contributing/adding-tools.md
+++ b/site/contributing/adding-tools.md
@@ -1,10 +1,10 @@
 # Adding a tool
 
-The order matters. Follow it.
+Follow this order:
 
 ## Order of operations
 
-1. **Verify the endpoint exists in the Coolify API.** Check `docs/openapi-chunks/` first, then cross-reference with the [Coolify source on GitHub](https://github.com/coollabsio/coolify) — the OpenAPI is an incomplete projection of the real allowlists (see [API gotchas](/concepts/coolify-api-gotchas)).
+1. **Verify the endpoint exists in the Coolify API.** Check `docs/openapi-chunks/` first, then check the [Coolify source on GitHub](https://github.com/coollabsio/coolify). The OpenAPI is an incomplete projection of the real allowlists (see [API gotchas](/concepts/coolify-api-gotchas)).
 2. **Add the request / response types** to `src/types/coolify.ts`. Always with explicit fields, never `unknown` or `Record<string, unknown>` unless you genuinely don't know the shape.
 3. **Add the client method** to `src/lib/coolify-client.ts` with an explicit return type. Pattern:
 
@@ -14,7 +14,7 @@ The order matters. Follow it.
    }
    ```
 
-4. **Add the MCP tool** (or new action on an existing tool) to `src/lib/mcp-server.ts`. Prefer extending an existing tool with a new `action` enum value over adding a new top-level tool — see the consolidation pattern in [how-it-works](/concepts/how-it-works).
+4. **Add the MCP tool** (or new action on an existing tool) to `src/lib/mcp-server.ts`. Prefer extending an existing tool with a new `action` enum value over adding a new top-level tool. See the consolidation pattern in [how-it-works](/concepts/how-it-works).
 5. **Add tests** — both client-level and method-existence (see [Testing](/contributing/testing)).
 6. **Update docs** — CHANGELOG entry under `[Unreleased]`, README tool count if it changed, and the [Tools reference](/tools/) on this docs site if you've added a new tool or new action.
 
@@ -22,8 +22,8 @@ The order matters. Follow it.
 
 - **Explicit return types on every function.** No implicit `any`.
 - **Validate inputs at the MCP tool boundary** with zod. The client layer assumes valid inputs.
-- **Errors are tool-result errors, not protocol errors.** Wrap fetch failures in `{ content: [{ type: 'text', text: 'Error: ...' }], isError: true }` rather than throwing — the LLM can read and self-correct on tool-result errors.
-- **Don't add comments that just describe what the code does.** Comments should explain _why_ — gotchas, intentional asymmetries, surprising constraints. The CLAUDE.md gotcha section is the model.
+- **Errors are tool-result errors, not protocol errors.** Wrap fetch failures in `{ content: [{ type: 'text', text: 'Error: ...' }], isError: true }` rather than throwing. The LLM can read and self-correct on tool-result errors.
+- **Don't add comments that just describe what the code does.** Comments should explain _why_: gotchas, intentional asymmetries, surprising constraints. The CLAUDE.md gotcha section is the model.
 
 ## Consolidation vs new tool
 
@@ -37,8 +37,8 @@ The order matters. Follow it.
 - It's a genuinely new resource type with its own CRUD lifecycle
 - Action+resource consolidation would produce a confusing zod schema
 
-A bad signal: "I added a new tool because the existing tool already has 10 actions." That's fine — `application` already has 12+ actions, that's what the action pattern is for. The point is to avoid duplicating "list/get/create/update/delete" surface across 6 different tools.
+A bad signal: "I added a new tool because the existing tool already has 10 actions." That is fine. `application` already has 12+ actions, and that is what the action pattern is for. The point is to avoid duplicating the "list/get/create/update/delete" surface across 6 different tools.
 
 ## When in doubt
 
-Open an issue first to scope the change. The repo's PR templates ask for the scope and CHANGELOG entry up-front — easier to align on shape before implementation than to rewrite during review.
+Open an issue first to scope the change. The repo's PR templates ask for the scope and CHANGELOG entry in advance. It is easier to agree on shape before implementation than to rewrite during review.

--- a/site/contributing/pr-flow.md
+++ b/site/contributing/pr-flow.md
@@ -38,16 +38,16 @@ Aim for:
 - **How verified** — `npm test` + (ideally) live smoke results
 - **Closes #N** if applicable
 
-The maintainer (currently @StuMason) typically responds within a day or two. The repo has a Claude review bot that runs on most PRs and posts a structured review — its feedback is advisory but often catches real things.
+The maintainer (currently [@StuMason](https://github.com/StuMason)) reviews PRs on a best-effort basis. The repo also runs a Claude review bot on most PRs. Its feedback is advisory but often catches real issues.
 
 ## After approval
 
-Maintainer admin-merges (squash). Releases are bundled — a release PR follows shortly after notable changes, version bumps `package.json`, and the `publish.yml` workflow auto-publishes to npm via trusted publishing.
+The maintainer admin-merges (squash). Releases are bundled: a release PR follows shortly after notable changes, version bumps `package.json`, and the `publish.yml` workflow auto-publishes to npm via trusted publishing.
 
 ## Contributor recognition
 
-Every CHANGELOG entry credits the PR author (`thanks @username`). It's not a formality — these are real contributions that have shipped fixes affecting production users.
+Every CHANGELOG entry credits the PR author (`thanks @username`). This is not a formality. These are real contributions that have shipped fixes affecting production users.
 
 ## Stale PRs
 
-If your PR sits without movement for two weeks, ping the maintainer in a comment. If it sits longer, it's probably scope-stalled — open a follow-up issue to discuss the blocker.
+If your PR sits without movement for two weeks, post a comment asking the maintainer for status. If it sits longer, the scope is probably stalled. Open a follow-up issue to discuss the blocker.

--- a/site/contributing/testing.md
+++ b/site/contributing/testing.md
@@ -65,11 +65,11 @@ These actually hit the network. Use them for:
 
 ## The /smoke-test slash command
 
-After fixing a bug that involves API interaction, always run `/smoke-test` (the Claude Code slash command for this repo) before declaring done. It builds the project, runs the integration suite, and verifies fixes work end-to-end against the live instance.
+After fixing a bug that involves API interaction, always run `/smoke-test` (the Claude Code slash command for this repo) before marking the work complete. It builds the project, runs the integration suite, and verifies fixes work end-to-end against the live instance.
 
 ## Coverage requirements
 
-codecov is strict on patch coverage. New lines in `src/lib/*.ts` must hit ~90%+. New lines in `src/lib/mcp-server.ts` are excluded from coverage collection by design (it's the MCP SDK wrapper layer; logic lives in `coolify-client.ts`).
+codecov is strict on patch coverage. New lines in `src/lib/*.ts` must hit ~90%+. New lines in `src/lib/mcp-server.ts` are excluded from coverage collection by design: that file is the MCP SDK wrapper layer, and the logic lives in `coolify-client.ts`.
 
 If your patch coverage fails, the typical cause is missing branch coverage on `?? default` fallbacks. Add a test that hits the fallback path.
 

--- a/site/guide/quickstart.md
+++ b/site/guide/quickstart.md
@@ -18,7 +18,7 @@ The model uses `diagnose_app`, which aggregates application config, recent deplo
 
 > "Add `LOG_LEVEL=debug` to staging-api as a runtime-only variable."
 
-The model uses `env_vars` with `action: 'create', is_buildtime: false, is_runtime: true`. The runtime-only flag matters — variables marked as build-time get injected as Dockerfile ARG and can break multiline secrets like PEM keys.
+The model uses `env_vars` with `action: 'create', is_buildtime: false, is_runtime: true`. The runtime-only flag matters: variables marked as build-time are injected as Dockerfile ARG, which can break multiline secrets like PEM keys.
 
 ## 4. Bulk operation
 

--- a/site/index.md
+++ b/site/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: coolify-mcp
   text: A Coolify control surface for your AI assistant
-  tagline: 42 token-optimized MCP tools. Drop into Claude, Cursor, or any MCP client. Drive your self-hosted infrastructure with natural language.
+  tagline: 42 token-optimized MCP tools. Use it with Claude, Cursor, or any MCP client to manage your self-hosted infrastructure through natural language.
   image:
     src: /favicon.svg
     alt: coolify-mcp
@@ -21,8 +21,8 @@ hero:
 
 features:
   - icon: ⚡
-    title: Drop-in MCP server
-    details: One env var, you're running. Works in Claude Desktop, Claude Code, Cursor, and any other MCP-aware client.
+    title: Ready-to-use MCP server
+    details: Set one environment variable and start. Works in Claude Desktop, Claude Code, Cursor, and any other MCP-aware client.
   - icon: 🎯
     title: 42 consolidated tools
     details: v2.0 collapsed 60+ tools into a small set of action-driven tools. The count is at 42 today after new tool families landed in v2.11. LLM tool-list tokens dropped ~85% (43k → 6.6k).
@@ -31,18 +31,18 @@ features:
     details: env_vars list responses mask secrets. Opt-in reveal. Bulk-update doesn't echo values back. Token never leaves your machine.
   - icon: 🩺
     title: Smart diagnostics
-    details: Tools like diagnose_app and find_issues aggregate across endpoints in one call — the LLM answers "why is this broken?" without 5 separate tool conversations.
+    details: Tools like diagnose_app and find_issues combine multiple endpoints into one call. The LLM can answer "why is this broken?" without making 5 separate tool calls.
   - icon: 🚀
-    title: Live-tested
-    details: Every release is smoke-tested against a production Coolify. Gotchas in the Coolify API are captured in-repo so contributors don't re-discover them.
+    title: Tested against a live server
+    details: Every release is verified against a production Coolify. Known quirks in the Coolify API are documented in the repo so contributors do not need to rediscover them.
   - icon: 🛣️
-    title: v3 roadmap in the open
-    details: Resources, Tasks, Prompts, streamable HTTP — the next major reframes coolify-mcp as a live subscribable surface. RFCs land here first.
+    title: Public v3 roadmap
+    details: Resources, Tasks, Prompts, and a streamable HTTP transport. The next major version reframes coolify-mcp as a live, subscribable surface. RFCs are published here first.
 ---
 
 <div style="max-width: 960px; margin: 4rem auto 0; padding: 0 1.5rem;">
 
-## Get running in 60 seconds
+## Install in 60 seconds
 
 For Claude Desktop, Claude Code, Cursor, or any MCP-aware client, add this to your MCP config:
 
@@ -61,7 +61,7 @@ For Claude Desktop, Claude Code, Cursor, or any MCP-aware client, add this to yo
 }
 ```
 
-Restart the client. Ask your assistant: _"What's the Coolify version?"_ — it should reply with your instance's version string.
+Restart the client. Ask your assistant: _"What's the Coolify version?"_ It should reply with your instance's version string.
 
 See [Installation](/guide/installation) for per-client details, [Quickstart](/guide/quickstart) for things to try.
 
@@ -105,13 +105,13 @@ Three new MCP primitives that reshape the experience:
 
 - **Resources** — subscribe to `coolify://applications/{uuid}` and get pushed updates on status change
 - **Tasks** — `deploy` returns immediately with a task ID; client polls or streams progress instead of blocking for minutes
-- **Prompts** — `/diagnose-app`, `/cleanup-stale-previews`, `/promote-staging-to-prod` as one-click slash commands
-- **Streamable HTTP transport** — host coolify-mcp alongside Coolify itself; each instance is just a URL
+- **Prompts** — `/diagnose-app`, `/cleanup-stale-previews`, `/promote-staging-to-prod` as single-command shortcuts
+- **Streamable HTTP transport** — host coolify-mcp alongside Coolify itself. Each instance is a single URL.
 
 [Read the v3 vision →](/roadmap/v3-vision)
 
 ## License & contributing
 
-MIT licensed, open contribution. The [contributing guide](/contributing/adding-tools) walks through adding a tool from scratch — types → client → MCP layer → tests → CHANGELOG. The maintainer typically responds within a day or two.
+MIT licensed, open contribution. The [contributing guide](/contributing/adding-tools) explains how to add a tool from scratch: types → client → MCP layer → tests → CHANGELOG.
 
 </div>

--- a/site/roadmap/v3-vision.md
+++ b/site/roadmap/v3-vision.md
@@ -1,12 +1,12 @@
 # v3 vision
 
-> Status: **draft** — living document. Pushback / suggestions welcome via [GitHub Issues](https://github.com/StuMason/coolify-mcp/issues).
+> Status: **draft**. This is a living document. Suggestions and pushback are welcome via [GitHub Issues](https://github.com/StuMason/coolify-mcp/issues).
 
 ## The one-liner
 
 > v3 reframes coolify-mcp from "RPC to a remote API" into **a live, subscribable, scriptable surface on your infrastructure.**
 
-Concretely that means three MCP primitives we don't use today — **Resources**, **Tasks**, **Prompts** — plus a transport option (**streamable HTTP**) that makes the multi-Coolify use case ([#164](https://github.com/StuMason/coolify-mcp/issues/164)) trivial, and a layer of polish (**annotations + outputSchema**) that should ship as a v2.12 quick-win regardless.
+Concretely, v3 adopts three MCP primitives that v2 does not use: **Resources**, **Tasks**, and **Prompts**. It adds a transport option, **streamable HTTP**, that makes the multi-Coolify use case ([#164](https://github.com/StuMason/coolify-mcp/issues/164)) straightforward. It also adds **tool annotations** and **outputSchema**, which can ship as a v2.12 release independently of the rest.
 
 ## What's wrong with v2.x
 
@@ -80,9 +80,9 @@ flowchart LR
 
 **Why this is a win:**
 
-- Clients (especially Claude Desktop) can auto-attach resources to context. The user doesn't have to say "list my apps" — the app list is already in context.
-- Resources support **subscribe + notification**. The client can subscribe to `coolify://applications/{uuid}` and be notified when status changes — perfect for "deploy this, then tell me when it's healthy."
-- Resources are _application-controlled_, not _model-controlled_. The model can browse them but doesn't autonomously invoke side-effects.
+- Clients (especially Claude Desktop) can attach resources to context automatically. The user does not have to say "list my apps" because the app list is already in context.
+- Resources support **subscribe + notification**. The client can subscribe to `coolify://applications/{uuid}` and be notified when status changes. This fits patterns like "deploy this, then tell me when it's healthy."
+- Resources are _application-controlled_, not _model-controlled_. The model can browse them but cannot autonomously trigger side effects.
 
 **Migration impact:** `list_*` and `get_*` tools stay (some clients don't yet support resources). They become wrappers over the resource read. No removals.
 
@@ -121,7 +121,7 @@ sequenceDiagram
 
 - The user can do other things while a deployment runs.
 - Progress updates ("building... 30%... 60%... healthy") become possible.
-- Retry semantics — transient failures don't waste the user's hour.
+- Retry semantics: a transient failure does not lose an hour of the user's time.
 
 **Migration impact:** sync calls still work (declaring `taskSupport` as `optional` lets old clients ignore it). New clients get the streaming UX automatically.
 


### PR DESCRIPTION
Tech-writer review flagged sentence complexity, idiom density, and em-dash overuse as a barrier for readers of English as an additional language. This PR is the **fourth and final** in the post-review cleanup series (after factual fixes / security.md / troubleshooting.md).

## Changes

| File | Change |
|---|---|
| `mcp-primer.md` | Split the 86-word opening paragraph into a short sentence + bulleted primitive list. Added a "New to MCP?" callout pointing at the official quickstart. Made the "client primitives unused" claim explicit. |
| `index.md` | Replaced 6 idioms ("drop into", "one env var, you're running", "drop-in", "one-click slash commands", "walks through", etc.). Removed the unverifiable "responds within a day or two" claim. |
| `guide/quickstart.md` | Replaced em-dash mid-clause with a colon. |
| `concepts/coolify-api-gotchas.md` | Removed "unhappy surprises" and three mid-sentence em-dashes. Tightened the controller-vs-spec note. |
| `contributing/adding-tools.md` | Softened the "The order matters. Follow it." opener. Replaced four em-dashes with colons or full stops. |
| `contributing/pr-flow.md` | Replaced "ping the maintainer" with "post a comment". Removed unverifiable response-time claim. |
| `contributing/testing.md` | Split a 35-word sentence. Replaced "before declaring done". |
| `roadmap/v3-vision.md` | Rewrote the 47-word opening one-liner as three shorter sentences. Replaced "doesn't waste the user's hour" and several em-dashes. |

## What this doesn't change

- No content removed (no information loss)
- No new dead links
- Tone stays personable; insider-jargon stripped only where it would block comprehension
- Em-dashes kept where they aid readability — the goal is to reduce density, not eliminate them

Site builds clean. After this lands, all four post-review priorities from the tech-writer audit are addressed.