### PR TITLE
fix: project deployment get through essential projection when logs requested (#232)

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -2615,14 +2615,37 @@ describe('CoolifyClient', () => {
       );
     });
 
-    it('should get a deployment with logs when includeLogs is true', async () => {
-      const deploymentWithLogs = { ...mockDeployment, logs: 'Build started...' };
+    it('should get a deployment with logs when includeLogs is true, still projected through essential', async () => {
+      const deploymentWithLogs = {
+        ...mockDeployment,
+        logs: 'Build started...',
+        // Simulate raw upstream fields that must never leak through.
+        application: { docker_compose: 'raw compose', manual_webhook_secret_github: 'whsec' },
+        destination: { server: { settings: { sentinel_token: 'sentinel-secret' } } },
+      };
       mockFetch.mockResolvedValueOnce(mockResponse(deploymentWithLogs));
 
       const result = await client.getDeployment('dep-uuid', { includeLogs: true });
 
-      // With includeLogs: true, returns full Deployment with logs
-      expect(result).toEqual(deploymentWithLogs);
+      // With includeLogs: true, logs are attached to the essential projection —
+      // raw upstream fields (application/server graph, secrets, id) never leak.
+      expect(result).toEqual({
+        uuid: 'dep-uuid',
+        deployment_uuid: 'dep-123',
+        application_uuid: undefined,
+        application_name: 'test-app',
+        server_name: undefined,
+        status: 'finished',
+        commit: undefined,
+        force_rebuild: false,
+        is_webhook: false,
+        is_api: true,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        logs_available: true,
+        logs_info: 'Logs available (16 chars). Use lines param to retrieve.',
+        logs: 'Build started...',
+      });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/deployments/dep-uuid',
         expect.any(Object),
@@ -2668,13 +2691,24 @@ describe('CoolifyClient', () => {
       );
     });
 
-    it('should return full deployments when includeLogs is true', async () => {
-      const withLogs = { ...mockDeployment, logs: 'build log stream' };
+    it('should attach logs to the essential projection when includeLogs is true (never the raw object)', async () => {
+      const withLogs = {
+        ...mockDeployment,
+        logs: 'build log stream',
+        application: { docker_compose: 'raw compose' },
+        destination: { server: { settings: { sentinel_token: 'sentinel-secret' } } },
+      };
       mockFetch.mockResolvedValueOnce(mockResponse({ count: 1, deployments: [withLogs] }));
 
       const result = await client.listApplicationDeployments('app-uuid', { includeLogs: true });
 
-      expect(result).toEqual({ count: 1, deployments: [withLogs] });
+      expect(result.count).toBe(1);
+      expect(result.deployments).toHaveLength(1);
+      const [first] = result.deployments;
+      expect(first.logs).toBe('build log stream');
+      expect(first).not.toHaveProperty('application');
+      expect(first).not.toHaveProperty('destination');
+      expect(first).not.toHaveProperty('id');
     });
 
     it('should tolerate a malformed envelope (missing deployments array)', async () => {

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -6,7 +6,7 @@
  * These tests verify MCP server instantiation and structure.
  */
 import { createRequire } from 'module';
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import {
   CoolifyMcpServer,
   VERSION,
@@ -684,6 +684,142 @@ describe('CoolifyMcpServer v2', () => {
 
       const forwarded = spy.mock.calls[0]?.[0] as unknown as Record<string, unknown>;
       expect(forwarded.destination_uuid).toBeUndefined();
+    });
+  });
+
+  describe('deployment tool handler (#232 essential projection)', () => {
+    // Regression for #232: `deployment {action: get, lines: N}` used to call
+    // getDeployment(uuid, { includeLogs: true }) and spread the RAW upstream
+    // payload into the response — leaking the destination server's
+    // logdrain_custom_config bearer token, sentinel_token, webhook secrets,
+    // and the full docker_compose/application graph. It must now always go
+    // through toDeploymentEssential(), with only the (string) logs attached.
+
+    const callDeployment = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<{ content: Array<{ text: string }> }> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['deployment'];
+      return tool.handler(args, {}) as Promise<{ content: Array<{ text: string }> }>;
+    };
+
+    // Mock the raw HTTP layer (not the client) so the test exercises the real
+    // CoolifyClient projection logic, not just the mcp-server spread.
+    const mockFetch = jest.fn<typeof fetch>();
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+      global.fetch = mockFetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      mockFetch.mockReset();
+    });
+
+    function mockJsonResponse(data: unknown): Response {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        text: async () => JSON.stringify(data),
+      } as Response;
+    }
+
+    // A raw upstream deployment payload shaped like real Coolify responses:
+    // the full application graph plus the destination server object,
+    // including the secrets called out in #232.
+    function rawDeploymentWithSecrets(logsEntryCount: number): Record<string, unknown> {
+      const logs = JSON.stringify(
+        Array.from({ length: logsEntryCount }, (_, i) => ({
+          output: `log line ${i}`,
+          timestamp: `2026-07-02T00:00:0${i}Z`,
+          hidden: false,
+        })),
+      );
+      return {
+        id: 1,
+        uuid: 'dep-uuid',
+        deployment_uuid: 'dep-123',
+        application_uuid: 'app-uuid',
+        application_name: 'test-app',
+        server_name: 'test-server',
+        status: 'finished',
+        commit: 'abc123',
+        force_rebuild: false,
+        is_webhook: false,
+        is_api: true,
+        restart_only: false,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        logs,
+        // Raw upstream fields that must never leak through the projection:
+        application: {
+          uuid: 'app-uuid',
+          docker_compose: 'x'.repeat(5000),
+          docker_compose_raw: 'x'.repeat(5000),
+          custom_labels: 'a'.repeat(2000),
+          manual_webhook_secret_github: 'ghsecret',
+          manual_webhook_secret_gitlab: 'glsecret',
+        },
+        destination: {
+          server: {
+            uuid: 'server-uuid',
+            ip: '1.2.3.4',
+            settings: {
+              logdrain_custom_config: 'Bearer live-logdrain-token-abc123',
+              sentinel_token: 'live-sentinel-token-xyz789',
+            },
+            proxy: { config: 'y'.repeat(3000) },
+          },
+        },
+      };
+    }
+
+    it('returns essential fields + logs only, no leaked secrets or nested graphs', async () => {
+      mockFetch.mockResolvedValueOnce(mockJsonResponse(rawDeploymentWithSecrets(5)));
+
+      const result = await callDeployment(server, { action: 'get', uuid: 'dep-uuid', lines: 5 });
+      const text = result.content[0].text;
+
+      expect(text).not.toContain('logdrain');
+      expect(text).not.toContain('sentinel_token');
+      expect(text).not.toContain('manual_webhook_secret');
+      expect(text).not.toContain('docker_compose');
+      expect(text).not.toMatch(/"application":\s*{/);
+      expect(text).not.toMatch(/"server":\s*{/);
+      expect(text).not.toMatch(/"destination":\s*{/);
+
+      const parsed = JSON.parse(text) as { data: Record<string, unknown> };
+      expect(parsed.data).toMatchObject({
+        uuid: 'dep-uuid',
+        application_uuid: 'app-uuid',
+        application_name: 'test-app',
+        server_name: 'test-server',
+        status: 'finished',
+      });
+      expect(typeof parsed.data.logs).toBe('string');
+      expect(parsed.data).not.toHaveProperty('application');
+      expect(parsed.data).not.toHaveProperty('destination');
+      expect(parsed.data).not.toHaveProperty('id');
+    });
+
+    it('keeps the response under 20KB even with a bloated upstream payload', async () => {
+      mockFetch.mockResolvedValueOnce(mockJsonResponse(rawDeploymentWithSecrets(5)));
+
+      const result = await callDeployment(server, { action: 'get', uuid: 'dep-uuid', lines: 5 });
+      const text = result.content[0].text;
+
+      expect(text.length).toBeLessThan(20_000);
     });
   });
 });

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1170,9 +1170,15 @@ export class CoolifyClient {
   async getDeployment(
     uuid: string,
     options?: { includeLogs?: boolean },
-  ): Promise<Deployment | DeploymentEssential> {
+  ): Promise<DeploymentEssential> {
     const deployment = await this.request<Deployment>(`/deployments/${uuid}`);
-    return options?.includeLogs ? deployment : toDeploymentEssential(deployment);
+    const essential = toDeploymentEssential(deployment);
+    // Attach the raw log string (never the raw upstream object, which also embeds
+    // the full application/server graph and secrets) onto the essential projection.
+    if (options?.includeLogs && deployment.logs) {
+      essential.logs = deployment.logs;
+    }
+    return essential;
   }
 
   async deployByTagOrUuid(tagOrUuid: string, force: boolean = false): Promise<MessageResponse> {
@@ -1193,19 +1199,27 @@ export class CoolifyClient {
    * By default returns a DeploymentEssential summary (no `logs` field) because
    * each deployment's log blob can be 30–100KB, and a typical list has 20–35
    * deployments — exceeding MCP response token limits. Pass `includeLogs: true`
-   * to get raw Deployment objects with full build logs.
+   * to also attach the raw log string to each essential projection (never the
+   * raw upstream deployment object, which also embeds the full application/server
+   * graph and secrets).
    */
   async listApplicationDeployments(
     appUuid: string,
     options?: { includeLogs?: boolean },
-  ): Promise<{ count: number; deployments: Deployment[] | DeploymentEssential[] }> {
+  ): Promise<{ count: number; deployments: DeploymentEssential[] }> {
     const envelope = await this.request<{ count: number; deployments: Deployment[] }>(
       `/deployments/applications/${appUuid}`,
     );
     const deployments = Array.isArray(envelope?.deployments) ? envelope.deployments : [];
     return {
       count: typeof envelope?.count === 'number' ? envelope.count : deployments.length,
-      deployments: options?.includeLogs ? deployments : deployments.map(toDeploymentEssential),
+      deployments: deployments.map((dep) => {
+        const essential = toDeploymentEssential(dep);
+        if (options?.includeLogs && dep.logs) {
+          essential.logs = dep.logs;
+        }
+        return essential;
+      }),
     };
   }
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -22,7 +22,6 @@ import type {
   BuildPack,
   ResponseAction,
   ResponsePagination,
-  Deployment,
 } from '../types/coolify.js';
 import { DocsSearchEngine } from './docs-search.js';
 
@@ -1176,9 +1175,9 @@ export class CoolifyMcpServer extends McpServer {
               const ll = lines;
               return wrapWithActions(
                 async () => {
-                  const deployment = (await this.client.getDeployment(uuid, {
+                  const deployment = await this.client.getDeployment(uuid, {
                     includeLogs: true,
-                  })) as Deployment;
+                  });
                   if (deployment.logs) {
                     const result = truncateLogs(deployment.logs, ll, max_chars ?? 50000, p);
                     deployment.logs = result.logs;

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -1342,4 +1342,5 @@ export interface DeploymentEssential {
   updated_at: string;
   logs_available?: boolean; // true if logs exist but were excluded
   logs_info?: string;
+  logs?: string; // populated only when the caller explicitly requested logs (never raw upstream fields)
 }


### PR DESCRIPTION
## Problem

`deployment {action: get, uuid, lines: N}` bypassed the `toDeploymentEssential()` projection: the handler called `getDeployment(uuid, { includeLogs: true })`, which returned the **raw upstream Coolify payload** and spread it directly into the tool response.

That raw payload embeds the entire application graph (rendered `docker_compose`, `custom_labels`, webhook secrets) plus the destination `server` object, including `server.settings.logdrain_custom_config` (a live bearer token for the log drain) and `sentinel_token`.

Observed in production: `deployment {action: get, uuid, lines: 5}` returned a ~78KB payload for 5 log lines, with the secrets above embedded in the body — undoing the webhook-secret masking added in v2.12.0 for `list_resources`, and blowing typical MCP response token budgets.

The same bypass existed in `deployment {action: list_for_app, include_logs: true}` via `listApplicationDeployments(uuid, { includeLogs: true })`.

## Fix

- `CoolifyClient.getDeployment()` and `CoolifyClient.listApplicationDeployments()` now **always** project through `toDeploymentEssential()`. When logs are requested, the raw log string is attached as a `logs` field on the *projection* — the raw upstream object (application graph, server/destination graph, secrets) is never returned.
- Added `logs?: string` as an optional field on `DeploymentEssential` (`src/types/coolify.ts`).
- `src/lib/mcp-server.ts`'s `deployment` tool handler needed no structural changes beyond dropping a now-unneeded `as Deployment` cast — it already just spreads whatever the client returns, and the client now only ever returns the essential shape. Pagination (`logs_meta`, next/prev) and `max_chars` handling via `truncateLogs()` are unchanged.
- Did **not** route the output through `maskResourceItemFull`/`SENSITIVE_RESOURCE_FIELDS` (the v2.12.0 `list_resources` masking helper) — that helper targets the flat `ResourceListItemFull` shape from `/resources` and doesn't apply cleanly here. `toDeploymentEssential()` is already an allowlist projection (it only ever copies named-safe fields across), so there's no raw-field surface left for that denylist to guard. Forcing it in would be contorting the code for no real protection.

## Tests

- `src/__tests__/coolify-client.test.ts`: updated the two tests that previously asserted `includeLogs: true` returns the *raw* deployment/list — they now assert the essential projection with `logs` attached, and that raw fields (`application`, `destination`, `id`) never appear.
- `src/__tests__/mcp-server.test.ts`: new `deployment tool handler (#232 essential projection)` suite. Mocks the raw HTTP layer (not the client) with a realistic bloated upstream payload embedding `logdrain_custom_config`, `sentinel_token`, `manual_webhook_secret_*`, and `docker_compose`, then drives the real `deployment` tool end-to-end:
  - asserts the serialized response contains none of those leaked keys and no nested `application`/`server`/`destination` objects,
  - asserts the response stays under 20KB even with a bloated upstream payload.

## Verification

- `npm test` — 365 passed
- `npm run lint` — 0 errors (4 pre-existing `no-explicit-any` warnings, unrelated to this change)
- `npx prettier --check .` — clean
- `npm run build` — clean

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)