### PR TITLE
chore: release v2.12.0 — list_resources essential projection + webhook secret masking (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-05-30
+
 ### Security
 
 - **`list_resources` masks webhook secrets and basic-auth credentials by default** (#204) — when `system({ action: 'list_resources', include_full: true })` is called, the per-resource fields `manual_webhook_secret_github` / `manual_webhook_secret_gitlab` / `manual_webhook_secret_gitea` / `manual_webhook_secret_bitbucket` and `http_basic_auth_password` are now replaced with `'***'` so an MCP client / LLM granted "list resources" cannot silently exfiltrate webhook HMAC signing keys or front-of-app passwords. Pass `reveal: true` alongside `include_full: true` to round-trip plaintext. Mirrors the v2.9.0 `env_vars` masking posture from #159 / #182. Applied at the API boundary in `listResources()` so any other code path also inherits masking by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masonator/coolify-mcp",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@masonator/coolify-mcp",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "mcpName": "io.github.StuMason/coolify",
   "description": "MCP server for Coolify — 42 optimized tools for infrastructure management, diagnostics, and documentation search",
   "type": "module",


### PR DESCRIPTION
## Release v2.12.0

Bumps version 2.11.0 → 2.12.0 and finalizes the CHANGELOG for the v2.12.0 release.

Tagged **minor** (not patch) per the in-PR review on #206: the typed signature change is "repairing a lie" (the prior `Promise<ResourceListItem[]>` was wrong-at-runtime), but the runtime payload shape shrinks ~143× by default. The `include_full: true` escape hatch keeps it sub-major.

## What's in v2.12.0

### Security

- **`list_resources` masks webhook secrets and basic-auth credentials by default** (#204) — `manual_webhook_secret_{github,gitlab,gitea,bitbucket}` and `http_basic_auth_password` are replaced with `'***'` on the `include_full: true` path. Pass `reveal: true` to round-trip plaintext. Mirrors v2.9.0 `env_vars` masking.

### Fixed

- **`system list_resources` essential projection by default** (#203) — `{ uuid, name, type, status? }` instead of the full ~95-field Coolify payload. Set `include_full: true` to opt into the raw response.
- **`is_build_time` typo bleed-in from #172** (#205) — test mock + CHANGELOG cleanup.
- **`toResourceListItemEssential` guards `status` with `typeof`** — drops the unchecked `as string` cast; defensive against future Coolify shape changes.

### Changed (breaking, typed-only)

- **`listResources` signature** — `Promise<ResourceListItem[]>` → `Promise<ResourceListItem[] | ResourceListItemFull[]>` with new optional `options?: { include_full?: boolean; reveal?: boolean }` param. The previous type was wrong-at-runtime, so any caller that worked end-to-end was already accommodating the bloated shape.

### Added (types)

- **`ResourceListItemFull` type** — `ResourceListItem & Record<string, unknown>`. Forces consumers to narrow before reading non-essential fields.

All landed via #206 (thanks @kashik0i).

## Test plan

- [x] `npm test` — 361 pass, 98.09% / 99.53% coverage
- [x] `npm run lint` — 0 errors, 4 pre-existing warnings (unchanged)
- [x] `npm run format` — clean
- [x] VERSION constant test passes (mcp-server.ts reads from package.json — confirmed 2.12.0 propagates)
- [ ] Once merged: publish workflow auto-fires on package.json change, publishes `@masonator/coolify-mcp@2.12.0` to npm, tags `v2.12.0`, creates GitHub release with the CHANGELOG section as notes.

## Follow-up tracking

- #209 — audit `list_resources include_full` for other sensitive nested surfaces (env_vars[], db creds, etc.) — out of scope for this release.