### PR TITLE
feat: diagnose_app cross-checks latest deployment status (#239)

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -3459,6 +3459,58 @@ describe('CoolifyClient', () => {
         expect(result.health.issues).toContain('2 failed deployment(s) in last 5');
       });
 
+      it('should flag stale code when app is running but the latest deployment failed', async () => {
+        const staleDeployments = [
+          { ...mockDeployments[0], uuid: 'deploy-latest', status: 'failed' },
+          { ...mockDeployments[1], status: 'finished' },
+        ];
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApp)) // status: running:healthy
+          .mockResolvedValueOnce(mockResponse(mockLogs))
+          .mockResolvedValueOnce(mockResponse(mockEnvVars))
+          .mockResolvedValueOnce(
+            mockResponse({ count: staleDeployments.length, deployments: staleDeployments }),
+          );
+
+        const result = await client.diagnoseApplication(testAppUuid);
+
+        expect(result.health.status).toBe('unhealthy');
+        expect(result.health.issues).toContain(
+          'Running container predates the last (failed) deployment (deploy-latest) — the app is serving stale code. Use the deployment tool (action: get, uuid: deploy-latest, lines) to see why it failed.',
+        );
+      });
+
+      it('should not flag stale code when the latest deployment succeeded', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApp))
+          .mockResolvedValueOnce(mockResponse(mockLogs))
+          .mockResolvedValueOnce(mockResponse(mockEnvVars))
+          .mockResolvedValueOnce(
+            mockResponse({ count: mockDeployments.length, deployments: mockDeployments }),
+          );
+
+        const result = await client.diagnoseApplication(testAppUuid);
+
+        expect(result.health.status).toBe('healthy');
+        expect(result.health.issues.some((issue) => issue.includes('stale code'))).toBe(false);
+      });
+
+      it('should skip the deployment-freshness check without breaking diagnosis when deployments are unavailable', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApp))
+          .mockResolvedValueOnce(mockResponse(mockLogs))
+          .mockResolvedValueOnce(mockResponse(mockEnvVars))
+          .mockRejectedValueOnce(new Error('Deployments unavailable'));
+
+        const result = await client.diagnoseApplication(testAppUuid);
+
+        expect(result.application).not.toBeNull();
+        expect(result.health.status).toBe('healthy');
+        expect(result.recent_deployments).toEqual([]);
+        expect(result.errors).toContain('deployments: Deployments unavailable');
+        expect(result.health.issues.some((issue) => issue.includes('stale code'))).toBe(false);
+      });
+
       it('should handle partial failures gracefully', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse(mockApp))

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1970,6 +1970,23 @@ export class CoolifyClient {
       }
     }
 
+    // Cross-check: the container can be running:healthy while the latest
+    // deployment failed/was cancelled — old code still serving, new code
+    // never arrived (#239). Skip silently if we have no app or no deployments.
+    if (app && deployments && deployments.length > 0) {
+      const latestDeployment = deployments[0];
+      const appIsRunning = (app.status || '').includes('running');
+      if (
+        appIsRunning &&
+        (latestDeployment.status === 'failed' || latestDeployment.status === 'cancelled')
+      ) {
+        issues.push(
+          `Running container predates the last (${latestDeployment.status}) deployment (${latestDeployment.uuid}) — the app is serving stale code. Use the deployment tool (action: get, uuid: ${latestDeployment.uuid}, lines) to see why it ${latestDeployment.status}.`,
+        );
+        healthStatus = 'unhealthy';
+      }
+    }
+
     return {
       application: app
         ? {


### PR DESCRIPTION
## Summary
- `diagnoseApplication` now cross-checks the running app state against its latest deployment. If the app is `running` but the most recent deployment `failed` or was `cancelled`, it adds an explicit finding: the running container predates the last (failed/cancelled) deployment and is serving stale code — including the deployment's uuid and a next-action hint to fetch its logs via the `deployment` tool (`action: get`, `lines`).
- Reuses the deployments already fetched for the diagnostic (no extra API call). If that call fails or returns no deployments, the check is skipped silently — consistent with how the rest of `diagnoseApplication` degrades on partial failures.
- If the latest deployment succeeded or is in progress, no note is added — matches the existing convention of staying silent on healthy state rather than adding "all good" noise.

Closes #239

## Test plan
- [x] Added `should flag stale code when app is running but the latest deployment failed`
- [x] Added `should not flag stale code when the latest deployment succeeded`
- [x] Added `should skip the deployment-freshness check without breaking diagnosis when deployments are unavailable`
- [x] `npm test` — 366 passed
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in changed lines)
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)