### PR TITLE
feat: add wait option to deploy tool (#238)

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -554,6 +554,28 @@ describe('CoolifyClient', () => {
       );
     });
 
+    it('should parse the deployments envelope Coolify returns for /deploy (#238)', async () => {
+      // Real Coolify returns { deployments: [{ message, resource_uuid, deployment_uuid }] },
+      // one entry per triggered deployment (a tag can match several apps).
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          deployments: [
+            { message: 'Deployment queued', resource_uuid: 'app-1', deployment_uuid: 'dep-1' },
+            { message: 'Deployment queued', resource_uuid: 'app-2', deployment_uuid: 'dep-2' },
+          ],
+        }),
+      );
+
+      const result = await client.deployByTagOrUuid('my-tag', true);
+
+      expect(result).toEqual({
+        deployments: [
+          { message: 'Deployment queued', resource_uuid: 'app-1', deployment_uuid: 'dep-1' },
+          { message: 'Deployment queued', resource_uuid: 'app-2', deployment_uuid: 'dep-2' },
+        ],
+      });
+    });
+
     it('should deploy by Coolify UUID (24 char alphanumeric)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Deployed' }));
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1062,6 +1062,179 @@ describe('CoolifyMcpServer v2', () => {
       expect(deleteSpy).toHaveBeenCalledWith('svc-uuid', 'task-uuid');
     });
   });
+
+  describe('deploy tool handler', () => {
+    // #238 — opt-in `wait` polls the deployment to a terminal status instead
+    // of firing-and-forgetting. The no-wait path must stay byte-for-byte
+    // identical to the pre-#238 behaviour.
+
+    const callDeploy = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<unknown> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+          >;
+        }
+      )._registeredTools['deploy'];
+      return tool.handler(args, {});
+    };
+
+    const essentialDeployment = (
+      overrides: Partial<Record<string, unknown>> = {},
+    ): Record<string, unknown> => ({
+      uuid: 'dep-uuid',
+      deployment_uuid: 'dep-uuid',
+      application_uuid: 'app-uuid',
+      application_name: 'my-app',
+      status: 'in_progress',
+      commit: 'abc123',
+      force_rebuild: false,
+      is_webhook: false,
+      is_api: true,
+      created_at: '2026-01-01T10:00:00Z',
+      updated_at: '2026-01-01T10:00:00Z',
+      ...overrides,
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('no-wait path is unchanged: triggers deploy and returns immediately', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'deployByTagOrUuid')
+        .mockResolvedValue({ deployments: [{ deployment_uuid: 'dep-uuid' }] });
+      const pollSpy = jest.spyOn(server['client'], 'getDeployment');
+
+      const result = (await callDeploy(server, { tag_or_uuid: 'my-tag', force: true })) as {
+        content: Array<{ text: string }>;
+      };
+
+      expect(spy).toHaveBeenCalledWith('my-tag', true);
+      expect(pollSpy).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.data).toEqual({ deployments: [{ deployment_uuid: 'dep-uuid' }] });
+      expect(parsed._actions).toEqual([
+        { tool: 'list_deployments', args: {}, hint: 'Check deployment status' },
+      ]);
+    });
+
+    it('wait: true polls until finished', async () => {
+      jest.useFakeTimers();
+      jest
+        .spyOn(server['client'], 'deployByTagOrUuid')
+        .mockResolvedValue({ deployments: [{ deployment_uuid: 'dep-uuid' }] });
+      const getDeploymentSpy = jest
+        .spyOn(server['client'], 'getDeployment')
+        .mockResolvedValueOnce(essentialDeployment({ status: 'in_progress' }) as never)
+        .mockResolvedValueOnce(essentialDeployment({ status: 'finished' }) as never);
+
+      const resultPromise = callDeploy(server, { tag_or_uuid: 'my-tag', wait: true }) as Promise<{
+        content: Array<{ text: string }>;
+      }>;
+
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await resultPromise;
+
+      expect(getDeploymentSpy).toHaveBeenCalledTimes(2);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.data.status).toBe('finished');
+      expect(parsed.data.deployment_uuid).toBe('dep-uuid');
+      expect(parsed.data.logs_tail).toBeUndefined();
+    });
+
+    it('wait: true returns a bounded log tail on failure, never the raw payload', async () => {
+      jest.useFakeTimers();
+      jest
+        .spyOn(server['client'], 'deployByTagOrUuid')
+        .mockResolvedValue({ deployments: [{ deployment_uuid: 'dep-uuid' }] });
+      jest
+        .spyOn(server['client'], 'getDeployment')
+        .mockImplementation(async (uuid: string, options?: { includeLogs?: boolean }) => {
+          if (options?.includeLogs) {
+            return {
+              ...essentialDeployment({ status: 'failed' }),
+              logs: JSON.stringify([{ output: 'build failed: OOM', timestamp: 't1' }]),
+              // Fields that would only appear on the raw upstream object —
+              // must never leak into the tool response.
+              server: { ip: '10.0.0.1', private_key: 'super-secret' },
+              application: { env_secret: 'shh' },
+            } as never;
+          }
+          return essentialDeployment({ status: 'failed' }) as never;
+        });
+
+      const resultPromise = callDeploy(server, { tag_or_uuid: 'my-tag', wait: true }) as Promise<{
+        content: Array<{ text: string }>;
+      }>;
+
+      const result = await resultPromise;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.data.status).toBe('failed');
+      expect(parsed.data.deployment_uuid).toBe('dep-uuid');
+      expect(parsed.data.logs_tail).toContain('build failed: OOM');
+      expect(result.content[0].text).not.toContain('private_key');
+      expect(result.content[0].text).not.toContain('env_secret');
+      expect(parsed.data).not.toHaveProperty('server');
+      expect(parsed.data).not.toHaveProperty('application');
+    });
+
+    it('wait: true returns an explicit timeout with a next-action hint', async () => {
+      jest.useFakeTimers();
+      jest
+        .spyOn(server['client'], 'deployByTagOrUuid')
+        .mockResolvedValue({ deployments: [{ deployment_uuid: 'dep-uuid' }] });
+      jest
+        .spyOn(server['client'], 'getDeployment')
+        .mockResolvedValue(essentialDeployment({ status: 'in_progress' }) as never);
+
+      const resultPromise = callDeploy(server, {
+        tag_or_uuid: 'my-tag',
+        wait: true,
+        timeout_seconds: 10,
+      }) as Promise<{ content: Array<{ text: string }> }>;
+
+      // Let the poll loop exceed the 10s timeout.
+      await jest.advanceTimersByTimeAsync(15_000);
+      const result = await resultPromise;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.data.status).toBe('in_progress');
+      expect(parsed.data.timed_out).toBe(true);
+      expect(parsed.data.deployment_uuid).toBe('dep-uuid');
+      expect(parsed.data.next_action).toEqual(expect.stringContaining('deployment'));
+    });
+
+    it('wait: true watches only the first deployment when a tag triggers several', async () => {
+      jest.useFakeTimers();
+      jest.spyOn(server['client'], 'deployByTagOrUuid').mockResolvedValue({
+        deployments: [{ deployment_uuid: 'dep-1' }, { deployment_uuid: 'dep-2' }],
+      });
+      const getDeploymentSpy = jest.spyOn(server['client'], 'getDeployment').mockResolvedValue(
+        essentialDeployment({
+          status: 'finished',
+          deployment_uuid: 'dep-1',
+          uuid: 'dep-1',
+        }) as never,
+      );
+
+      const resultPromise = callDeploy(server, { tag_or_uuid: 'my-tag', wait: true }) as Promise<{
+        content: Array<{ text: string }>;
+      }>;
+      const result = await resultPromise;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(getDeploymentSpy).toHaveBeenCalledWith('dep-1');
+      expect(getDeploymentSpy).not.toHaveBeenCalledWith('dep-2');
+      expect(parsed.data.deployment_uuid).toBe('dep-1');
+      expect(parsed.data.additional_deployment_uuids).toEqual(['dep-2']);
+    });
+  });
 });
 
 describe('truncateLogs', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -63,6 +63,7 @@ import type {
   // Deployment types
   Deployment,
   DeploymentEssential,
+  DeployTriggerResponse,
   // Team types
   Team,
   TeamMember,
@@ -1204,10 +1205,13 @@ export class CoolifyClient {
     return essential;
   }
 
-  async deployByTagOrUuid(tagOrUuid: string, force: boolean = false): Promise<MessageResponse> {
+  async deployByTagOrUuid(
+    tagOrUuid: string,
+    force: boolean = false,
+  ): Promise<DeployTriggerResponse> {
     // Detect if the value looks like a UUID or a tag name
     const param = this.isLikelyUuid(tagOrUuid) ? 'uuid' : 'tag';
-    return this.request<MessageResponse>(
+    return this.request<DeployTriggerResponse>(
       `/deploy?${param}=${encodeURIComponent(tagOrUuid)}&force=${force}`,
       { method: 'GET' },
     );

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -23,6 +23,9 @@ import type {
   ResponseAction,
   ResponsePagination,
   ScheduledTaskExecution,
+  Deployment,
+  DeploymentEssential,
+  DeployTriggerResponse,
 } from '../types/coolify.js';
 import { DocsSearchEngine } from './docs-search.js';
 
@@ -213,6 +216,58 @@ function wrapWithActions<T>(
     }));
 }
 
+// =============================================================================
+// Deploy wait/poll helpers (#238)
+// =============================================================================
+
+/** Deployment statuses that end a run — polling stops once one of these is hit. */
+const TERMINAL_DEPLOYMENT_STATUSES: ReadonlySet<string> = new Set([
+  'finished',
+  'failed',
+  'cancelled',
+]);
+
+const DEFAULT_DEPLOY_TIMEOUT_SECONDS = 300;
+const DEPLOY_POLL_INTERVAL_MS = 5000;
+
+function isTerminalDeploymentStatus(status: string): boolean {
+  return TERMINAL_DEPLOYMENT_STATUSES.has(status);
+}
+
+/** Isolated so tests can drive polling with jest fake timers instead of real waits. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function durationSeconds(createdAt?: string, updatedAt?: string): number | undefined {
+  if (!createdAt || !updatedAt) return undefined;
+  const start = Date.parse(createdAt);
+  const end = Date.parse(updatedAt);
+  if (Number.isNaN(start) || Number.isNaN(end)) return undefined;
+  return Math.max(0, Math.round((end - start) / 1000));
+}
+
+/**
+ * Small, safe projection returned by `deploy` when `wait: true`.
+ * Built from essential fields + a bounded log tail only — never the raw
+ * upstream deployment object, which can carry server/application secrets
+ * (see #232).
+ */
+interface DeployWaitResult {
+  status: string;
+  deployment_uuid: string;
+  application_uuid?: string;
+  commit?: string;
+  created_at?: string;
+  updated_at?: string;
+  duration_seconds?: number;
+  timed_out?: boolean;
+  logs_tail?: string;
+  logs_meta?: { total_entries: number; showing: string };
+  next_action?: string;
+  additional_deployment_uuids?: string[];
+}
+
 export class CoolifyMcpServer extends McpServer {
   private readonly client: CoolifyClient;
   private readonly docsSearch: DocsSearchEngine = new DocsSearchEngine();
@@ -225,6 +280,94 @@ export class CoolifyMcpServer extends McpServer {
 
   async connect(transport: Transport): Promise<void> {
     await super.connect(transport);
+  }
+
+  /**
+   * Poll a single deployment until it reaches a terminal status or the
+   * timeout elapses. Uses `getDeployment`'s no-logs projection
+   * (`DeploymentEssential`) while polling, and only fetches logs (once,
+   * truncated) if the deployment failed.
+   */
+  private async pollDeployment(uuid: string, timeoutSeconds: number): Promise<DeployWaitResult> {
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    let current = (await this.client.getDeployment(uuid)) as DeploymentEssential;
+
+    while (!isTerminalDeploymentStatus(current.status) && Date.now() < deadline) {
+      await sleep(DEPLOY_POLL_INTERVAL_MS);
+      current = (await this.client.getDeployment(uuid)) as DeploymentEssential;
+    }
+
+    if (!isTerminalDeploymentStatus(current.status)) {
+      return {
+        status: current.status,
+        deployment_uuid: uuid,
+        application_uuid: current.application_uuid,
+        timed_out: true,
+        next_action: `Still "${current.status}" after ${timeoutSeconds}s — poll \`deployment\` (action: "get", uuid: "${uuid}") to keep watching.`,
+      };
+    }
+
+    if (current.status === 'failed') {
+      const withLogs = (await this.client.getDeployment(uuid, {
+        includeLogs: true,
+      })) as Deployment;
+      const tail = withLogs.logs ? truncateLogs(withLogs.logs, 30, 10_000) : undefined;
+      return {
+        status: current.status,
+        deployment_uuid: uuid,
+        application_uuid: current.application_uuid,
+        commit: current.commit,
+        created_at: current.created_at,
+        updated_at: current.updated_at,
+        duration_seconds: durationSeconds(current.created_at, current.updated_at),
+        logs_tail: tail?.logs,
+        logs_meta: tail
+          ? {
+              total_entries: tail.total,
+              showing: `${tail.showing_start}-${tail.showing_end} of ${tail.total}`,
+            }
+          : undefined,
+        next_action: `Deployment failed. See logs_tail above, or \`deployment\` (action: "get", uuid: "${uuid}", lines: N) for more.`,
+      };
+    }
+
+    return {
+      status: current.status,
+      deployment_uuid: uuid,
+      application_uuid: current.application_uuid,
+      commit: current.commit,
+      created_at: current.created_at,
+      updated_at: current.updated_at,
+      duration_seconds: durationSeconds(current.created_at, current.updated_at),
+    };
+  }
+
+  /**
+   * Trigger a deploy and wait for it to finish. A tag can resolve to
+   * multiple applications, so `deployByTagOrUuid` may return several
+   * `deployment_uuid`s — only the first is polled; any others are
+   * surfaced under `additional_deployment_uuids` for the caller to check
+   * separately via `deployment get`.
+   */
+  private async triggerAndWaitForDeploy(
+    tagOrUuid: string,
+    force: boolean | undefined,
+    timeoutSeconds: number,
+  ): Promise<DeployWaitResult | DeployTriggerResponse> {
+    const triggered = await this.client.deployByTagOrUuid(tagOrUuid, force);
+    const [first, ...rest] = triggered.deployments ?? [];
+
+    if (!first?.deployment_uuid) {
+      // Nothing to poll against — hand back the trigger response as-is.
+      return triggered;
+    }
+
+    const result = await this.pollDeployment(first.deployment_uuid, timeoutSeconds);
+    const additional = rest.map((d) => d.deployment_uuid).filter((u): u is string => !!u);
+    if (additional.length > 0) {
+      result.additional_deployment_uuids = additional;
+    }
+    return result;
   }
 
   private registerTools(): void {
@@ -1148,12 +1291,42 @@ export class CoolifyMcpServer extends McpServer {
     this.tool(
       'deploy',
       'Deploy by tag/UUID',
-      { tag_or_uuid: z.string(), force: z.boolean().optional() },
-      async ({ tag_or_uuid, force }) =>
-        wrapWithActions(
-          () => this.client.deployByTagOrUuid(tag_or_uuid, force),
-          () => [{ tool: 'list_deployments', args: {}, hint: 'Check deployment status' }],
-        ),
+      {
+        tag_or_uuid: z.string(),
+        force: z.boolean().optional(),
+        wait: z
+          .boolean()
+          .optional()
+          .describe(
+            'Wait for the deployment to reach a terminal status (finished/failed/cancelled) instead of returning immediately, polling every ~5s. If tag_or_uuid matches multiple applications (a tag can trigger several deployments), only the first is watched — the rest are returned under additional_deployment_uuids for you to check separately via `deployment get`. On failure the response includes a bounded log tail. Default false (fire-and-forget, unchanged response).',
+          ),
+        timeout_seconds: z
+          .number()
+          .optional()
+          .describe(
+            'Max seconds to poll when wait is true before giving up and returning the current status plus a next-action hint (default 300). Ignored when wait is false.',
+          ),
+      },
+      async ({ tag_or_uuid, force, wait, timeout_seconds }) => {
+        if (!wait) {
+          return wrapWithActions(
+            () => this.client.deployByTagOrUuid(tag_or_uuid, force),
+            () => [{ tool: 'list_deployments', args: {}, hint: 'Check deployment status' }],
+          );
+        }
+        return wrapWithActions(
+          () =>
+            this.triggerAndWaitForDeploy(
+              tag_or_uuid,
+              force,
+              timeout_seconds ?? DEFAULT_DEPLOY_TIMEOUT_SECONDS,
+            ),
+          (result) =>
+            'deployment_uuid' in result
+              ? getDeploymentActions(result.deployment_uuid, result.status, result.application_uuid)
+              : [],
+        );
+      },
     );
 
     this.tool(

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -858,6 +858,21 @@ export interface DeployByTagRequest {
   force?: boolean;
 }
 
+/**
+ * Response from `GET /deploy?tag=|uuid=`. A tag can match multiple
+ * applications, so Coolify returns one entry per triggered deployment.
+ * `message` at the top level is kept for backwards compatibility with
+ * older/mocked callers that only ever saw a bare `{ message }`.
+ */
+export interface DeployTriggerResponse {
+  message?: string;
+  deployments?: Array<{
+    message?: string;
+    resource_uuid?: string;
+    deployment_uuid?: string;
+  }>;
+}
+
 // =============================================================================
 // Team Types
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #238

`deploy` used to fire-and-forget: a build could fail (e.g. build container OOM-killed) while the old container kept serving, and the caller never found out — a deployed-looking site that's actually still on stale code.

Adds an opt-in `wait: boolean` (+ `timeout_seconds`, default 300) to the `deploy` tool:

- Triggers the deploy as before, then polls `getDeployment` every ~5s until a terminal status (`finished` / `failed` / `cancelled`) or the timeout elapses.
- **Success**: returns `status`, `deployment_uuid`, `commit`, timestamps, and `duration_seconds`.
- **Failure**: same, plus a bounded log tail (`truncateLogs`, last 30 entries / 10KB) — built from essential fields only, never the raw upstream `Deployment` object (which can carry `server`/`application` secrets — see #232).
- **Timeout**: current status + `timed_out: true` + a `next_action` hint to keep polling via `deployment get`.
- **No-wait path is byte-for-byte unchanged.**

### Multi-deployment tags

A tag can match several applications, so Coolify's `/deploy` response can contain multiple `deployment_uuid`s. This PR **watches only the first** and lists the rest under `additional_deployment_uuids` in the response, so the caller can poll them separately via `deployment get`. Watching all of them concurrently was considered but adds meaningful complexity (parallel polling, combined timeout/status semantics) for a case that's uncommon in practice; the explicit `additional_deployment_uuids` field keeps the behavior discoverable instead of silent.

### Side fix

`deployByTagOrUuid` was typed as `Promise<MessageResponse>` (`{ message: string }`), but Coolify's real `/deploy` response is `{ deployments: [{ message, resource_uuid, deployment_uuid }] }` (confirmed against `docs/openapi-chunks/deployments-api.yaml`). This was a latent "wrong-at-runtime" type (same class of bug as #158), and had to be fixed to extract the deployment uuid(s) to poll. New `DeployTriggerResponse` type added; old `{ message }`-only shape still works for backwards compatibility.

### Test mockability

Poll sleeps use an isolated `sleep()` helper so tests drive them with `jest.useFakeTimers()` + `jest.advanceTimersByTimeAsync()` rather than real waits.

## Test plan

- [x] `npm test` — 369 passed (5 new: success/failure/timeout/no-wait/multi-deployment-first-only)
- [x] `npm run lint` — clean (pre-existing warnings only, no errors)
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — passes
- [x] Verified failure-path test asserts the response never contains `server`/`application`/`private_key`/`env_secret` fields from a raw upstream payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)