### PR TITLE
fix: accept destination_uuid on database create (#217)

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -628,6 +628,64 @@ describe('CoolifyMcpServer v2', () => {
       expect(updateData).not.toHaveProperty('uuid');
     });
   });
+
+  describe('database tool handler', () => {
+    // Regression for #217 — the database tool's create action didn't expose
+    // destination_uuid, so Coolify rejected creates on servers with more than
+    // one destination ("Server has multiple destinations. Please provide a
+    // destination_uuid.").
+
+    const callDatabase = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<unknown> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['database'];
+      return tool.handler(args, {});
+    };
+
+    it('forwards destination_uuid to createPostgresql when provided', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'createPostgresql')
+        .mockResolvedValue({ uuid: 'db-1' });
+
+      await callDatabase(server, {
+        action: 'create',
+        type: 'postgresql',
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+        destination_uuid: 'dest-uuid',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination_uuid: 'dest-uuid',
+        }),
+      );
+    });
+
+    it('omits destination_uuid from createPostgresql when not provided', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'createPostgresql')
+        .mockResolvedValue({ uuid: 'db-2' });
+
+      await callDatabase(server, {
+        action: 'create',
+        type: 'postgresql',
+        project_uuid: 'proj-uuid',
+        server_uuid: 'server-uuid',
+      });
+
+      const forwarded = spy.mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+      expect(forwarded.destination_uuid).toBeUndefined();
+    });
+  });
 });
 
 describe('truncateLogs', () => {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -798,6 +798,10 @@ export class CoolifyMcpServer extends McpServer {
         server_uuid: z.string().optional(),
         project_uuid: z.string().optional(),
         environment_name: z.string().optional(),
+        destination_uuid: z
+          .string()
+          .optional()
+          .describe('Destination UUID. Required if server has multiple destinations.'),
         name: z.string().optional(),
         description: z.string().optional(),
         image: z.string().optional(),


### PR DESCRIPTION
## Summary

The `database` tool's `create` action didn't expose `destination_uuid` in its
zod input schema, so Coolify rejects database creates on any server with
more than one destination configured:

> Server has multiple destinations. Please provide a destination_uuid.

The `application` tool already handles this correctly by exposing
`destination_uuid` on its create schema. This PR mirrors that pattern for
`database`.

### What was already fine

- `CreateDatabaseBaseRequest` in `src/types/coolify.ts` already had an
  optional `destination_uuid` field, inherited by all the per-engine create
  request types (`CreatePostgresqlRequest`, `CreateMysqlRequest`, etc.).
- The client methods (`createPostgresql`, `createMysql`, `createMariadb`,
  `createMongodb`, `createRedis`, `createKeydb`, `createClickhouse`,
  `createDragonfly`) all just `JSON.stringify` the full request body, so they
  already forward `destination_uuid` if present.
- `docs/coolify-openapi.yaml` documents `destination_uuid` on every
  `/databases/{type}` create endpoint ("UUID of the destination if the
  server has multiple destinations") — the spec is accurate here, unlike the
  staleness noted in #236.

### The actual bug

Only the MCP tool schema in `src/lib/mcp-server.ts` was missing the field,
so zod stripped it out of the tool call before it ever reached the client.

### Fix

Added `destination_uuid: z.string().optional()` (with a description
matching the OpenAPI wording) to the `database` tool's schema. Since the
handler builds the request body via `const { action, type, uuid,
delete_volumes, ...dbData } = args` and forwards `dbData` straight to
whichever `dbMethods[type]` client call is selected, this single schema
change covers all 8 create variants (postgresql, mysql, mariadb, mongodb,
redis, keydb, clickhouse, dragonfly) — no handler changes needed.

## Test plan

- [x] Added `database tool handler` describe block in
      `src/__tests__/mcp-server.test.ts` following the existing
      `application tool handler` pattern: asserts `destination_uuid` is
      forwarded to `createPostgresql` when provided, and omitted when not.
- [x] `npm test` — 365 passed
- [x] `npm run lint` — 0 errors (2 pre-existing `no-explicit-any` warnings,
      unrelated to this change)
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — clean

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)