### PR TITLE
Add pull_latest parameter to restart action for services

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -2425,6 +2425,30 @@ describe('CoolifyClient', () => {
         expect.objectContaining({ method: 'GET' }),
       );
     });
+
+    it('should restart a service with pull_latest', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Restarted' }));
+
+      const result = await client.restartService('test-uuid', true);
+
+      expect(result).toEqual({ message: 'Restarted' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/test-uuid/restart?latest=true',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('should restart a service without pull_latest by default', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Restarted' }));
+
+      const result = await client.restartService('test-uuid', false);
+
+      expect(result).toEqual({ message: 'Restarted' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/test-uuid/restart',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
   });
 
   // =========================================================================

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1106,8 +1106,9 @@ export class CoolifyClient {
     });
   }
 
-  async restartService(uuid: string): Promise<MessageResponse> {
-    return this.request<MessageResponse>(`/services/${uuid}/restart`, {
+  async restartService(uuid: string, pullLatest = false): Promise<MessageResponse> {
+    const qs = pullLatest ? '?latest=true' : '';
+    return this.request<MessageResponse>(`/services/${uuid}/restart${qs}`, {
       method: 'GET',
     });
   }

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -936,8 +936,9 @@ export class CoolifyMcpServer extends McpServer {
         resource: z.enum(['application', 'database', 'service']),
         action: z.enum(['start', 'stop', 'restart']),
         uuid: z.string(),
+        pull_latest: z.boolean().optional().describe('Pull latest images before restarting (services only)'),
       },
-      async ({ resource, action, uuid }) => {
+      async ({ resource, action, uuid, pull_latest }) => {
         const methods: Record<string, Record<string, (u: string) => Promise<unknown>>> = {
           application: {
             start: (u) => this.client.startApplication(u),
@@ -952,7 +953,7 @@ export class CoolifyMcpServer extends McpServer {
           service: {
             start: (u) => this.client.startService(u),
             stop: (u) => this.client.stopService(u),
-            restart: (u) => this.client.restartService(u),
+            restart: (u) => this.client.restartService(u, pull_latest),
           },
         };
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -936,7 +936,10 @@ export class CoolifyMcpServer extends McpServer {
         resource: z.enum(['application', 'database', 'service']),
         action: z.enum(['start', 'stop', 'restart']),
         uuid: z.string(),
-        pull_latest: z.boolean().optional().describe('Pull latest images before restarting (services only)'),
+        pull_latest: z
+          .boolean()
+          .optional()
+          .describe('Pull latest images before restarting (services only)'),
       },
       async ({ resource, action, uuid, pull_latest }) => {
         const methods: Record<string, Record<string, (u: string) => Promise<unknown>>> = {


### PR DESCRIPTION
The Coolify API supports `?latest=true` on the service restart endpoint, which pulls fresh Docker images before restarting. This is the API equivalent of the "Pull Latest Images & Restart" button in the Coolify UI.

Add an optional `pull_latest` boolean parameter to the `control` tool. When `resource=service`, `action=restart`, and `pull_latest=true`, appends `?latest=true` to the request URL. No behavior change for other resource types or when omitted.

## Summary

- Add optional `pull_latest` boolean to `control` tool schema (services only)
- `restartService()` appends `?latest=true` query string when set
- No behavior change for applications, databases, or when `pull_latest` is omitted/false

## Changes

- `src/lib/coolify-client.ts` — `restartService(uuid, pullLatest)` accepts optional second param
- `src/lib/mcp-server.ts` — `control` tool schema gains `pull_latest: z.boolean().optional()`, passed through for service restarts
- `src/__tests__/coolify-client.test.ts` — Two new tests: `pull_latest=true` appends `?latest=true`, `pull_latest=false` omits it

## Test plan

- [x] Tests added/updated
- [x] Manually tested locally

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated if needed