### PR TITLE
fix: validate scheduled-task command length client-side, add error hints

### DIFF
--- a/site/concepts/coolify-api-gotchas.md
+++ b/site/concepts/coolify-api-gotchas.md
@@ -50,6 +50,14 @@ The new `hetzner` tool's endpoints (`/api/v1/hetzner/locations`, `server-types`,
 
 Also: the path uses `server-types` (hyphen). `server_types` (underscore) returns 404.
 
+## Scheduled task `command` is limited to 255 chars
+
+Coolify's `scheduled_tasks` table stores `command` as `$table->string('command')` — a plain Laravel `string()` column, i.e. `varchar(255)` — per [`database/migrations/2023_12_31_173041_create_scheduled_tasks_table.php`](https://github.com/coollabsio/coolify/blob/main/database/migrations/2023_12_31_173041_create_scheduled_tasks_table.php) in `coollabsio/coolify`. No later migration changes the column type. Commands longer than the limit fail with a **bodyless HTTP 500** (`Internal Server Error`, no validation message) rather than a 422 — the worst possible error for an agent to act on.
+
+Empirically (Coolify 4.1.2): 132/155/165/247-char commands created fine; ~265/~270/~320/~330-char commands all 500'd, confirming the ~255-char ceiling.
+
+The `scheduled_tasks` tool now validates `command` client-side with `.max(255, ...)` on both `create` and `update`, and `request()` appends a hint to the error message when a bare 500 on a `/scheduled-tasks` path is seen. Workaround for longer commands: split into multiple scheduled tasks, or bake a script into the container image and invoke it by a short path/name instead of inlining the full command. Fixed in #234.
+
 ## `listApplicationDeployments` response shape
 
 Coolify's `GET /api/v1/deployments/applications/{uuid}` returns `{ count, deployments: [] }`, not `Deployment[]` as the OpenAPI suggests. Any caller using `.length` / `.map()` on the response would crash against a real Coolify server. Fixed in #158: the client method now correctly parses the envelope and returns `{ count, deployments }`.

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { CoolifyClient } from '../lib/coolify-client.js';
+import { CoolifyClient, errorHint } from '../lib/coolify-client.js';
 import type { ServiceType, CreateServiceRequest, EnvironmentVariable } from '../types/coolify.js';
 
 // Helper to create mock response
@@ -810,6 +810,18 @@ describe('CoolifyClient', () => {
       await expect(client.listServers()).rejects.toThrow(
         'Validation failed. - name: The name field is required.; docker_compose_raw: The docker compose raw field is required.',
       );
+    });
+
+    it('should append a command-length hint on a bodyless 500 from a scheduled-tasks path', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({}, false, 500));
+
+      await expect(
+        client.createApplicationScheduledTask('app-uuid', {
+          name: 'task',
+          command: 'a'.repeat(300),
+          frequency: '* * * * *',
+        }),
+      ).rejects.toThrow(/varchar\(255\)/);
     });
   });
 
@@ -5017,5 +5029,33 @@ describe('CoolifyClient', () => {
         expect.objectContaining({ method: 'GET' }),
       );
     });
+  });
+});
+
+describe('errorHint', () => {
+  it('hints at the command-length limit for a 500 on a scheduled-tasks path', () => {
+    expect(errorHint(500, '/applications/app-uuid/scheduled-tasks')).toMatch(/varchar\(255\)/);
+    expect(errorHint(500, '/services/svc-uuid/scheduled-tasks/task-uuid')).toMatch(
+      /varchar\(255\)/,
+    );
+  });
+
+  it('does not hint at the command-length limit for a 500 on unrelated paths', () => {
+    expect(errorHint(500, '/servers')).toBeUndefined();
+  });
+
+  it('hints at the access token for 401 and 403', () => {
+    expect(errorHint(401, '/version')).toMatch(/COOLIFY_ACCESS_TOKEN/);
+    expect(errorHint(403, '/servers')).toMatch(/COOLIFY_ACCESS_TOKEN/);
+  });
+
+  it('hints at a possible resource-type mismatch for a 404 on a uuid route', () => {
+    expect(errorHint(404, '/applications/app-uuid')).toMatch(/different resource type/);
+  });
+
+  it('returns undefined for anything else (default passthrough)', () => {
+    expect(errorHint(200, '/servers')).toBeUndefined();
+    expect(errorHint(422, '/applications/app-uuid')).toBeUndefined();
+    expect(errorHint(404, '/health')).toBeUndefined();
   });
 });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -822,6 +822,63 @@ describe('CoolifyMcpServer v2', () => {
       expect(text.length).toBeLessThan(20_000);
     });
   });
+
+  describe('scheduled_tasks tool handler', () => {
+    // Regression for #234 — Coolify's `command` column is a 255-char varchar and
+    // rejects longer commands with a bodyless HTTP 500. The zod schema must reject
+    // an over-long command locally, before any HTTP call is attempted.
+
+    const getScheduledTasksTool = (
+      srv: CoolifyMcpServer,
+    ): {
+      inputSchema: { safeParse: (args: unknown) => { success: boolean; error?: unknown } };
+      handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown>;
+    } =>
+      (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            {
+              inputSchema: { safeParse: (args: unknown) => { success: boolean; error?: unknown } };
+              handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown>;
+            }
+          >;
+        }
+      )._registeredTools['scheduled_tasks'];
+
+    const baseArgs = {
+      resource: 'application' as const,
+      action: 'create' as const,
+      uuid: 'app-uuid',
+      name: 'my-task',
+      frequency: '* * * * *',
+    };
+
+    it('rejects a command over 255 chars locally, with an actionable message', () => {
+      const createSpy = jest.spyOn(server['client'], 'createApplicationScheduledTask');
+      const updateSpy = jest.spyOn(server['client'], 'updateApplicationScheduledTask');
+
+      const tool = getScheduledTasksTool(server);
+      const result = tool.inputSchema.safeParse({ ...baseArgs, command: 'a'.repeat(256) });
+
+      expect(result.success).toBe(false);
+      const error = result.error as { issues: { message: string }[] };
+      expect(error.issues[0]?.message).toContain(
+        'Coolify rejects scheduled-task commands longer than 255 chars',
+      );
+
+      // No HTTP call should have been attempted.
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts a command at exactly 255 chars', () => {
+      const tool = getScheduledTasksTool(server);
+      const result = tool.inputSchema.safeParse({ ...baseArgs, command: 'a'.repeat(255) });
+
+      expect(result.success).toBe(true);
+    });
+  });
 });
 
 describe('truncateLogs', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -239,6 +239,25 @@ function mapFqdnToDomains<T extends { fqdn?: string; domains?: string }>(
   return { ...rest, domains: fqdn };
 }
 
+/**
+ * Map a failed response's status/path to an actionable hint for known Coolify quirks.
+ * Coolify sometimes returns bodyless errors (e.g. bare `HTTP 500: Internal Server Error`)
+ * that leave the caller guessing at the cause — this appends a short, testable hint for
+ * the cases we've hit in practice. Returns undefined when no known case matches.
+ */
+export function errorHint(status: number, path: string): string | undefined {
+  if (status === 500 && /\/scheduled-tasks(\/|$)/.test(path)) {
+    return 'Known cause: Coolify stores scheduled-task `command` in a varchar(255) column and rejects longer commands with a bodyless 500 — check the command length (limit 255 chars).';
+  }
+  if (status === 401 || status === 403) {
+    return 'Check that COOLIFY_ACCESS_TOKEN is valid and has the required scopes for this operation.';
+  }
+  if (status === 404 && /\/[\w-]{8,}(\/|$)/.test(path)) {
+    return 'The uuid may belong to a different resource type than requested (e.g. an application uuid used on a service/database route).';
+  }
+  return undefined;
+}
+
 // =============================================================================
 // Summary Transformers - reduce full objects to essential fields
 // =============================================================================
@@ -521,6 +540,10 @@ export class CoolifyClient {
             )
             .join('; ');
           errorMessage = `${errorMessage} - ${validationDetails}`;
+        }
+        const hint = errorHint(response.status, path);
+        if (hint) {
+          errorMessage = `${errorMessage} (${hint})`;
         }
         throw new Error(errorMessage);
       }

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1658,14 +1658,21 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'scheduled_tasks',
-      'Manage scheduled tasks for app or service: list/create/update/delete/list_executions',
+      'Manage scheduled tasks for app or service: list/create/update/delete/list_executions. ' +
+        'Coolify stores `command` in a varchar(255) column and rejects longer commands with a bodyless HTTP 500 — keep commands to 255 chars or fewer.',
       {
         resource: z.enum(['application', 'service']),
         action: z.enum(['list', 'create', 'update', 'delete', 'list_executions']),
         uuid: z.string(),
         task_uuid: z.string().optional(),
         name: z.string().optional(),
-        command: z.string().optional(),
+        command: z
+          .string()
+          .max(
+            255,
+            'Coolify rejects scheduled-task commands longer than 255 chars — split the command or bake a script into the container image',
+          )
+          .optional(),
         frequency: z.string().optional(),
         container: z.string().optional(),
         timeout: z.number().optional(),


### PR DESCRIPTION
## What

Coolify rejects scheduled-task `command` values beyond ~250 chars with a **bodyless HTTP 500** (`Internal Server Error`, no validation message) that the MCP previously passed through verbatim. This closes #234, which absorbed item 3 of the now-closed #237.

## Upstream evidence for the limit

Checked Coolify's own migrations (`gh api repos/coollabsio/coolify/contents/database/migrations`). The table is created in [`database/migrations/2023_12_31_173041_create_scheduled_tasks_table.php`](https://github.com/coollabsio/coolify/blob/main/database/migrations/2023_12_31_173041_create_scheduled_tasks_table.php):

```php
$table->string('command');
```

A plain Laravel `string()` column is `varchar(255)`. I checked every later scheduled-tasks migration (`add_timeout_to_scheduled_tasks_table`, `improve_scheduled_task_executions_tracking`, etc.) — none of them touch the `command` column's type. So the limit is **255**, pinned from upstream source, not just the largest empirically-known-good value (247).

This matches the empirical datapoints in the issue: 247 chars OK, ~265+ fails — consistent with a 255-char ceiling (255 itself would still pass; the reporter's smallest failing sample was ~265).

## Changes

1. **Client-side validation** (`src/lib/mcp-server.ts`): `command` in the `scheduled_tasks` tool shape now has `.max(255, '...')` with an actionable message. The shape is shared between `create` and `update`, so both are covered by one change. Tool description also mentions the limit.
2. **Status-code-aware error hints** (`src/lib/coolify-client.ts`): new pure function `errorHint(status, path)` appends a short hint to bodyless failures:
   - `500` on a `/scheduled-tasks` path → command-length limit as a known cause.
   - `401`/`403` → check `COOLIFY_ACCESS_TOKEN` validity/scopes.
   - `404` on a uuid-shaped route → uuid may belong to a different resource type (app vs service vs database).
   - Anything else → no hint appended (passthrough unchanged).
3. **Docs**: added the gotcha (limit + workaround) to `site/concepts/coolify-api-gotchas.md`, matching the existing entry style and citing the migration file.

## Tests

- An over-long command is rejected via the tool's zod `inputSchema` before any HTTP call — asserted that the mocked `createApplicationScheduledTask` / `updateApplicationScheduledTask` client methods are never invoked.
- A 255-char command still validates successfully (boundary case).
- Unit tests for `errorHint` covering all three mapped cases and the default (undefined) passthrough.
- Integration-style test: a real bodyless 500 from `createApplicationScheduledTask` now surfaces the hint in the thrown error.

`npm test` (371 tests passing), `npm run lint`, `npx prettier --check .`, and `npm run build` all pass.

## Uncertain / worth a second look

- The 404 "uuid route" heuristic in `errorHint` is a generic regex (`/[\w-]{8,}(\/|$)/`) rather than validating true UUID format, since Coolify's uuids aren't RFC4122-shaped. It's intentionally loose per "don't over-engineer" — flagging in case a tighter check is preferred.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)