### PR TITLE
docs: cross-link laravel-coolify in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 📖 **Docs**: [**coolify-mcp.stumason.dev**](https://coolify-mcp.stumason.dev) — install guide, quickstart, full tools reference, MCP primer, Coolify API gotchas, contributing guide, and the public v3 roadmap.
 
+> 💡 **Building a Laravel app?** Check out [**laravel-coolify**](https://github.com/StuMason/laravel-coolify) — deploy Laravel to Coolify with a Horizon-style dashboard, Artisan commands, and auto-generated Dockerfiles.
+
 A Model Context Protocol (MCP) server for [Coolify](https://coolify.io/), enabling AI assistants to manage and debug your Coolify instances through natural language.
 
 ## Features


### PR DESCRIPTION
Adds a one-line callout near the top of the README pointing readers to the sibling package **laravel-coolify**, so someone landing here discovers the Laravel deploy package too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)