### PR TITLE
feat(site): Work with me page

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -39,6 +39,7 @@ export default withMermaid(
         { text: 'Concepts', link: '/concepts/mcp-primer', activeMatch: '/concepts/' },
         { text: 'Contributing', link: '/contributing/adding-tools', activeMatch: '/contributing/' },
         { text: 'Roadmap', link: '/roadmap/', activeMatch: '/roadmap/' },
+        { text: 'Work with me', link: '/hire', activeMatch: '/hire' },
         {
           text: 'v2.11.0',
           items: [
@@ -109,7 +110,8 @@ export default withMermaid(
       },
 
       footer: {
-        message: 'MIT licensed. Built in the open.',
+        message:
+          'MIT licensed. Built in the open. <a href="/hire">Need this on your own product? Work with me →</a>',
         copyright:
           'By <a href="https://stumason.dev">Stu Mason</a> and <a href="https://github.com/StuMason/coolify-mcp/graphs/contributors">contributors</a>.',
       },

--- a/site/hire.md
+++ b/site/hire.md
@@ -1,0 +1,27 @@
+---
+description: Hire Stu Mason — the developer behind coolify-mcp. MCP servers for your product, AI & LLM integration, Laravel builds and rescues.
+---
+
+# Work with me
+
+I'm Stu Mason — I built coolify-mcp. Solutions architect, 15+ years, based in Kent, UK.
+
+This server is what my work looks like in the open: token budgets measured and published, secrets masked by default, every release tested against a live Coolify, API quirks documented so nobody rediscovers them. If you want that standard on your own product, that's the day job.
+
+## What I do
+
+- **MCP servers for your product** — give Claude, Cursor and every other MCP client a first-class surface for your API, like this one. The MCP ecosystem rewards whoever shows up early and does it properly.
+- **AI & LLM integration** — agents, pipelines and tooling that survive contact with production, not demos.
+- **Laravel & full-stack builds** — MVPs, prototype rescues, and embedded work inside your team's board and standups.
+
+## Receipts
+
+- This repo: 400+ stars, ~12k npm installs a month.
+- [stumason.dev](https://stumason.dev) — my activity feed is public. Real PRs, summarised daily, nothing curated after the fact.
+- [Reviews](https://stumason.dev/reviews) — 5★ from clients and the people I've worked alongside.
+
+## Start here
+
+- [Book a call](https://calendly.com/stumason/explore) — 30 minutes, no pitch deck.
+- [stumason.dev/services](https://stumason.dev/services) — the full menu.
+- Or email [hey@stumason.dev](mailto:hey@stumason.dev) and tell me what's broken.

--- a/site/index.md
+++ b/site/index.md
@@ -114,4 +114,8 @@ Three new MCP primitives that reshape the experience:
 
 MIT licensed, open contribution. The [contributing guide](/contributing/adding-tools) explains how to add a tool from scratch: types → client → MCP layer → tests → CHANGELOG.
 
+## Who builds this
+
+[Stu Mason](https://stumason.dev) — solutions architect, 15+ years, Kent, UK. coolify-mcp is the public face of how I work: measured token budgets, secrets masked by default, tested against live infrastructure. If you want an MCP server for your own product — or AI integration that survives production — [work with me](/hire).
+
 </div>


### PR DESCRIPTION
The docs site is the project's biggest traffic surface (~12k npm installs/month) and had no path to hiring the author.

- `/hire`: what I do (MCP servers for your product, AI integration, Laravel), receipts (this repo's numbers, the live feed at stumason.dev, reviews), and three ways to start
- Nav: 'Work with me' entry
- Footer: 'Need this on your own product? Work with me →'
- Home page: short 'Who builds this' section

Docs-only change, site builds clean.