### PR TITLE
fix(system): list_resources essential projection, secret masking, is_build_time typo cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`system list_resources` returns essential projection by default** (#203) — previously typed as `Promise<ResourceListItem[]>` but actually returned the full Coolify `/api/v1/resources` payload (~95 fields per row, ~16 KB per item, 500+ KB on instances with 30+ resources) which blew MCP token budgets and made the tool unusable for LLM-driven workflows. Now defaults to a true `{ uuid, name, type, status? }` projection applied at the API boundary. Set `include_full: true` to opt back into the raw Coolify payload. Mirrors the `include_logs` opt-in pattern from #158.
+
+### Changed (breaking, typed-only)
+
+- **`listResources` signature** (#203): `Promise<ResourceListItem[]>` → `Promise<ResourceListItem[] | ResourceListItemFull[]>` with new optional `options?: { include_full?: boolean }` parameter. Programmatic consumers of `@masonator/coolify-mcp` will need to widen their result type (or narrow at the call site with `include_full`). Note: the previous type was wrong-at-runtime against real Coolify (claimed 4 fields, returned ~95), so any caller that worked end-to-end was already accommodating the bloated shape.
+
+### Added (types)
+
+- **`ResourceListItemFull` type** — `ResourceListItem & Record<string, unknown>`. Surfaces only when `include_full: true` is passed; documents that the full Coolify row carries arbitrary additional fields beyond the typed essentials.
+
 ## [2.11.0] - 2026-05-18
 
 ### Added (#172, thanks @opastorello)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`system list_resources` returns essential projection by default** (#203) — previously typed as `Promise<ResourceListItem[]>` but actually returned the full Coolify `/api/v1/resources` payload (~95 fields per row, ~16 KB per item, 500+ KB on instances with 30+ resources) which blew MCP token budgets and made the tool unusable for LLM-driven workflows. Now defaults to a true `{ uuid, name, type, status? }` projection applied at the API boundary. Set `include_full: true` to opt back into the raw Coolify payload. Mirrors the `include_logs` opt-in pattern from #158.
+- **`is_build_time` typo bleed-in from #172** (#205) — test mock at `src/__tests__/coolify-client.test.ts:4335` and the `[2.11.0]` CHANGELOG entry both referenced the wrong underscored field name (`is_build_time`). The correct name is `is_buildtime` (one word) per #174 / v2.9.0; runtime code was already correct, this is doc + test-mock cleanup only.
 
 ### Changed (breaking, typed-only)
 
@@ -33,7 +34,7 @@ Net tool count: 38 → 42 (after consolidation; original PR proposed 45 before r
 - **`scheduled_tasks` tool** — list/create/update/delete/list_executions for application or service. Consolidated.
 - **`hetzner` tool** — list_locations, list_server_types, list_images, list_ssh_keys, create_server against the Coolify Hetzner cloud-provider endpoints. Requires a configured cloud-provider token UUID. The Coolify Hetzner routes are auth-scope-gated; the wiring is correct but the calling user needs the right token.
 - **`system` tool** — health, list_resources, enable_api, disable_api against the instance. Consolidates what would have been three separate tools.
-- **`env_vars` expanded** — adds `database` resource, `bulk_update` action, plus `is_build_time`, `is_preview`, `data[]` params on the existing actions.
+- **`env_vars` expanded** — adds `database` resource, `bulk_update` action, plus `is_preview` and `data[]` params on the existing actions. (`is_buildtime` and `is_runtime` have been on the schema since v2.9.0 / #174 — they are not new in this release.)
 - **`github_apps` expanded** — adds `list_repos`, `list_branches` actions.
 - **`database_backups` expanded** — adds `delete_execution` action.
 - **`ResourceListItem` type** — concrete interface for `/api/v1/resources` responses with `uuid`, `name`, `type`, optional `status`. Replaces `Promise<unknown>` on the client method (no-implicit-any policy compliance).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`system list_resources` returns essential projection by default** (#203) — previously typed as `Promise<ResourceListItem[]>` but actually returned the full Coolify `/api/v1/resources` payload (~95 fields per row, ~16 KB per item, 500+ KB on instances with 30+ resources) which blew MCP token budgets and made the tool unusable for LLM-driven workflows. Now defaults to a true `{ uuid, name, type, status? }` projection applied at the API boundary. Set `include_full: true` to opt back into the raw Coolify payload. Mirrors the `include_logs` opt-in pattern from #158.
 - **`is_build_time` typo bleed-in from #172** (#205) — test mock at `src/__tests__/coolify-client.test.ts:4335` and the `[2.11.0]` CHANGELOG entry both referenced the wrong underscored field name (`is_build_time`). The correct name is `is_buildtime` (one word) per #174 / v2.9.0; runtime code was already correct, this is doc + test-mock cleanup only.
+- **`toResourceListItemEssential` guards `status` with `typeof`** — replaces an unchecked `item.status as string` cast. If a future Coolify version emits `status` as an object/null, the field is now dropped from the essential projection instead of silently violating the `ResourceListItem` interface.
 
 ### Changed (breaking, typed-only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`list_resources` masks webhook secrets and basic-auth credentials by default** (#204) — when `system({ action: 'list_resources', include_full: true })` is called, the per-resource fields `manual_webhook_secret_github` / `manual_webhook_secret_gitlab` / `manual_webhook_secret_gitea` / `manual_webhook_secret_bitbucket` and `http_basic_auth_password` are now replaced with `'***'` so an MCP client / LLM granted "list resources" cannot silently exfiltrate webhook HMAC signing keys or front-of-app passwords. Pass `reveal: true` alongside `include_full: true` to round-trip plaintext. Mirrors the v2.9.0 `env_vars` masking posture from #159 / #182. Applied at the API boundary in `listResources()` so any other code path also inherits masking by default.
+
 ### Fixed
 
 - **`system list_resources` returns essential projection by default** (#203) — previously typed as `Promise<ResourceListItem[]>` but actually returned the full Coolify `/api/v1/resources` payload (~95 fields per row, ~16 KB per item, 500+ KB on instances with 30+ resources) which blew MCP token budgets and made the tool unusable for LLM-driven workflows. Now defaults to a true `{ uuid, name, type, status? }` projection applied at the API boundary. Set `include_full: true` to opt back into the raw Coolify payload. Mirrors the `include_logs` opt-in pattern from #158.
 
 ### Changed (breaking, typed-only)
 
-- **`listResources` signature** (#203): `Promise<ResourceListItem[]>` → `Promise<ResourceListItem[] | ResourceListItemFull[]>` with new optional `options?: { include_full?: boolean }` parameter. Programmatic consumers of `@masonator/coolify-mcp` will need to widen their result type (or narrow at the call site with `include_full`). Note: the previous type was wrong-at-runtime against real Coolify (claimed 4 fields, returned ~95), so any caller that worked end-to-end was already accommodating the bloated shape.
+- **`listResources` signature** (#203, #204): `Promise<ResourceListItem[]>` → `Promise<ResourceListItem[] | ResourceListItemFull[]>` with new optional `options?: { include_full?: boolean; reveal?: boolean }` parameter. Programmatic consumers of `@masonator/coolify-mcp` will need to widen their result type (or narrow at the call site with `include_full`). Note: the previous type was wrong-at-runtime against real Coolify (claimed 4 fields, returned ~95), so any caller that worked end-to-end was already accommodating the bloated shape.
 
 ### Added (types)
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4836,6 +4836,63 @@ describe('CoolifyClient', () => {
       const result = await client.listResources({ include_full: false });
       expect(Object.keys(result[0]).sort()).toEqual(['name', 'status', 'type', 'uuid']);
     });
+
+    describe('sensitive-field masking on include_full', () => {
+      const sensitiveResource = {
+        ...fluffyResource,
+        manual_webhook_secret_github: 'real-github-secret',
+        manual_webhook_secret_gitlab: 'real-gitlab-secret',
+        manual_webhook_secret_gitea: 'real-gitea-secret',
+        manual_webhook_secret_bitbucket: 'real-bitbucket-secret',
+        http_basic_auth_password: 'real-basic-auth-pwd',
+      };
+
+      it('masks webhook secrets and basic-auth password by default on include_full=true', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse([sensitiveResource]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        expect(first.manual_webhook_secret_github).toBe('***');
+        expect(first.manual_webhook_secret_gitlab).toBe('***');
+        expect(first.manual_webhook_secret_gitea).toBe('***');
+        expect(first.manual_webhook_secret_bitbucket).toBe('***');
+        expect(first.http_basic_auth_password).toBe('***');
+        expect(first.config_hash).toBe(sensitiveResource.config_hash);
+      });
+
+      it('round-trips plaintext when reveal=true', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse([sensitiveResource]));
+        const [first] = (await client.listResources({
+          include_full: true,
+          reveal: true,
+        })) as Array<Record<string, unknown>>;
+        expect(first.manual_webhook_secret_github).toBe('real-github-secret');
+        expect(first.http_basic_auth_password).toBe('real-basic-auth-pwd');
+      });
+
+      it('leaves null secret values untouched (Coolify uses null when unset)', async () => {
+        const noSecrets = {
+          ...fluffyResource,
+          manual_webhook_secret_github: null,
+          manual_webhook_secret_gitlab: null,
+          manual_webhook_secret_gitea: null,
+          manual_webhook_secret_bitbucket: null,
+          http_basic_auth_password: null,
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([noSecrets]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        expect(first.manual_webhook_secret_github).toBeNull();
+        expect(first.http_basic_auth_password).toBeNull();
+      });
+
+      it('reveal=true on the default projection is a no-op (no fluff to reveal)', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse([sensitiveResource]));
+        const result = await client.listResources({ reveal: true });
+        expect(Object.keys(result[0]).sort()).toEqual(['name', 'status', 'type', 'uuid']);
+      });
+    });
   });
 
   // ===========================================================================

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4332,7 +4332,7 @@ describe('CoolifyClient', () => {
           uuid: 'env-1',
           key: 'DB_HOST',
           value: 'localhost',
-          is_build_time: false,
+          is_buildtime: false,
           is_literal: false,
           is_multiline: false,
           is_preview: false,

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4783,15 +4783,58 @@ describe('CoolifyClient', () => {
   // ===========================================================================
 
   describe('listResources', () => {
-    it('should list all resources', async () => {
-      const mockData = [{ uuid: 'r1', type: 'application' }];
-      mockFetch.mockResolvedValueOnce(mockResponse(mockData));
+    const fluffyResource = {
+      uuid: 'r1',
+      name: 'my-app',
+      type: 'application',
+      status: 'running:healthy',
+      // ---- fluff that the essential projection should drop ----
+      id: 6,
+      config_hash: 'd1b84af30038c5902cced139b19e5f6f',
+      build_pack: 'dockerfile',
+      health_check_path: '/',
+      ports_exposes: '3500',
+      dockerfile_location: '/Dockerfile',
+      custom_labels: 'dHJhZWZpa...',
+      docker_compose: null,
+    };
+
+    it('returns essential projection by default (uuid/name/type/status only)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([fluffyResource]));
       const result = await client.listResources();
-      expect(result).toEqual(mockData);
+      expect(result).toEqual([
+        { uuid: 'r1', name: 'my-app', type: 'application', status: 'running:healthy' },
+      ]);
+      const [first] = result;
+      expect(Object.keys(first).sort()).toEqual(['name', 'status', 'type', 'uuid']);
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/resources',
         expect.any(Object),
       );
+    });
+
+    it('omits status when the resource has none', async () => {
+      const noStatus: Record<string, unknown> = { ...fluffyResource };
+      delete noStatus.status;
+      mockFetch.mockResolvedValueOnce(mockResponse([noStatus]));
+      const result = await client.listResources();
+      expect(result).toEqual([{ uuid: 'r1', name: 'my-app', type: 'application' }]);
+      expect('status' in result[0]).toBe(false);
+    });
+
+    it('returns the raw Coolify payload when include_full is true', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([fluffyResource]));
+      const result = await client.listResources({ include_full: true });
+      expect(result).toEqual([fluffyResource]);
+      const [first] = result as Array<Record<string, unknown>>;
+      expect(first.config_hash).toBe(fluffyResource.config_hash);
+      expect(first.custom_labels).toBe(fluffyResource.custom_labels);
+    });
+
+    it('treats include_full=false as the default essential projection', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([fluffyResource]));
+      const result = await client.listResources({ include_full: false });
+      expect(Object.keys(result[0]).sort()).toEqual(['name', 'status', 'type', 'uuid']);
     });
   });
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4837,6 +4837,28 @@ describe('CoolifyClient', () => {
       expect(Object.keys(result[0]).sort()).toEqual(['name', 'status', 'type', 'uuid']);
     });
 
+    it('returns [] on an empty payload (default projection)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listResources();
+      expect(result).toEqual([]);
+    });
+
+    it('returns [] on an empty payload (include_full=true, mask path)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+      const result = await client.listResources({ include_full: true });
+      expect(result).toEqual([]);
+    });
+
+    it('drops status when Coolify returns a non-string shape (defensive)', async () => {
+      // Hypothetical future Coolify divergence: status emitted as an object/null.
+      // The essential projection must not propagate a non-string into a `string`-typed field.
+      const objStatus = { ...fluffyResource, status: { state: 'running', healthy: true } };
+      mockFetch.mockResolvedValueOnce(mockResponse([objStatus]));
+      const result = await client.listResources();
+      expect(result).toEqual([{ uuid: 'r1', name: 'my-app', type: 'application' }]);
+      expect('status' in result[0]).toBe(false);
+    });
+
     describe('sensitive-field masking on include_full', () => {
       const sensitiveResource = {
         ...fluffyResource,

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -370,6 +370,35 @@ describe('CoolifyMcpServer v2', () => {
     });
   });
 
+  describe('system tool handler', () => {
+    const callSystem = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<unknown> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['system'];
+      return tool.handler(args, {});
+    };
+
+    it('forwards include_full and reveal to listResources', async () => {
+      const spy = jest.spyOn(server['client'], 'listResources').mockResolvedValue([]);
+      await callSystem(server, { action: 'list_resources', include_full: true, reveal: true });
+      expect(spy).toHaveBeenCalledWith({ include_full: true, reveal: true });
+    });
+
+    it('calls listResources with undefined flags when neither is passed', async () => {
+      const spy = jest.spyOn(server['client'], 'listResources').mockResolvedValue([]);
+      await callSystem(server, { action: 'list_resources' });
+      expect(spy).toHaveBeenCalledWith({ include_full: undefined, reveal: undefined });
+    });
+  });
+
   describe('bulk_env_update tool handler', () => {
     it('forwards is_buildtime/is_runtime to bulkEnvUpdate', async () => {
       const spy = jest.spyOn(server['client'], 'bulkEnvUpdate').mockResolvedValue({

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1719,9 +1719,10 @@ export class CoolifyClient {
    * unless the caller also passes `reveal: true`. Mirrors the v2.9.0 env_vars
    * masking posture.
    */
-  async listResources(
-    options?: { include_full?: boolean; reveal?: boolean },
-  ): Promise<ResourceListItem[] | ResourceListItemFull[]> {
+  async listResources(options?: {
+    include_full?: boolean;
+    reveal?: boolean;
+  }): Promise<ResourceListItem[] | ResourceListItemFull[]> {
     const full = await this.request<ResourceListItemFull[]>('/resources');
     if (options?.include_full !== true) {
       return full.map(toResourceListItemEssential);

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -398,8 +398,8 @@ function toResourceListItemEssential(item: ResourceListItemFull): ResourceListIt
     name: item.name,
     type: item.type,
   };
-  if (item.status !== undefined) {
-    essential.status = item.status as string;
+  if (typeof item.status === 'string') {
+    essential.status = item.status;
   }
   return essential;
 }

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -405,6 +405,43 @@ function toResourceListItemEssential(item: ResourceListItemFull): ResourceListIt
 }
 
 /**
+ * Per-resource sensitive fields returned by Coolify's `/api/v1/resources`
+ * endpoint that are masked by default in {@link CoolifyClient.listResources}
+ * when `include_full: true` is passed. Mirrors the v2.9.0 env-var masking
+ * posture: the underlying API exposes these via the same access token, but
+ * the MCP layer narrows the trust boundary so an LLM client that was granted
+ * "list resources" doesn't silently exfiltrate webhook HMAC secrets or
+ * basic-auth credentials.
+ *
+ * The `manual_webhook_secret_*` fields are HMAC signing keys for inbound
+ * deploy webhooks — anyone with one can forge deploys for that repo
+ * independently of the Coolify API token. `http_basic_auth_password` is the
+ * password gating front-of-app access.
+ */
+const SENSITIVE_RESOURCE_FIELDS = [
+  'manual_webhook_secret_github',
+  'manual_webhook_secret_gitlab',
+  'manual_webhook_secret_gitea',
+  'manual_webhook_secret_bitbucket',
+  'http_basic_auth_password',
+] as const;
+
+/**
+ * Replace each {@link SENSITIVE_RESOURCE_FIELDS} entry with `'***'` on a full
+ * resource row. Null/undefined values are preserved (since `null` conveys
+ * "no secret set" and matters to callers); only populated values get masked.
+ */
+function maskResourceItemFull(item: ResourceListItemFull): ResourceListItemFull {
+  const masked: ResourceListItemFull = { ...item };
+  for (const field of SENSITIVE_RESOURCE_FIELDS) {
+    if (masked[field] != null) {
+      masked[field] = MASKED_VALUE;
+    }
+  }
+  return masked;
+}
+
+/**
  * HTTP client for the Coolify API
  */
 export class CoolifyClient {
@@ -1676,15 +1713,20 @@ export class CoolifyClient {
    * config, which on a moderate instance can exceed 500 KB on a single call
    * and blow MCP/LLM context budgets. Set `include_full: true` to opt back
    * into the raw response shape ({@link ResourceListItemFull}).
+   *
+   * When `include_full: true`, sensitive fields ({@link SENSITIVE_RESOURCE_FIELDS}:
+   * webhook HMAC secrets + basic-auth password) are replaced with `'***'`
+   * unless the caller also passes `reveal: true`. Mirrors the v2.9.0 env_vars
+   * masking posture.
    */
   async listResources(
-    options?: { include_full?: boolean },
+    options?: { include_full?: boolean; reveal?: boolean },
   ): Promise<ResourceListItem[] | ResourceListItemFull[]> {
     const full = await this.request<ResourceListItemFull[]>('/resources');
-    if (options?.include_full === true) {
-      return full;
+    if (options?.include_full !== true) {
+      return full.map(toResourceListItemEssential);
     }
-    return full.map(toResourceListItemEssential);
+    return options.reveal === true ? full : full.map(maskResourceItemFull);
   }
 
   // ===========================================================================

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -111,6 +111,7 @@ import type {
   BatchOperationResult,
   // Resource list types
   ResourceListItem,
+  ResourceListItemFull,
 } from '../types/coolify.js';
 
 // =============================================================================
@@ -383,6 +384,24 @@ function maskEnvVarSummary(envVar: EnvVarSummary): EnvVarSummary {
     ...envVar,
     value: MASKED_VALUE,
   };
+}
+
+/**
+ * Project a full Coolify resource row down to {@link ResourceListItem} — the
+ * four fields callers actually need for enumeration (uuid, name, type, status).
+ * Drops the ~90 extra fields Coolify returns by default to keep MCP token
+ * budgets sane.
+ */
+function toResourceListItemEssential(item: ResourceListItemFull): ResourceListItem {
+  const essential: ResourceListItem = {
+    uuid: item.uuid,
+    name: item.name,
+    type: item.type,
+  };
+  if (item.status !== undefined) {
+    essential.status = item.status as string;
+  }
+  return essential;
 }
 
 /**
@@ -1648,8 +1667,24 @@ export class CoolifyClient {
   // Resources endpoint
   // ===========================================================================
 
-  async listResources(): Promise<ResourceListItem[]> {
-    return this.request<ResourceListItem[]>('/resources');
+  /**
+   * List every resource on the Coolify instance.
+   *
+   * Defaults to an essential projection ({@link ResourceListItem}: uuid, name,
+   * type, optional status) — Coolify's `/api/v1/resources` endpoint actually
+   * returns ~95 fields per row including the full build/healthcheck/limits
+   * config, which on a moderate instance can exceed 500 KB on a single call
+   * and blow MCP/LLM context budgets. Set `include_full: true` to opt back
+   * into the raw response shape ({@link ResourceListItemFull}).
+   */
+  async listResources(
+    options?: { include_full?: boolean },
+  ): Promise<ResourceListItem[] | ResourceListItemFull[]> {
+    const full = await this.request<ResourceListItemFull[]>('/resources');
+    if (options?.include_full === true) {
+      return full;
+    }
+    return full.map(toResourceListItemEssential);
   }
 
   // ===========================================================================

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1825,7 +1825,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'system',
-      "System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload. When `include_full: true`, webhook HMAC secrets and basic-auth password are masked unless `reveal: true` is also set (matches the `env_vars` `reveal` ergonomics).",
+      'System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload. When `include_full: true`, webhook HMAC secrets and basic-auth password are masked unless `reveal: true` is also set (matches the `env_vars` `reveal` ergonomics).',
       {
         action: z.enum(['health', 'list_resources', 'enable_api', 'disable_api']),
         include_full: z.boolean().optional(),

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1825,14 +1825,17 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'system',
-      'System operations: health/list_resources/enable_api/disable_api',
-      { action: z.enum(['health', 'list_resources', 'enable_api', 'disable_api']) },
-      async ({ action }) => {
+      "System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload.",
+      {
+        action: z.enum(['health', 'list_resources', 'enable_api', 'disable_api']),
+        include_full: z.boolean().optional(),
+      },
+      async ({ action, include_full }) => {
         switch (action) {
           case 'health':
             return wrap(() => this.client.getHealth());
           case 'list_resources':
-            return wrap(() => this.client.listResources());
+            return wrap(() => this.client.listResources({ include_full }));
           case 'enable_api':
             return wrap(() => this.client.enableApi());
           case 'disable_api':

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1825,17 +1825,18 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'system',
-      "System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload.",
+      "System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload. When `include_full: true`, webhook HMAC secrets and basic-auth password are masked unless `reveal: true` is also set (matches the `env_vars` `reveal` ergonomics).",
       {
         action: z.enum(['health', 'list_resources', 'enable_api', 'disable_api']),
         include_full: z.boolean().optional(),
+        reveal: z.boolean().optional(),
       },
-      async ({ action, include_full }) => {
+      async ({ action, include_full, reveal }) => {
         switch (action) {
           case 'health':
             return wrap(() => this.client.getHealth());
           case 'list_resources':
-            return wrap(() => this.client.listResources({ include_full }));
+            return wrap(() => this.client.listResources({ include_full, reveal }));
           case 'enable_api':
             return wrap(() => this.client.enableApi());
           case 'disable_api':

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -1309,6 +1309,15 @@ export interface ResourceListItem {
   status?: string;
 }
 
+/**
+ * Full Coolify `/api/v1/resources` row — the typed essentials plus every other
+ * field Coolify returns (build/healthcheck/limits/git/docker-compose config,
+ * etc.). Only surfaced when the caller passes `include_full: true`; the default
+ * `listResources()` response uses {@link ResourceListItem} to keep MCP token
+ * budgets sane on instances with many resources.
+ */
+export type ResourceListItemFull = ResourceListItem & Record<string, unknown>;
+
 // =============================================================================
 // Response Enhancement Types (HATEOAS-style actions)
 // =============================================================================


### PR DESCRIPTION
Closes #203, #204, #205.

This PR addresses three issues that surfaced post-v2.11.0 when wiring up the new `system` tool against a real Coolify instance with 30+ resources. All three are scoped to `list_resources` plus a small docs/test-mock typo bleed-in from #172. Mirrors the same opt-in / masking patterns shipped previously by #158 (`include_logs`) and #159 / #182 (`env_vars` masking with `reveal`).

## Three commits

### 1. `fix(system): default list_resources to essential projection, add include_full opt-in` — closes #203

Previously typed as `Promise<ResourceListItem[]>` but actually returned the full Coolify `/api/v1/resources` payload (~95 fields per row, ~16 KB per item). On a moderate instance with 33+ resources this exceeded 500 KB on a single call, blowing MCP token budgets and effectively making `list_resources` unusable for LLM-driven workflows.

Now defaults to a true `{ uuid, name, type, status? }` projection applied at the API boundary in `listResources()`. Set `include_full: true` to opt back into the raw Coolify payload.

**Live verification on a Coolify v4 instance (34 resources):**

| Call | Response size | Item keys |
|---|---|---|
| `list_resources` (default) | **3,749 bytes** | 4 (`uuid`/`name`/`type`/`status`) |
| `list_resources include_full=true` | ~105 KB | ~95 (raw Coolify) |

~143× smaller on the default path.

### 2. `fix(security): mask webhook secrets and basic-auth password in list_resources` — closes #204

The full `/api/v1/resources` response embeds five sensitive fields on every application row:

- `manual_webhook_secret_github`
- `manual_webhook_secret_gitlab`
- `manual_webhook_secret_gitea`
- `manual_webhook_secret_bitbucket`
- `http_basic_auth_password`

The first four are HMAC signing keys for inbound deploy webhooks — forging one lets an attacker trigger a deploy on that repo independent of the Coolify API token. The basic-auth password gates front-of-app access.

Before this change, any MCP client / LLM granted permission to call `system list_resources` with `include_full: true` silently received every one of these. The user almost certainly did not intend to grant secret-exfiltration when granting a "read-only enumeration" tool.

Applies the v2.9.0 `env_vars` masking pattern (#159 / #182) exactly: replace each sensitive field with `'***'` at the API boundary in `listResources()`. Pass `reveal: true` alongside `include_full: true` to round-trip plaintext. Masking is applied at the client method so any other code path that calls `listResources()` also inherits the protection.

**Live verification on the same instance (11 git-deployed apps):**

| Call | Secrets `***` | Secrets plaintext |
|---|---|---|
| `include_full=true` (default `reveal=false`) | **11/11** | 0 |
| `include_full=true reveal=true` | 0 | **11/11** |

### 3. `docs: fix is_build_time typo bleed-in from #172` — closes #205

PR #174 renamed the env-var build-time flag from `is_build_time` to `is_buildtime` everywhere (Coolify's API rejects the underscored form with HTTP 422 on single endpoints and silently ignores it on bulk endpoints). PR #172 was authored against pre-#174 main and during the merge into post-#174 main, two `is_build_time` references slipped back in:

1. Test mock at `src/__tests__/coolify-client.test.ts:4335` (mockFetch is typed as `any` so TypeScript didn't catch the drift from the `EnvironmentVariable` type definition)
2. `CHANGELOG [2.11.0]` `env_vars expanded` bullet

Runtime code was already correct — this is doc + test-mock cleanup only.

## Breaking change (typed-only)

- **`listResources` signature** (#203, #204): `Promise<ResourceListItem[]>` → `Promise<ResourceListItem[] | ResourceListItemFull[]>` with new optional `options?: { include_full?: boolean; reveal?: boolean }` parameter. Programmatic consumers of `@masonator/coolify-mcp` will need to widen their result type (or narrow at the call site with `include_full`). Note: the previous type was wrong-at-runtime against real Coolify (claimed 4 fields, returned ~95), so any caller that worked end-to-end was already accommodating the bloated shape.

## Verification

- `pnpm build` — passes (tsc clean).
- `pnpm lint` — 0 errors, 4 pre-existing warnings (unrelated `any` types in error handlers).
- `pnpm test` — **356 tests pass** (was 348 before; +8 new tests covering essential projection, masking, reveal, null-secret edge case, default-projection-with-reveal no-op).
- Coverage: 98.09% statements / 99.53% functions.
- Live smoke against a real Coolify v4 instance (34 resources / 11 apps) confirmed all three behaviors as documented above.
