### PR TITLE
feat: add run_once action to scheduled_tasks (#233)

### DIFF
--- a/site/concepts/coolify-api-gotchas.md
+++ b/site/concepts/coolify-api-gotchas.md
@@ -63,3 +63,18 @@ The `scheduled_tasks` tool now validates `command` client-side with `.max(255, .
 Coolify's `GET /api/v1/deployments/applications/{uuid}` returns `{ count, deployments: [] }`, not `Deployment[]` as the OpenAPI suggests. Any caller using `.length` / `.map()` on the response would crash against a real Coolify server. Fixed in #158: the client method now correctly parses the envelope and returns `{ count, deployments }`.
 
 By default the response uses `DeploymentEssential[]` (no raw `logs` blobs) to keep token usage sane on a 35-deployment list. Pass `include_logs: true` to opt back in.
+
+## Scheduled tasks have no "run now" — and the every-minute dance is dangerous
+
+There is no upstream trigger/run-now endpoint for scheduled tasks: the bundled `docs/coolify-openapi.yaml` has no scheduled-task trigger (the only `trigger` in the spec is database backups), and `coolify-client.ts` has no such method. The only way to run a one-off command in a container is the manual dance: create a task with `frequency: "* * * * *"`, wait for the minute tick, read `list_executions`, delete the task.
+
+Sharp edges hit doing this manually (2026-07-02, applying a missed migration on the crunch app):
+
+- The task fires **every minute until deleted** — a non-idempotent SQL statement ran twice before the delete landed. Write commands as idempotent (`where not exists`, `insert ... on conflict`) or expect re-execution.
+- Timing the tick by hand (create → wait ~60-70s → `list_executions` → delete) is boilerplate every caller reimplements badly, and it's easy to delete too early (before the first execution lands) or too late (after a second tick fires).
+
+The `scheduled_tasks` tool's `run_once` action (#233) automates this: it creates the throwaway task, polls `list_executions` every ~5s for the first terminal execution (default 90s budget), deletes the task in a cleanup step that always runs (success, timeout, or error), and returns `status` + `message` (the command's stdout — see below). It still carries the same idempotency caveat, since the underlying cron can fire more than once before cleanup completes; deleting immediately after the first observed execution shrinks the window but does not close it.
+
+Also: `list_executions` returns a `message` field per execution that carries the command's **stdout** — easy to miss since nothing else in the response looks like output.
+
+Separately, Coolify silently rejects scheduled-task `command` values longer than ~255 chars as a bare `HTTP 500` with no body (#234) — keep commands short, or write a script into the container image and call that instead.

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -879,6 +879,189 @@ describe('CoolifyMcpServer v2', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  describe('scheduled_tasks tool handler - run_once', () => {
+    type ServerWithSleep = { sleep: (ms: number) => Promise<void> };
+
+    const callScheduledTasks = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<{ content: Array<{ type: string; text: string }> }> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['scheduled_tasks'];
+      return tool.handler(args, {}) as Promise<{ content: Array<{ type: string; text: string }> }>;
+    };
+
+    const baseArgs = {
+      resource: 'application' as const,
+      action: 'run_once' as const,
+      uuid: 'app-uuid',
+      command: 'php artisan migrate',
+      container: 'app',
+      wait_seconds: 10, // small budget -> few poll attempts in tests
+    };
+
+    const mockTask = {
+      id: 1,
+      uuid: 'task-uuid',
+      enabled: true,
+      name: 'oneoff-abc123',
+      command: 'php artisan migrate',
+      frequency: '* * * * *',
+      timeout: 0,
+      created_at: '',
+      updated_at: '',
+    };
+
+    beforeEach(() => {
+      // Poll loop uses a real setTimeout by default; override the instance method
+      // directly so tests are instant (jest.spyOn's generic inference struggles
+      // with private methods here, so a plain shadowing assignment is simpler).
+      (server as unknown as ServerWithSleep).sleep = (): Promise<void> => Promise.resolve();
+    });
+
+    it('validates command and container are required', async () => {
+      const result = await callScheduledTasks(server, {
+        resource: 'application',
+        action: 'run_once',
+        uuid: 'app-uuid',
+      });
+      expect(result.content[0]!.text).toBe('Error: command, container required');
+    });
+
+    it('creates a task, polls until a terminal execution, returns its output, and deletes the task', async () => {
+      const createSpy = jest
+        .spyOn(server['client'], 'createApplicationScheduledTask')
+        .mockResolvedValue(mockTask);
+      const listSpy = jest
+        .spyOn(server['client'], 'listApplicationScheduledTaskExecutions')
+        .mockResolvedValueOnce([]) // first poll: nothing yet
+        .mockResolvedValueOnce([
+          {
+            uuid: 'exec-uuid',
+            status: 'success',
+            message: 'Migrated: 2026_01_01_000000_add_col',
+            retry_count: 0,
+            created_at: '',
+            updated_at: '',
+          },
+        ]);
+      const deleteSpy = jest
+        .spyOn(server['client'], 'deleteApplicationScheduledTask')
+        .mockResolvedValue({ message: 'deleted' });
+
+      const result = await callScheduledTasks(server, baseArgs);
+
+      expect(createSpy).toHaveBeenCalledWith(
+        'app-uuid',
+        expect.objectContaining({
+          command: 'php artisan migrate',
+          frequency: '* * * * *',
+          container: 'app',
+          enabled: true,
+        }),
+      );
+      expect(listSpy).toHaveBeenCalledTimes(2);
+      expect(listSpy).toHaveBeenCalledWith('app-uuid', 'task-uuid');
+      expect(deleteSpy).toHaveBeenCalledWith('app-uuid', 'task-uuid');
+
+      const parsed = JSON.parse(result.content[0]!.text) as {
+        status: string;
+        message: string;
+        task_uuid: string;
+        cleanup: string;
+      };
+      expect(parsed.status).toBe('success');
+      expect(parsed.message).toBe('Migrated: 2026_01_01_000000_add_col');
+      expect(parsed.task_uuid).toBe('task-uuid');
+      expect(parsed.cleanup).toContain('deleted');
+    });
+
+    it('times out when no execution ever appears, and still deletes the task', async () => {
+      jest.spyOn(server['client'], 'createApplicationScheduledTask').mockResolvedValue(mockTask);
+      jest.spyOn(server['client'], 'listApplicationScheduledTaskExecutions').mockResolvedValue([]);
+      const deleteSpy = jest
+        .spyOn(server['client'], 'deleteApplicationScheduledTask')
+        .mockResolvedValue({ message: 'deleted' });
+
+      const result = await callScheduledTasks(server, baseArgs);
+
+      expect(deleteSpy).toHaveBeenCalledWith('app-uuid', 'task-uuid');
+      expect(result.content[0]!.text).toContain('Timed out');
+      expect(result.content[0]!.text).toContain('task-uuid');
+      expect(result.content[0]!.text).toContain('deleted');
+    });
+
+    it('still deletes the task when polling throws, and surfaces the poll error', async () => {
+      jest.spyOn(server['client'], 'createApplicationScheduledTask').mockResolvedValue(mockTask);
+      jest
+        .spyOn(server['client'], 'listApplicationScheduledTaskExecutions')
+        .mockRejectedValue(new Error('network blip'));
+      const deleteSpy = jest
+        .spyOn(server['client'], 'deleteApplicationScheduledTask')
+        .mockResolvedValue({ message: 'deleted' });
+
+      const result = await callScheduledTasks(server, baseArgs);
+
+      expect(deleteSpy).toHaveBeenCalledWith('app-uuid', 'task-uuid');
+      expect(result.content[0]!.text).toContain('network blip');
+      expect(result.content[0]!.text).toContain('task-uuid');
+    });
+
+    it('warns loudly with the task UUID when the cleanup delete itself fails', async () => {
+      jest.spyOn(server['client'], 'createApplicationScheduledTask').mockResolvedValue(mockTask);
+      jest.spyOn(server['client'], 'listApplicationScheduledTaskExecutions').mockResolvedValue([
+        {
+          uuid: 'exec-uuid',
+          status: 'success',
+          message: 'ok',
+          retry_count: 0,
+          created_at: '',
+          updated_at: '',
+        },
+      ]);
+      jest
+        .spyOn(server['client'], 'deleteApplicationScheduledTask')
+        .mockRejectedValue(new Error('403 forbidden'));
+
+      const result = await callScheduledTasks(server, baseArgs);
+
+      const parsed = JSON.parse(result.content[0]!.text) as { cleanup: string };
+      expect(parsed.cleanup).toContain('WARNING');
+      expect(parsed.cleanup).toContain('task-uuid');
+      expect(parsed.cleanup).toContain('403 forbidden');
+    });
+
+    it('supports the service resource', async () => {
+      const createSpy = jest
+        .spyOn(server['client'], 'createServiceScheduledTask')
+        .mockResolvedValue(mockTask);
+      jest.spyOn(server['client'], 'listServiceScheduledTaskExecutions').mockResolvedValue([
+        {
+          uuid: 'e',
+          status: 'success',
+          message: 'ok',
+          retry_count: 0,
+          created_at: '',
+          updated_at: '',
+        },
+      ]);
+      const deleteSpy = jest
+        .spyOn(server['client'], 'deleteServiceScheduledTask')
+        .mockResolvedValue({ message: 'deleted' });
+
+      await callScheduledTasks(server, { ...baseArgs, resource: 'service', uuid: 'svc-uuid' });
+
+      expect(createSpy).toHaveBeenCalledWith('svc-uuid', expect.any(Object));
+      expect(deleteSpy).toHaveBeenCalledWith('svc-uuid', 'task-uuid');
+    });
+  });
 });
 
 describe('truncateLogs', () => {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -22,6 +22,7 @@ import type {
   BuildPack,
   ResponseAction,
   ResponsePagination,
+  ScheduledTaskExecution,
 } from '../types/coolify.js';
 import { DocsSearchEngine } from './docs-search.js';
 
@@ -1658,11 +1659,17 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'scheduled_tasks',
-      'Manage scheduled tasks for app or service: list/create/update/delete/list_executions. ' +
-        'Coolify stores `command` in a varchar(255) column and rejects longer commands with a bodyless HTTP 500 — keep commands to 255 chars or fewer.',
+      'Manage scheduled tasks for app or service: list/create/update/delete/list_executions/run_once. ' +
+        "list_executions: the command's stdout comes back in the execution's message field. " +
+        'run_once: composite that creates a throwaway "* * * * *" task, polls list_executions every ~5s ' +
+        'for the first terminal execution (or until wait_seconds elapses, default 90), deletes the task, ' +
+        'and returns status+message. WARNING: the underlying cron may fire more than once before cleanup ' +
+        'completes — make the command idempotent (e.g. `where not exists`) or tolerate re-execution. ' +
+        'Coolify stores `command` in a varchar(255) column and rejects longer commands with a bodyless ' +
+        'HTTP 500 — keep commands to 255 chars or fewer (#234).',
       {
         resource: z.enum(['application', 'service']),
-        action: z.enum(['list', 'create', 'update', 'delete', 'list_executions']),
+        action: z.enum(['list', 'create', 'update', 'delete', 'list_executions', 'run_once']),
         uuid: z.string(),
         task_uuid: z.string().optional(),
         name: z.string().optional(),
@@ -1677,6 +1684,10 @@ export class CoolifyMcpServer extends McpServer {
         container: z.string().optional(),
         timeout: z.number().optional(),
         enabled: z.boolean().optional(),
+        wait_seconds: z
+          .number()
+          .optional()
+          .describe('run_once only: poll budget in seconds before giving up (default 90)'),
       },
       async (args) => {
         const { resource, action, uuid, task_uuid } = args;
@@ -1739,6 +1750,19 @@ export class CoolifyMcpServer extends McpServer {
               isApp
                 ? this.client.listApplicationScheduledTaskExecutions(uuid, task_uuid)
                 : this.client.listServiceScheduledTaskExecutions(uuid, task_uuid),
+            );
+          case 'run_once':
+            if (!args.command || !args.container)
+              return {
+                content: [{ type: 'text' as const, text: 'Error: command, container required' }],
+              };
+            return this.runOnceScheduledTask(
+              resource,
+              uuid,
+              args.command,
+              args.container,
+              args.timeout,
+              args.wait_seconds,
             );
         }
       },
@@ -1921,5 +1945,149 @@ export class CoolifyMcpServer extends McpServer {
       async ({ project_uuid, force }) =>
         wrap(() => this.client.redeployProjectApps(project_uuid, force ?? true)),
     );
+  }
+
+  /**
+   * Injectable delay for the run_once poll loop. A real setTimeout in production;
+   * tests replace it with `jest.spyOn(server, 'sleep').mockResolvedValue(undefined)`
+   * so polling logic runs without waiting on the wall clock.
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Composite one-off command execution (#233 / #208): there is no upstream
+   * "run now" endpoint for scheduled tasks, so this creates a throwaway
+   * `* * * * *` task, polls list_executions until the first execution reaches a
+   * terminal status (or the poll budget runs out), and returns its status+message.
+   *
+   * The task is deleted in a finally-equivalent (try/finally-style) block so cleanup
+   * always runs — on success, on timeout, and on a polling error. If cleanup itself
+   * fails, the returned message says so loudly with the task UUID so a human can
+   * remove it manually (it would otherwise keep firing every minute).
+   */
+  private async runOnceScheduledTask(
+    resource: 'application' | 'service',
+    uuid: string,
+    command: string,
+    container: string,
+    timeout: number | undefined,
+    waitSeconds: number | undefined,
+  ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+    const isApp = resource === 'application';
+    const pollIntervalMs = 5000;
+    const budgetSeconds = waitSeconds ?? 90;
+    const maxAttempts = Math.max(1, Math.ceil((budgetSeconds * 1000) / pollIntervalMs));
+    const name = `oneoff-${Math.random().toString(36).slice(2, 10)}`;
+
+    let taskUuid: string;
+    try {
+      const task = isApp
+        ? await this.client.createApplicationScheduledTask(uuid, {
+            name,
+            command,
+            frequency: '* * * * *',
+            container,
+            timeout,
+            enabled: true,
+          })
+        : await this.client.createServiceScheduledTask(uuid, {
+            name,
+            command,
+            frequency: '* * * * *',
+            container,
+            timeout,
+            enabled: true,
+          });
+      taskUuid = task.uuid;
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error creating one-off task: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+
+    let execution: ScheduledTaskExecution | undefined;
+    let pollErrorMessage: string | undefined;
+
+    try {
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const executions = isApp
+          ? await this.client.listApplicationScheduledTaskExecutions(uuid, taskUuid)
+          : await this.client.listServiceScheduledTaskExecutions(uuid, taskUuid);
+        const first = executions[0];
+        if (first && first.status !== 'running') {
+          execution = first;
+          break;
+        }
+        if (attempt < maxAttempts - 1) await this.sleep(pollIntervalMs);
+      }
+    } catch (error) {
+      pollErrorMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    // Cleanup always runs, regardless of how the poll loop above ended.
+    let deleteErrorMessage: string | undefined;
+    try {
+      if (isApp) {
+        await this.client.deleteApplicationScheduledTask(uuid, taskUuid);
+      } else {
+        await this.client.deleteServiceScheduledTask(uuid, taskUuid);
+      }
+    } catch (error) {
+      deleteErrorMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    const cleanupNote = deleteErrorMessage
+      ? `WARNING: failed to delete one-off task ${taskUuid} — it will keep firing every minute ` +
+        `until it is removed manually. Delete error: ${deleteErrorMessage}`
+      : `One-off task ${taskUuid} deleted.`;
+
+    if (pollErrorMessage) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error polling one-off task ${taskUuid} executions: ${pollErrorMessage}. ${cleanupNote}`,
+          },
+        ],
+      };
+    }
+
+    if (!execution) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              `Timed out after ${budgetSeconds}s waiting for one-off task ${taskUuid} to produce ` +
+              `an execution. ${cleanupNote}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            {
+              status: execution.status,
+              message: execution.message,
+              task_uuid: taskUuid,
+              cleanup: cleanupNote,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
   }
 }


### PR DESCRIPTION
## Summary

Adds `action: "run_once"` to the `scheduled_tasks` tool — a composite that runs a one-off command in an app/service container and returns its output. There is no upstream trigger/run-now endpoint for scheduled tasks (verified: no such route in `docs/coolify-openapi.yaml`, no such client method), so this composes the existing create / list_executions / delete client methods rather than adding a new endpoint.

**Params:** `resource` ('application'|'service'), `uuid`, `command`, `container`, optional `timeout`, optional `wait_seconds` (poll budget, default 90).

**Behaviour:**
1. Creates a task with a generated `oneoff-<random suffix>` name, `frequency: "* * * * *"`, enabled.
2. Polls `list_executions` every ~5s (attempt-counted, not wall-clock-gated, so it stays testable) for up to `wait_seconds` until the first execution reaches a terminal (non-`running`) status.
3. **Always deletes the task afterwards** — success, timeout, or a polling error all fall through to the same cleanup step (Rust-`finally`-equivalent structure). If the delete itself fails, the response says so loudly, includes the task UUID, and warns that the cron will keep firing every minute until it's removed by hand.
4. Returns the execution's `status` + `message` (the API returns the command's stdout in `message`).

**Idempotency caveat (carried in the tool description):** the underlying cron can fire more than once before cleanup lands — deleting right after the first observed execution shrinks the window but doesn't close it. Commands must be idempotent or tolerant of re-execution.

**Command length:** noted in the tool description that Coolify silently 500s on scheduled-task commands over ~255 chars (#234, still open/unfixed on this branch) — not implemented as a hard `.max()` validation here since that's #234's scope, just documented so `run_once` callers aren't surprised.

**Type modelling (#237 item 2):** turns out `ScheduledTaskExecution.message` already existed in `src/types/coolify.ts` (added back in #172) — the issue's premise was slightly stale. What was actually missing was the `list_executions` tool description not mentioning that stdout lives in `message`; fixed that instead.

**Docs:** added the every-minute/idempotency gotcha (plus the "no run-now endpoint" context and the `message`-is-stdout note) to `site/concepts/coolify-api-gotchas.md`.

Closes #233
Closes #208

## Test plan

- [x] `npm test` — 369 tests passing, coverage 98.1%/86.36%/99.53%/98.91% (all above threshold)
- [x] New `scheduled_tasks tool handler - run_once` suite covers: success path (create→poll→return output→delete called), timeout path (no execution appears, delete still called, message includes task UUID), poll-error path (list_executions throws, delete still called, error surfaced), delete-failure path (message warns loudly with UUID + underlying error), input validation, and the service-resource variant
- [x] `npm run lint` — 0 errors (4 pre-existing warnings, none introduced by this change)
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — clean

## Notes / uncertainties

- The poll loop counts attempts (`wait_seconds / 5`) rather than gating on wall-clock time, specifically so the "instant sleep" test stub doesn't turn timeout tests into real multi-second waits. This is a slight approximation of "poll every ~5s for wait_seconds" but keeps behaviour deterministic and tests fast.
- `sleep` is a private class method overridden directly on the instance in tests (`server.sleep = () => Promise.resolve()`) rather than via `jest.spyOn`, because `jest.spyOn`'s generic inference reduces to `never` when intersecting an object type with a class that already declares the member as `private`. Flagging in case there's a preferred pattern already in use elsewhere I missed.
- Did not touch `package.json`/`CHANGELOG.md` per the task constraints — happy to add a changelog entry if that's expected before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)