### PR TITLE
fix: refresh bundled OpenAPI spec and add client-vs-spec drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Check client-vs-spec drift
+        run: npm run check:spec-drift
+
       - name: Build
         run: npm run build
 

--- a/docs/coolify-openapi.yaml
+++ b/docs/coolify-openapi.yaml
@@ -13,6 +13,13 @@ paths:
       summary: List
       description: 'List all applications.'
       operationId: list-applications
+      parameters:
+        - name: tag
+          in: query
+          description: 'Filter applications by tag name.'
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: 'Get all applications.'
@@ -49,7 +56,6 @@ paths:
                 - git_repository
                 - git_branch
                 - build_pack
-                - ports_exposes
               properties:
                 project_uuid:
                   type: string
@@ -71,7 +77,7 @@ paths:
                   description: 'The git branch.'
                 build_pack:
                   type: string
-                  enum: [nixpacks, static, dockerfile, dockercompose]
+                  enum: [nixpacks, railpack, static, dockerfile, dockercompose]
                   description: 'The build pack type.'
                 ports_exposes:
                   type: string
@@ -87,7 +93,7 @@ paths:
                   description: 'The application description.'
                 domains:
                   type: string
-                  description: 'The application domains.'
+                  description: 'The application URLs in a comma-separated list.'
                 git_commit_sha:
                   type: string
                   description: 'The git commit SHA.'
@@ -100,6 +106,15 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                is_spa:
+                  type: boolean
+                  description: 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'
+                is_auto_deploy_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'
+                is_force_https_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if HTTPS is forced. Defaults to true.'
                 static_image:
                   type: string
                   enum: ['nginx:alpine']
@@ -224,12 +239,12 @@ paths:
                 dockerfile:
                   type: string
                   description: 'The Dockerfile content.'
+                dockerfile_location:
+                  type: string
+                  description: 'The Dockerfile location in the repository.'
                 docker_compose_location:
                   type: string
                   description: 'The Docker Compose location.'
-                docker_compose_raw:
-                  type: string
-                  description: 'The Docker Compose raw content.'
                 docker_compose_custom_start_command:
                   type: string
                   description: 'The Docker Compose custom start command.'
@@ -238,7 +253,24 @@ paths:
                   description: 'The Docker Compose custom build command.'
                 docker_compose_domains:
                   type: array
-                  description: 'The Docker Compose domains.'
+                  description: 'Array of URLs to be applied to containers of a dockercompose application.'
+                  items:
+                    {
+                      properties:
+                        {
+                          name:
+                            {
+                              type: string,
+                              description: 'The service name as defined in docker-compose.',
+                            },
+                          domain:
+                            {
+                              type: string,
+                              description: 'Comma-separated list of URLs (e.g. "https://app.coolify.io,https://app2.coolify.io")',
+                            },
+                        },
+                      type: object,
+                    }
                 watch_paths:
                   type: string
                   description: 'The watch paths.'
@@ -267,6 +299,14 @@ paths:
                   type: boolean
                   default: true
                   description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'
+                is_preserve_repository_enabled:
+                  type: boolean
+                  default: false
+                  description: 'Preserve repository during deployment.'
               type: object
       responses:
         '201':
@@ -348,7 +388,6 @@ paths:
                 - git_repository
                 - git_branch
                 - build_pack
-                - ports_exposes
               properties:
                 project_uuid:
                   type: string
@@ -379,7 +418,7 @@ paths:
                   description: 'The destination UUID.'
                 build_pack:
                   type: string
-                  enum: [nixpacks, static, dockerfile, dockercompose]
+                  enum: [nixpacks, railpack, static, dockerfile, dockercompose]
                   description: 'The build pack type.'
                 name:
                   type: string
@@ -389,7 +428,7 @@ paths:
                   description: 'The application description.'
                 domains:
                   type: string
-                  description: 'The application domains.'
+                  description: 'The application URLs in a comma-separated list.'
                 git_commit_sha:
                   type: string
                   description: 'The git commit SHA.'
@@ -402,6 +441,15 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                is_spa:
+                  type: boolean
+                  description: 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'
+                is_auto_deploy_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'
+                is_force_https_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if HTTPS is forced. Defaults to true.'
                 static_image:
                   type: string
                   enum: ['nginx:alpine']
@@ -526,12 +574,12 @@ paths:
                 dockerfile:
                   type: string
                   description: 'The Dockerfile content.'
+                dockerfile_location:
+                  type: string
+                  description: 'The Dockerfile location in the repository'
                 docker_compose_location:
                   type: string
                   description: 'The Docker Compose location.'
-                docker_compose_raw:
-                  type: string
-                  description: 'The Docker Compose raw content.'
                 docker_compose_custom_start_command:
                   type: string
                   description: 'The Docker Compose custom start command.'
@@ -540,7 +588,24 @@ paths:
                   description: 'The Docker Compose custom build command.'
                 docker_compose_domains:
                   type: array
-                  description: 'The Docker Compose domains.'
+                  description: 'Array of URLs to be applied to containers of a dockercompose application.'
+                  items:
+                    {
+                      properties:
+                        {
+                          name:
+                            {
+                              type: string,
+                              description: 'The service name as defined in docker-compose.',
+                            },
+                          domain:
+                            {
+                              type: string,
+                              description: 'Comma-separated list of URLs (e.g. "https://app.coolify.io,https://app2.coolify.io")',
+                            },
+                        },
+                      type: object,
+                    }
                 watch_paths:
                   type: string
                   description: 'The watch paths.'
@@ -569,6 +634,14 @@ paths:
                   type: boolean
                   default: true
                   description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'
+                is_preserve_repository_enabled:
+                  type: boolean
+                  default: false
+                  description: 'Preserve repository during deployment.'
               type: object
       responses:
         '201':
@@ -650,7 +723,6 @@ paths:
                 - git_repository
                 - git_branch
                 - build_pack
-                - ports_exposes
               properties:
                 project_uuid:
                   type: string
@@ -681,7 +753,7 @@ paths:
                   description: 'The destination UUID.'
                 build_pack:
                   type: string
-                  enum: [nixpacks, static, dockerfile, dockercompose]
+                  enum: [nixpacks, railpack, static, dockerfile, dockercompose]
                   description: 'The build pack type.'
                 name:
                   type: string
@@ -691,7 +763,7 @@ paths:
                   description: 'The application description.'
                 domains:
                   type: string
-                  description: 'The application domains.'
+                  description: 'The application URLs in a comma-separated list.'
                 git_commit_sha:
                   type: string
                   description: 'The git commit SHA.'
@@ -704,6 +776,15 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                is_spa:
+                  type: boolean
+                  description: 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'
+                is_auto_deploy_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'
+                is_force_https_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if HTTPS is forced. Defaults to true.'
                 static_image:
                   type: string
                   enum: ['nginx:alpine']
@@ -828,12 +909,12 @@ paths:
                 dockerfile:
                   type: string
                   description: 'The Dockerfile content.'
+                dockerfile_location:
+                  type: string
+                  description: 'The Dockerfile location in the repository.'
                 docker_compose_location:
                   type: string
                   description: 'The Docker Compose location.'
-                docker_compose_raw:
-                  type: string
-                  description: 'The Docker Compose raw content.'
                 docker_compose_custom_start_command:
                   type: string
                   description: 'The Docker Compose custom start command.'
@@ -842,7 +923,24 @@ paths:
                   description: 'The Docker Compose custom build command.'
                 docker_compose_domains:
                   type: array
-                  description: 'The Docker Compose domains.'
+                  description: 'Array of URLs to be applied to containers of a dockercompose application.'
+                  items:
+                    {
+                      properties:
+                        {
+                          name:
+                            {
+                              type: string,
+                              description: 'The service name as defined in docker-compose.',
+                            },
+                          domain:
+                            {
+                              type: string,
+                              description: 'Comma-separated list of URLs (e.g. "https://app.coolify.io,https://app2.coolify.io")',
+                            },
+                        },
+                      type: object,
+                    }
                 watch_paths:
                   type: string
                   description: 'The watch paths.'
@@ -871,6 +969,14 @@ paths:
                   type: boolean
                   default: true
                   description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'
+                is_preserve_repository_enabled:
+                  type: boolean
+                  default: false
+                  description: 'Preserve repository during deployment.'
               type: object
       responses:
         '201':
@@ -934,8 +1040,8 @@ paths:
     post:
       tags:
         - Applications
-      summary: 'Create (Dockerfile)'
-      description: 'Create new application based on a simple Dockerfile.'
+      summary: 'Create (Dockerfile without git)'
+      description: 'Create new application based on a simple Dockerfile (without git).'
       operationId: create-dockerfile-application
       requestBody:
         description: 'Application object that needs to be created.'
@@ -967,7 +1073,7 @@ paths:
                   description: 'The Dockerfile content.'
                 build_pack:
                   type: string
-                  enum: [nixpacks, static, dockerfile, dockercompose]
+                  enum: [dockerfile]
                   description: 'The build pack type.'
                 ports_exposes:
                   type: string
@@ -983,7 +1089,7 @@ paths:
                   description: 'The application description.'
                 domains:
                   type: string
-                  description: 'The application domains.'
+                  description: 'The application URLs in a comma-separated list.'
                 docker_registry_image_name:
                   type: string
                   description: 'The docker registry image name.'
@@ -1095,6 +1201,9 @@ paths:
                 instant_deploy:
                   type: boolean
                   description: 'The flag to indicate if the application should be deployed instantly.'
+                is_force_https_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if HTTPS is forced. Defaults to true.'
                 use_build_server:
                   type: boolean
                   nullable: true
@@ -1120,6 +1229,10 @@ paths:
                   type: boolean
                   default: true
                   description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'
               type: object
       responses:
         '201':
@@ -1183,8 +1296,8 @@ paths:
     post:
       tags:
         - Applications
-      summary: 'Create (Docker Image)'
-      description: 'Create new application based on a prebuilt docker image'
+      summary: 'Create (Docker Image without git)'
+      description: 'Create new application based on a prebuilt docker image (without git).'
       operationId: create-dockerimage-application
       requestBody:
         description: 'Application object that needs to be created.'
@@ -1198,7 +1311,6 @@ paths:
                 - environment_name
                 - environment_uuid
                 - docker_registry_image_name
-                - ports_exposes
               properties:
                 project_uuid:
                   type: string
@@ -1232,7 +1344,7 @@ paths:
                   description: 'The application description.'
                 domains:
                   type: string
-                  description: 'The application domains.'
+                  description: 'The application URLs in a comma-separated list.'
                 ports_mappings:
                   type: string
                   description: 'The ports mappings.'
@@ -1335,6 +1447,9 @@ paths:
                 instant_deploy:
                   type: boolean
                   description: 'The flag to indicate if the application should be deployed instantly.'
+                is_force_https_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if HTTPS is forced. Defaults to true.'
                 use_build_server:
                   type: boolean
                   nullable: true
@@ -1360,122 +1475,10 @@ paths:
                   type: boolean
                   default: true
                   description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
-              type: object
-      responses:
-        '201':
-          description: 'Application created successfully.'
-          content:
-            application/json:
-              schema:
-                properties:
-                  uuid: { type: string }
-                type: object
-        '401':
-          $ref: '#/components/responses/401'
-        '400':
-          $ref: '#/components/responses/400'
-        '409':
-          description: 'Domain conflicts detected.'
-          content:
-            application/json:
-              schema:
-                properties:
-                  message:
-                    {
-                      type: string,
-                      example: 'Domain conflicts detected. Use force_domain_override=true to proceed.',
-                    }
-                  warning:
-                    {
-                      type: string,
-                      example: 'Using the same domain for multiple resources can cause routing conflicts and unpredictable behavior.',
-                    }
-                  conflicts:
-                    {
-                      type: array,
-                      items:
-                        {
-                          properties:
-                            {
-                              domain: { type: string, example: example.com },
-                              resource_name: { type: string, example: 'My Application' },
-                              resource_uuid:
-                                { type: string, nullable: true, example: abc123-def456 },
-                              resource_type:
-                                {
-                                  type: string,
-                                  enum: [application, service, instance],
-                                  example: application,
-                                },
-                              message:
-                                {
-                                  type: string,
-                                  example: "Domain example.com is already in use by application 'My Application'",
-                                },
-                            },
-                          type: object,
-                        },
-                    }
-                type: object
-      security:
-        - bearerAuth: []
-  /applications/dockercompose:
-    post:
-      tags:
-        - Applications
-      summary: 'Create (Docker Compose)'
-      description: 'Create new application based on a docker-compose file.'
-      operationId: create-dockercompose-application
-      requestBody:
-        description: 'Application object that needs to be created.'
-        required: true
-        content:
-          application/json:
-            schema:
-              required:
-                - project_uuid
-                - server_uuid
-                - environment_name
-                - environment_uuid
-                - docker_compose_raw
-              properties:
-                project_uuid:
-                  type: string
-                  description: 'The project UUID.'
-                server_uuid:
-                  type: string
-                  description: 'The server UUID.'
-                environment_name:
-                  type: string
-                  description: 'The environment name. You need to provide at least one of environment_name or environment_uuid.'
-                environment_uuid:
-                  type: string
-                  description: 'The environment UUID. You need to provide at least one of environment_name or environment_uuid.'
-                docker_compose_raw:
-                  type: string
-                  description: 'The Docker Compose raw content.'
-                destination_uuid:
-                  type: string
-                  description: 'The destination UUID if the server has more than one destinations.'
-                name:
-                  type: string
-                  description: 'The application name.'
-                description:
-                  type: string
-                  description: 'The application description.'
-                instant_deploy:
+                is_container_label_escape_enabled:
                   type: boolean
-                  description: 'The flag to indicate if the application should be deployed instantly.'
-                use_build_server:
-                  type: boolean
-                  nullable: true
-                  description: 'Use build server.'
-                connect_to_docker_network:
-                  type: boolean
-                  description: 'The flag to connect the service to the predefined Docker network.'
-                force_domain_override:
-                  type: boolean
-                  description: 'Force domain usage even if conflicts are detected. Default is false.'
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'
               type: object
       responses:
         '201':
@@ -1549,7 +1552,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Get application by UUID.'
@@ -1578,7 +1580,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: delete_configurations
           in: query
           description: 'Delete configurations.'
@@ -1637,7 +1638,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Application updated.'
         required: true
@@ -1671,7 +1671,7 @@ paths:
                   description: 'The destination UUID.'
                 build_pack:
                   type: string
-                  enum: [nixpacks, static, dockerfile, dockercompose]
+                  enum: [nixpacks, railpack, static, dockerfile, dockercompose]
                   description: 'The build pack type.'
                 name:
                   type: string
@@ -1681,7 +1681,7 @@ paths:
                   description: 'The application description.'
                 domains:
                   type: string
-                  description: 'The application domains.'
+                  description: 'The application URLs in a comma-separated list.'
                 git_commit_sha:
                   type: string
                   description: 'The git commit SHA.'
@@ -1694,6 +1694,15 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                is_spa:
+                  type: boolean
+                  description: 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'
+                is_auto_deploy_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'
+                is_force_https_enabled:
+                  type: boolean
+                  description: 'The flag to indicate if HTTPS is forced. Defaults to true.'
                 install_command:
                   type: string
                   description: 'The install command.'
@@ -1814,12 +1823,12 @@ paths:
                 dockerfile:
                   type: string
                   description: 'The Dockerfile content.'
+                dockerfile_location:
+                  type: string
+                  description: 'The Dockerfile location in the repository.'
                 docker_compose_location:
                   type: string
                   description: 'The Docker Compose location.'
-                docker_compose_raw:
-                  type: string
-                  description: 'The Docker Compose raw content.'
                 docker_compose_custom_start_command:
                   type: string
                   description: 'The Docker Compose custom start command.'
@@ -1828,7 +1837,24 @@ paths:
                   description: 'The Docker Compose custom build command.'
                 docker_compose_domains:
                   type: array
-                  description: 'The Docker Compose domains.'
+                  description: 'Array of URLs to be applied to containers of a dockercompose application.'
+                  items:
+                    {
+                      properties:
+                        {
+                          name:
+                            {
+                              type: string,
+                              description: 'The service name as defined in docker-compose.',
+                            },
+                          domain:
+                            {
+                              type: string,
+                              description: 'Comma-separated list of URLs (e.g. "https://app.coolify.io,https://app2.coolify.io")',
+                            },
+                        },
+                      type: object,
+                    }
                 watch_paths:
                   type: string
                   description: 'The watch paths.'
@@ -1842,6 +1868,13 @@ paths:
                 force_domain_override:
                   type: boolean
                   description: 'Force domain usage even if conflicts are detected. Default is false.'
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'
+                is_preserve_repository_enabled:
+                  type: boolean
+                  description: 'Preserve git repository during application update. If false, the existing repository will be removed and replaced with the new one. If true, the existing repository will be kept and the new one will be ignored. Default is false.'
               type: object
       responses:
         '200':
@@ -1917,7 +1950,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: lines
           in: query
           description: 'Number of lines to show from the end of the logs.'
@@ -1957,7 +1989,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'All environment variables by application UUID.'
@@ -1988,7 +2019,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Env created.'
         required: true
@@ -2045,7 +2075,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Env updated.'
         required: true
@@ -2081,9 +2110,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  message: { type: string, example: 'Environment variable updated.' }
-                type: object
+                $ref: '#/components/schemas/EnvironmentVariable'
         '401':
           $ref: '#/components/responses/401'
         '400':
@@ -2106,7 +2133,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Bulk envs updated.'
         required: true
@@ -2156,9 +2182,9 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  message: { type: string, example: 'Environment variables updated.' }
-                type: object
+                type: array
+                items:
+                  $ref: '#/components/schemas/EnvironmentVariable'
         '401':
           $ref: '#/components/responses/401'
         '400':
@@ -2181,14 +2207,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: env_uuid
           in: path
           description: 'UUID of the environment variable.'
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Environment variable deleted.'
@@ -2220,7 +2244,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: force
           in: query
           description: 'Force rebuild.'
@@ -2267,7 +2290,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+        - name: docker_cleanup
+          in: query
+          description: 'Perform docker cleanup (prune networks, volumes, etc.).'
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'Stop application.'
@@ -2299,7 +2327,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Restart application.'
@@ -2317,6 +2344,249 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+  '/applications/{uuid}/storages':
+    get:
+      tags:
+        - Applications
+      summary: 'List Storages'
+      description: 'List all persistent storages and file storages by application UUID.'
+      operationId: list-storages-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'All storages by application UUID.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  persistent_storages: { type: array, items: { type: object } }
+                  file_storages: { type: array, items: { type: object } }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Applications
+      summary: 'Create Storage'
+      description: 'Create a persistent storage or file storage for an application.'
+      operationId: create-storage-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - mount_path
+              properties:
+                type:
+                  type: string
+                  enum: [persistent, file]
+                  description: 'The type of storage.'
+                name:
+                  type: string
+                  description: 'Volume name (persistent only, required for persistent).'
+                mount_path:
+                  type: string
+                  description: 'The container mount path.'
+                host_path:
+                  type: string
+                  nullable: true
+                  description: 'The host path (persistent only, optional).'
+                content:
+                  type: string
+                  nullable: true
+                  description: 'File content (file only, optional).'
+                is_directory:
+                  type: boolean
+                  description: 'Whether this is a directory mount (file only, default false).'
+                fs_path:
+                  type: string
+                  description: 'Host directory path (required when is_directory is true).'
+              type: object
+              additionalProperties: false
+      responses:
+        '201':
+          description: 'Storage created.'
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Applications
+      summary: 'Update Storage'
+      description: 'Update a persistent storage or file storage by application UUID.'
+      operationId: update-storage-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Storage updated. For read-only storages (from docker-compose or services), only is_preview_suffix_enabled can be updated.'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+              properties:
+                uuid:
+                  type: string
+                  description: 'The UUID of the storage (preferred).'
+                id:
+                  type: integer
+                  description: 'The ID of the storage (deprecated, use uuid instead).'
+                type:
+                  type: string
+                  enum: [persistent, file]
+                  description: 'The type of storage: persistent or file.'
+                is_preview_suffix_enabled:
+                  type: boolean
+                  description: 'Whether to add -pr-N suffix for preview deployments.'
+                name:
+                  type: string
+                  description: 'The volume name (persistent only, not allowed for read-only storages).'
+                mount_path:
+                  type: string
+                  description: 'The container mount path (not allowed for read-only storages).'
+                host_path:
+                  type: string
+                  nullable: true
+                  description: 'The host path (persistent only, not allowed for read-only storages).'
+                content:
+                  type: string
+                  nullable: true
+                  description: 'The file content (file only, not allowed for read-only storages).'
+              type: object
+              additionalProperties: false
+      responses:
+        '200':
+          description: 'Storage updated.'
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/applications/{uuid}/storages/{storage_uuid}':
+    delete:
+      tags:
+        - Applications
+      summary: 'Delete Storage'
+      description: 'Delete a persistent storage or file storage by application UUID.'
+      operationId: delete-storage-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+        - name: storage_uuid
+          in: path
+          description: 'UUID of the storage.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Storage deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/applications/{uuid}/previews/{pull_request_id}':
+    delete:
+      tags:
+        - Applications
+      summary: 'Delete Preview Deployment'
+      description: 'Delete a preview deployment for a pull request. Cancels active deployments, stops containers, removes volumes/networks, and deletes the preview record.'
+      operationId: delete-preview-deployment-by-pull-request-id
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+        - name: pull_request_id
+          in: path
+          description: 'Pull request ID of the preview to delete.'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Preview deletion queued.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         - bearerAuth: []
   /cloud-tokens:
@@ -2447,7 +2717,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Cloud provider token deleted.'
@@ -2571,7 +2840,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Get all backups for a database'
@@ -2601,7 +2869,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Backup configuration data'
         required: true
@@ -2642,8 +2909,8 @@ paths:
                   type: integer
                   description: 'Number of days to retain backups locally'
                 database_backup_retention_max_storage_locally:
-                  type: integer
-                  description: 'Max storage (MB) for local backups'
+                  type: number
+                  description: 'Max storage (GB) for local backups'
                 database_backup_retention_amount_s3:
                   type: integer
                   description: 'Number of backups to retain in S3'
@@ -2651,8 +2918,12 @@ paths:
                   type: integer
                   description: 'Number of days to retain backups in S3'
                 database_backup_retention_max_storage_s3:
+                  type: number
+                  description: 'Max storage (GB) for S3 backups'
+                timeout:
                   type: integer
-                  description: 'Max storage (MB) for S3 backups'
+                  description: 'Backup job timeout in seconds (min: 60, max: 36000)'
+                  default: 3600
               type: object
       responses:
         '201':
@@ -2689,7 +2960,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Get all databases'
@@ -2719,7 +2989,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: delete_configurations
           in: query
           description: 'Delete configurations.'
@@ -2778,7 +3047,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Database data'
         required: true
@@ -2801,6 +3069,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -2903,6 +3174,30 @@ paths:
                 mysql_conf:
                   type: string
                   description: 'MySQL conf'
+                health_check_enabled:
+                  type: boolean
+                  description: 'Enable the database healthcheck probe.'
+                  default: true
+                health_check_interval:
+                  type: integer
+                  description: 'Healthcheck interval in seconds.'
+                  minimum: 1
+                  default: 15
+                health_check_timeout:
+                  type: integer
+                  description: 'Healthcheck timeout in seconds.'
+                  minimum: 1
+                  default: 5
+                health_check_retries:
+                  type: integer
+                  description: 'Healthcheck retries count.'
+                  minimum: 1
+                  default: 5
+                health_check_start_period:
+                  type: integer
+                  description: 'Healthcheck start period in seconds.'
+                  minimum: 0
+                  default: 5
               type: object
       responses:
         '200':
@@ -2937,7 +3232,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: delete_s3
           in: query
           description: 'Whether to delete all backup files from S3'
@@ -2978,14 +3272,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: scheduled_backup_uuid
           in: path
           description: 'UUID of the backup configuration.'
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Database backup configuration data'
         required: true
@@ -3021,7 +3313,7 @@ paths:
                   type: integer
                   description: 'Retention days of the backup locally'
                 database_backup_retention_max_storage_locally:
-                  type: integer
+                  type: number
                   description: 'Max storage of the backup locally'
                 database_backup_retention_amount_s3:
                   type: integer
@@ -3030,8 +3322,12 @@ paths:
                   type: integer
                   description: 'Retention days of the backup in s3'
                 database_backup_retention_max_storage_s3:
-                  type: integer
+                  type: number
                   description: 'Max storage of the backup in S3'
+                timeout:
+                  type: integer
+                  description: 'Backup job timeout in seconds (min: 60, max: 36000)'
+                  default: 3600
               type: object
       responses:
         '200':
@@ -3113,6 +3409,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3204,6 +3503,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3292,6 +3594,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3383,6 +3688,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3474,6 +3782,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3574,6 +3885,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3674,6 +3988,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3765,6 +4082,9 @@ paths:
                 public_port:
                   type: integer
                   description: 'Public port of the database'
+                public_port_timeout:
+                  type: integer
+                  description: 'Public port timeout in seconds (default: 3600)'
                 limits_memory:
                   type: string
                   description: 'Memory limit of the database'
@@ -3821,14 +4141,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: execution_uuid
           in: path
           description: 'UUID of the backup execution to delete'
           required: true
           schema:
             type: string
-            format: uuid
         - name: delete_s3
           in: query
           description: 'Whether to delete the backup from S3'
@@ -3875,7 +4193,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'List of backup executions'
@@ -3919,7 +4236,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Start database.'
@@ -3951,7 +4267,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+        - name: docker_cleanup
+          in: query
+          description: 'Perform docker cleanup (prune networks, volumes, etc.).'
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'Stop database.'
@@ -3983,7 +4304,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Restart database.'
@@ -3999,6 +4319,460 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+  '/databases/{uuid}/envs':
+    get:
+      tags:
+        - Databases
+      summary: 'List Envs'
+      description: 'List all envs by database UUID.'
+      operationId: list-envs-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Environment variables.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EnvironmentVariable'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Databases
+      summary: 'Create Env'
+      description: 'Create env by database UUID.'
+      operationId: create-env-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Env created.'
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                key:
+                  type: string
+                  description: 'The key of the environment variable.'
+                value:
+                  type: string
+                  description: 'The value of the environment variable.'
+                is_literal:
+                  type: boolean
+                  description: 'The flag to indicate if the environment variable is a literal, nothing espaced.'
+                is_multiline:
+                  type: boolean
+                  description: 'The flag to indicate if the environment variable is multiline.'
+                is_shown_once:
+                  type: boolean
+                  description: "The flag to indicate if the environment variable's value is shown on the UI."
+              type: object
+      responses:
+        '201':
+          description: 'Environment variable created.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  uuid: { type: string, example: nc0k04gk8g0cgsk440g0koko }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Databases
+      summary: 'Update Env'
+      description: 'Update env by database UUID.'
+      operationId: update-env-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Env updated.'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - key
+                - value
+              properties:
+                key:
+                  type: string
+                  description: 'The key of the environment variable.'
+                value:
+                  type: string
+                  description: 'The value of the environment variable.'
+                is_literal:
+                  type: boolean
+                  description: 'The flag to indicate if the environment variable is a literal, nothing espaced.'
+                is_multiline:
+                  type: boolean
+                  description: 'The flag to indicate if the environment variable is multiline.'
+                is_shown_once:
+                  type: boolean
+                  description: "The flag to indicate if the environment variable's value is shown on the UI."
+              type: object
+      responses:
+        '201':
+          description: 'Environment variable updated.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/databases/{uuid}/envs/bulk':
+    patch:
+      tags:
+        - Databases
+      summary: 'Update Envs (Bulk)'
+      description: 'Update multiple envs by database UUID.'
+      operationId: update-envs-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Bulk envs updated.'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    {
+                      properties:
+                        {
+                          key:
+                            { type: string, description: 'The key of the environment variable.' },
+                          value:
+                            { type: string, description: 'The value of the environment variable.' },
+                          is_literal:
+                            {
+                              type: boolean,
+                              description: 'The flag to indicate if the environment variable is a literal, nothing espaced.',
+                            },
+                          is_multiline:
+                            {
+                              type: boolean,
+                              description: 'The flag to indicate if the environment variable is multiline.',
+                            },
+                          is_shown_once:
+                            {
+                              type: boolean,
+                              description: "The flag to indicate if the environment variable's value is shown on the UI.",
+                            },
+                        },
+                      type: object,
+                    }
+              type: object
+      responses:
+        '201':
+          description: 'Environment variables updated.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EnvironmentVariable'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/databases/{uuid}/envs/{env_uuid}':
+    delete:
+      tags:
+        - Databases
+      summary: 'Delete Env'
+      description: 'Delete env by UUID.'
+      operationId: delete-env-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+        - name: env_uuid
+          in: path
+          description: 'UUID of the environment variable.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Environment variable deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string, example: 'Environment variable deleted.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+  '/databases/{uuid}/storages':
+    get:
+      tags:
+        - Databases
+      summary: 'List Storages'
+      description: 'List all persistent storages and file storages by database UUID.'
+      operationId: list-storages-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'All storages by database UUID.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  persistent_storages: { type: array, items: { type: object } }
+                  file_storages: { type: array, items: { type: object } }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Databases
+      summary: 'Create Storage'
+      description: 'Create a persistent storage or file storage for a database.'
+      operationId: create-storage-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - mount_path
+              properties:
+                type:
+                  type: string
+                  enum: [persistent, file]
+                  description: 'The type of storage.'
+                name:
+                  type: string
+                  description: 'Volume name (persistent only, required for persistent).'
+                mount_path:
+                  type: string
+                  description: 'The container mount path.'
+                host_path:
+                  type: string
+                  nullable: true
+                  description: 'The host path (persistent only, optional).'
+                content:
+                  type: string
+                  nullable: true
+                  description: 'File content (file only, optional).'
+                is_directory:
+                  type: boolean
+                  description: 'Whether this is a directory mount (file only, default false).'
+                fs_path:
+                  type: string
+                  description: 'Host directory path (required when is_directory is true).'
+              type: object
+              additionalProperties: false
+      responses:
+        '201':
+          description: 'Storage created.'
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Databases
+      summary: 'Update Storage'
+      description: 'Update a persistent storage or file storage by database UUID.'
+      operationId: update-storage-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Storage updated. For read-only storages (from docker-compose or services), only is_preview_suffix_enabled can be updated.'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+              properties:
+                uuid:
+                  type: string
+                  description: 'The UUID of the storage (preferred).'
+                id:
+                  type: integer
+                  description: 'The ID of the storage (deprecated, use uuid instead).'
+                type:
+                  type: string
+                  enum: [persistent, file]
+                  description: 'The type of storage: persistent or file.'
+                is_preview_suffix_enabled:
+                  type: boolean
+                  description: 'Whether to add -pr-N suffix for preview deployments.'
+                name:
+                  type: string
+                  description: 'The volume name (persistent only, not allowed for read-only storages).'
+                mount_path:
+                  type: string
+                  description: 'The container mount path (not allowed for read-only storages).'
+                host_path:
+                  type: string
+                  nullable: true
+                  description: 'The host path (persistent only, not allowed for read-only storages).'
+                content:
+                  type: string
+                  nullable: true
+                  description: 'The file content (file only, not allowed for read-only storages).'
+              type: object
+              additionalProperties: false
+      responses:
+        '200':
+          description: 'Storage updated.'
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/databases/{uuid}/storages/{storage_uuid}':
+    delete:
+      tags:
+        - Databases
+      summary: 'Delete Storage'
+      description: 'Delete a persistent storage or file storage by database UUID.'
+      operationId: delete-storage-by-database-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the database.'
+          required: true
+          schema:
+            type: string
+        - name: storage_uuid
+          in: path
+          description: 'UUID of the storage.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Storage deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         - bearerAuth: []
   /deployments:
@@ -4135,6 +4909,16 @@ paths:
           description: 'Pull Request Id for deploying specific PR builds. Cannot be used with tag parameter.'
           schema:
             type: integer
+        - name: pull_request_id
+          in: query
+          description: 'Preview deployment identifier. Alias of pr.'
+          schema:
+            type: integer
+        - name: docker_tag
+          in: query
+          description: 'Docker image tag for Docker Image preview deployments. Requires pull_request_id.'
+          schema:
+            type: string
       responses:
         '200':
           description: "Get deployment(s) UUID's"
@@ -4177,7 +4961,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: skip
           in: query
           description: 'Number of records to skip.'
@@ -4907,6 +5690,64 @@ paths:
           $ref: '#/components/responses/400'
       security:
         - bearerAuth: []
+  /mcp/enable:
+    post:
+      summary: 'Enable MCP Server'
+      description: 'Enable the MCP server endpoint at /mcp (only with root permissions).'
+      operationId: enable-mcp
+      responses:
+        '200':
+          description: 'MCP server enabled.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string, example: 'MCP server enabled.' }
+                type: object
+        '403':
+          description: 'You are not allowed to enable the MCP server.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    { type: string, example: 'You are not allowed to enable the MCP server.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+      security:
+        - bearerAuth: []
+  /mcp/disable:
+    post:
+      summary: 'Disable MCP Server'
+      description: 'Disable the MCP server endpoint at /mcp (only with root permissions).'
+      operationId: disable-mcp
+      responses:
+        '200':
+          description: 'MCP server disabled.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string, example: 'MCP server disabled.' }
+                type: object
+        '403':
+          description: 'You are not allowed to disable the MCP server.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    { type: string, example: 'You are not allowed to disable the MCP server.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+      security:
+        - bearerAuth: []
   /health:
     get:
       summary: Healthcheck
@@ -5027,7 +5868,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Project deleted.'
@@ -5060,7 +5900,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Project updated.'
         required: true
@@ -5270,6 +6109,452 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+      security:
+        - bearerAuth: []
+  '/applications/{uuid}/scheduled-tasks':
+    get:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'List Tasks'
+      description: 'List all scheduled tasks for an application.'
+      operationId: list-scheduled-tasks-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Get all scheduled tasks for an application.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScheduledTask'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'Create Task'
+      description: 'Create a new scheduled task for an application.'
+      operationId: create-scheduled-task-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Scheduled task data'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - command
+                - frequency
+              properties:
+                name:
+                  type: string
+                  description: 'The name of the scheduled task.'
+                command:
+                  type: string
+                  description: 'The command to execute.'
+                frequency:
+                  type: string
+                  description: 'The frequency of the scheduled task.'
+                container:
+                  type: string
+                  nullable: true
+                  description: 'The container where the command should be executed.'
+                timeout:
+                  type: integer
+                  description: 'The timeout of the scheduled task in seconds.'
+                  default: 300
+                enabled:
+                  type: boolean
+                  description: 'The flag to indicate if the scheduled task is enabled.'
+                  default: true
+              type: object
+      responses:
+        '201':
+          description: 'Scheduled task created.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTask'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/applications/{uuid}/scheduled-tasks/{task_uuid}':
+    delete:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'Delete Task'
+      description: 'Delete a scheduled task for an application.'
+      operationId: delete-scheduled-task-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+        - name: task_uuid
+          in: path
+          description: 'UUID of the scheduled task.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Scheduled task deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string, example: 'Scheduled task deleted.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'Update Task'
+      description: 'Update a scheduled task for an application.'
+      operationId: update-scheduled-task-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+        - name: task_uuid
+          in: path
+          description: 'UUID of the scheduled task.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Scheduled task data'
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  description: 'The name of the scheduled task.'
+                command:
+                  type: string
+                  description: 'The command to execute.'
+                frequency:
+                  type: string
+                  description: 'The frequency of the scheduled task.'
+                container:
+                  type: string
+                  nullable: true
+                  description: 'The container where the command should be executed.'
+                timeout:
+                  type: integer
+                  description: 'The timeout of the scheduled task in seconds.'
+                  default: 300
+                enabled:
+                  type: boolean
+                  description: 'The flag to indicate if the scheduled task is enabled.'
+                  default: true
+              type: object
+      responses:
+        '200':
+          description: 'Scheduled task updated.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTask'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/applications/{uuid}/scheduled-tasks/{task_uuid}/executions':
+    get:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'List Executions'
+      description: 'List all executions for a scheduled task on an application.'
+      operationId: list-scheduled-task-executions-by-application-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+        - name: task_uuid
+          in: path
+          description: 'UUID of the scheduled task.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Get all executions for a scheduled task.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScheduledTaskExecution'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+  '/services/{uuid}/scheduled-tasks':
+    get:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'List Tasks'
+      description: 'List all scheduled tasks for a service.'
+      operationId: list-scheduled-tasks-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Get all scheduled tasks for a service.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScheduledTask'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'Create Task'
+      description: 'Create a new scheduled task for a service.'
+      operationId: create-scheduled-task-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Scheduled task data'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - command
+                - frequency
+              properties:
+                name:
+                  type: string
+                  description: 'The name of the scheduled task.'
+                command:
+                  type: string
+                  description: 'The command to execute.'
+                frequency:
+                  type: string
+                  description: 'The frequency of the scheduled task.'
+                container:
+                  type: string
+                  nullable: true
+                  description: 'The container where the command should be executed.'
+                timeout:
+                  type: integer
+                  description: 'The timeout of the scheduled task in seconds.'
+                  default: 300
+                enabled:
+                  type: boolean
+                  description: 'The flag to indicate if the scheduled task is enabled.'
+                  default: true
+              type: object
+      responses:
+        '201':
+          description: 'Scheduled task created.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTask'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/services/{uuid}/scheduled-tasks/{task_uuid}':
+    delete:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'Delete Task'
+      description: 'Delete a scheduled task for a service.'
+      operationId: delete-scheduled-task-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+        - name: task_uuid
+          in: path
+          description: 'UUID of the scheduled task.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Scheduled task deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string, example: 'Scheduled task deleted.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'Update Task'
+      description: 'Update a scheduled task for a service.'
+      operationId: update-scheduled-task-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+        - name: task_uuid
+          in: path
+          description: 'UUID of the scheduled task.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Scheduled task data'
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  description: 'The name of the scheduled task.'
+                command:
+                  type: string
+                  description: 'The command to execute.'
+                frequency:
+                  type: string
+                  description: 'The frequency of the scheduled task.'
+                container:
+                  type: string
+                  nullable: true
+                  description: 'The container where the command should be executed.'
+                timeout:
+                  type: integer
+                  description: 'The timeout of the scheduled task in seconds.'
+                  default: 300
+                enabled:
+                  type: boolean
+                  description: 'The flag to indicate if the scheduled task is enabled.'
+                  default: true
+              type: object
+      responses:
+        '200':
+          description: 'Scheduled task updated.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTask'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/services/{uuid}/scheduled-tasks/{task_uuid}/executions':
+    get:
+      tags:
+        - 'Scheduled Tasks'
+      summary: 'List Executions'
+      description: 'List all executions for a scheduled task on a service.'
+      operationId: list-scheduled-task-executions-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+        - name: task_uuid
+          in: path
+          description: 'UUID of the scheduled task.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Get all executions for a scheduled task.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScheduledTaskExecution'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
       security:
         - bearerAuth: []
   /security/keys:
@@ -5573,7 +6858,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Server deleted.'
@@ -5641,6 +6925,24 @@ paths:
                   type: string
                   enum: [traefik, caddy, none]
                   description: 'The proxy type.'
+                concurrent_builds:
+                  type: integer
+                  description: 'Number of concurrent builds.'
+                dynamic_timeout:
+                  type: integer
+                  description: 'Deployment timeout in seconds.'
+                deployment_queue_limit:
+                  type: integer
+                  description: 'Maximum number of queued deployments.'
+                server_disk_usage_notification_threshold:
+                  type: integer
+                  description: 'Server disk usage notification threshold (%).'
+                server_disk_usage_check_frequency:
+                  type: string
+                  description: 'Cron expression for disk usage check frequency.'
+                connection_timeout:
+                  type: integer
+                  description: 'SSH connection timeout in seconds (1-300). Default: 10.'
               type: object
       responses:
         '201':
@@ -5802,97 +7104,8 @@ paths:
                 - environment_uuid
               properties:
                 type:
-                  description: 'The one-click service type'
+                  description: 'The one-click service type (e.g. "actualbudget", "calibre-web", "gitea-with-mysql" ...)'
                   type: string
-                  enum:
-                    [
-                      activepieces,
-                      appsmith,
-                      appwrite,
-                      authentik,
-                      babybuddy,
-                      budge,
-                      changedetection,
-                      chatwoot,
-                      classicpress-with-mariadb,
-                      classicpress-with-mysql,
-                      classicpress-without-database,
-                      cloudflared,
-                      code-server,
-                      dashboard,
-                      directus,
-                      directus-with-postgresql,
-                      docker-registry,
-                      docuseal,
-                      docuseal-with-postgres,
-                      dokuwiki,
-                      duplicati,
-                      emby,
-                      embystat,
-                      fider,
-                      filebrowser,
-                      firefly,
-                      formbricks,
-                      ghost,
-                      gitea,
-                      gitea-with-mariadb,
-                      gitea-with-mysql,
-                      gitea-with-postgresql,
-                      glance,
-                      glances,
-                      glitchtip,
-                      grafana,
-                      grafana-with-postgresql,
-                      grocy,
-                      heimdall,
-                      homepage,
-                      jellyfin,
-                      kuzzle,
-                      listmonk,
-                      logto,
-                      mediawiki,
-                      meilisearch,
-                      metabase,
-                      metube,
-                      minio,
-                      moodle,
-                      n8n,
-                      n8n-with-postgresql,
-                      next-image-transformation,
-                      nextcloud,
-                      nocodb,
-                      odoo,
-                      openblocks,
-                      pairdrop,
-                      penpot,
-                      phpmyadmin,
-                      pocketbase,
-                      posthog,
-                      reactive-resume,
-                      rocketchat,
-                      shlink,
-                      slash,
-                      snapdrop,
-                      statusnook,
-                      stirling-pdf,
-                      supabase,
-                      syncthing,
-                      tolgee,
-                      trigger,
-                      trigger-with-external-database,
-                      twenty,
-                      umami,
-                      unleash-with-postgresql,
-                      unleash-without-database,
-                      uptime-kuma,
-                      vaultwarden,
-                      vikunja,
-                      weblate,
-                      whoogle,
-                      wordpress-with-mariadb,
-                      wordpress-with-mysql,
-                      wordpress-without-database,
-                    ]
                 name:
                   type: string
                   maxLength: 255
@@ -5922,7 +7135,35 @@ paths:
                   description: 'Start the service immediately after creation.'
                 docker_compose_raw:
                   type: string
-                  description: 'The Docker Compose raw content.'
+                  description: 'The base64 encoded Docker Compose content.'
+                urls:
+                  type: array
+                  description: 'Array of URLs to be applied to containers of a service.'
+                  items:
+                    {
+                      properties:
+                        {
+                          name:
+                            {
+                              type: string,
+                              description: 'The service name as defined in docker-compose.',
+                            },
+                          url:
+                            {
+                              type: string,
+                              description: 'Comma-separated list of URLs (e.g. "https://app.coolify.io,https://app2.coolify.io").',
+                            },
+                        },
+                      type: object,
+                    }
+                force_domain_override:
+                  type: boolean
+                  default: false
+                  description: 'Force domain override even if conflicts are detected.'
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. If you want to use env variables inside the labels, turn this off.'
               type: object
       responses:
         '201':
@@ -5938,6 +7179,49 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '409':
+          description: 'Domain conflicts detected.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    {
+                      type: string,
+                      example: 'Domain conflicts detected. Use force_domain_override=true to proceed.',
+                    }
+                  warning:
+                    {
+                      type: string,
+                      example: 'Using the same domain for multiple resources can cause routing conflicts and unpredictable behavior.',
+                    }
+                  conflicts:
+                    {
+                      type: array,
+                      items:
+                        {
+                          properties:
+                            {
+                              domain: { type: string, example: example.com },
+                              resource_name: { type: string, example: 'My Application' },
+                              resource_uuid:
+                                { type: string, nullable: true, example: abc123-def456 },
+                              resource_type:
+                                {
+                                  type: string,
+                                  enum: [application, service, instance],
+                                  example: application,
+                                },
+                              message:
+                                {
+                                  type: string,
+                                  example: "Domain example.com is already in use by application 'My Application'",
+                                },
+                            },
+                          type: object,
+                        },
+                    }
+                type: object
         '422':
           $ref: '#/components/responses/422'
       security:
@@ -6042,7 +7326,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Service updated.'
         required: true
@@ -6080,7 +7363,35 @@ paths:
                   description: 'Connect the service to the predefined docker network.'
                 docker_compose_raw:
                   type: string
-                  description: 'The Docker Compose raw content.'
+                  description: 'The base64 encoded Docker Compose content.'
+                urls:
+                  type: array
+                  description: 'Array of URLs to be applied to containers of a service.'
+                  items:
+                    {
+                      properties:
+                        {
+                          name:
+                            {
+                              type: string,
+                              description: 'The service name as defined in docker-compose.',
+                            },
+                          url:
+                            {
+                              type: string,
+                              description: 'Comma-separated list of URLs (e.g. "https://app.coolify.io,https://app2.coolify.io").',
+                            },
+                        },
+                      type: object,
+                    }
+                force_domain_override:
+                  type: boolean
+                  default: false
+                  description: 'Force domain override even if conflicts are detected.'
+                is_container_label_escape_enabled:
+                  type: boolean
+                  default: true
+                  description: 'Escape special characters in labels. By default, $ (and other chars) is escaped. If you want to use env variables inside the labels, turn this off.'
               type: object
       responses:
         '200':
@@ -6098,6 +7409,49 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          description: 'Domain conflicts detected.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    {
+                      type: string,
+                      example: 'Domain conflicts detected. Use force_domain_override=true to proceed.',
+                    }
+                  warning:
+                    {
+                      type: string,
+                      example: 'Using the same domain for multiple resources can cause routing conflicts and unpredictable behavior.',
+                    }
+                  conflicts:
+                    {
+                      type: array,
+                      items:
+                        {
+                          properties:
+                            {
+                              domain: { type: string, example: example.com },
+                              resource_name: { type: string, example: 'My Application' },
+                              resource_uuid:
+                                { type: string, nullable: true, example: abc123-def456 },
+                              resource_type:
+                                {
+                                  type: string,
+                                  enum: [application, service, instance],
+                                  example: application,
+                                },
+                              message:
+                                {
+                                  type: string,
+                                  example: "Domain example.com is already in use by application 'My Application'",
+                                },
+                            },
+                          type: object,
+                        },
+                    }
+                type: object
         '422':
           $ref: '#/components/responses/422'
       security:
@@ -6116,7 +7470,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'All environment variables by service UUID.'
@@ -6147,7 +7500,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Env created.'
         required: true
@@ -6206,7 +7558,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Env updated.'
         required: true
@@ -6242,9 +7593,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  message: { type: string, example: 'Environment variable updated.' }
-                type: object
+                $ref: '#/components/schemas/EnvironmentVariable'
         '401':
           $ref: '#/components/responses/401'
         '400':
@@ -6269,7 +7618,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       requestBody:
         description: 'Bulk envs updated.'
         required: true
@@ -6319,9 +7667,9 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  message: { type: string, example: 'Environment variables updated.' }
-                type: object
+                type: array
+                items:
+                  $ref: '#/components/schemas/EnvironmentVariable'
         '401':
           $ref: '#/components/responses/401'
         '400':
@@ -6346,14 +7694,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: env_uuid
           in: path
           description: 'UUID of the environment variable.'
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Environment variable deleted.'
@@ -6385,7 +7731,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: 'Start service.'
@@ -6417,7 +7762,12 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
+        - name: docker_cleanup
+          in: query
+          description: 'Perform docker cleanup (prune networks, volumes, etc.).'
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'Stop service.'
@@ -6449,7 +7799,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
         - name: latest
           in: query
           description: 'Pull latest images.'
@@ -6471,6 +7820,214 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+  '/services/{uuid}/storages':
+    get:
+      tags:
+        - Services
+      summary: 'List Storages'
+      description: 'List all persistent storages and file storages by service UUID.'
+      operationId: list-storages-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'All storages by service UUID.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  persistent_storages: { type: array, items: { type: object } }
+                  file_storages: { type: array, items: { type: object } }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Services
+      summary: 'Create Storage'
+      description: 'Create a persistent storage or file storage for a service sub-resource.'
+      operationId: create-storage-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - mount_path
+                - resource_uuid
+              properties:
+                type:
+                  type: string
+                  enum: [persistent, file]
+                  description: 'The type of storage.'
+                resource_uuid:
+                  type: string
+                  description: 'UUID of the service application or database sub-resource.'
+                name:
+                  type: string
+                  description: 'Volume name (persistent only, required for persistent).'
+                mount_path:
+                  type: string
+                  description: 'The container mount path.'
+                host_path:
+                  type: string
+                  nullable: true
+                  description: 'The host path (persistent only, optional).'
+                content:
+                  type: string
+                  nullable: true
+                  description: 'File content (file only, optional).'
+                is_directory:
+                  type: boolean
+                  description: 'Whether this is a directory mount (file only, default false).'
+                fs_path:
+                  type: string
+                  description: 'Host directory path (required when is_directory is true).'
+              type: object
+              additionalProperties: false
+      responses:
+        '201':
+          description: 'Storage created.'
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Services
+      summary: 'Update Storage'
+      description: 'Update a persistent storage or file storage by service UUID.'
+      operationId: update-storage-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: 'Storage updated. For read-only storages (from docker-compose or services), only is_preview_suffix_enabled can be updated.'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+              properties:
+                uuid:
+                  type: string
+                  description: 'The UUID of the storage (preferred).'
+                id:
+                  type: integer
+                  description: 'The ID of the storage (deprecated, use uuid instead).'
+                type:
+                  type: string
+                  enum: [persistent, file]
+                  description: 'The type of storage: persistent or file.'
+                is_preview_suffix_enabled:
+                  type: boolean
+                  description: 'Whether to add -pr-N suffix for preview deployments.'
+                name:
+                  type: string
+                  description: 'The volume name (persistent only, not allowed for read-only storages).'
+                mount_path:
+                  type: string
+                  description: 'The container mount path (not allowed for read-only storages).'
+                host_path:
+                  type: string
+                  nullable: true
+                  description: 'The host path (persistent only, not allowed for read-only storages).'
+                content:
+                  type: string
+                  nullable: true
+                  description: 'The file content (file only, not allowed for read-only storages).'
+              type: object
+              additionalProperties: false
+      responses:
+        '200':
+          description: 'Storage updated.'
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        - bearerAuth: []
+  '/services/{uuid}/storages/{storage_uuid}':
+    delete:
+      tags:
+        - Services
+      summary: 'Delete Storage'
+      description: 'Delete a persistent storage or file storage by service UUID.'
+      operationId: delete-storage-by-service-uuid
+      parameters:
+        - name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+        - name: storage_uuid
+          in: path
+          description: 'UUID of the storage.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Storage deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         - bearerAuth: []
   /teams:
@@ -6652,6 +8209,7 @@ components:
           description: 'Build pack.'
           enum:
             - nixpacks
+            - railpack
             - static
             - dockerfile
             - dockercompose
@@ -6723,6 +8281,16 @@ components:
         health_check_start_period:
           type: integer
           description: 'Health check start period in seconds.'
+        health_check_type:
+          type: string
+          description: 'Health check type: http or cmd.'
+          enum:
+            - http
+            - cmd
+        health_check_command:
+          type: string
+          nullable: true
+          description: 'Health check command for CMD type.'
         limits_memory:
           type: string
           description: 'Memory limit.'
@@ -6908,6 +8476,18 @@ components:
           type: string
         pull_request_id:
           type: integer
+        docker_registry_image_tag:
+          type: string
+          nullable: true
+        configuration_hash:
+          type: string
+          nullable: true
+        configuration_snapshot:
+          type: object
+          nullable: true
+        configuration_diff:
+          type: object
+          nullable: true
         force_rebuild:
           type: boolean
         commit:
@@ -6994,6 +8574,9 @@ components:
           type: string
         real_value:
           type: string
+        comment:
+          type: string
+          nullable: true
         version:
           type: string
         created_at:
@@ -7041,11 +8624,86 @@ components:
           type: string
         description:
           type: string
-        environments:
-          description: 'The environments of the project.'
-          type: array
-          items:
-            $ref: '#/components/schemas/Environment'
+      type: object
+    ScheduledTask:
+      description: 'Scheduled Task model'
+      properties:
+        id:
+          type: integer
+          description: 'The unique identifier of the scheduled task in the database.'
+        uuid:
+          type: string
+          description: 'The unique identifier of the scheduled task.'
+        enabled:
+          type: boolean
+          description: 'The flag to indicate if the scheduled task is enabled.'
+        name:
+          type: string
+          description: 'The name of the scheduled task.'
+        command:
+          type: string
+          description: 'The command to execute.'
+        frequency:
+          type: string
+          description: 'The frequency of the scheduled task.'
+        container:
+          type: string
+          nullable: true
+          description: 'The container where the command should be executed.'
+        timeout:
+          type: integer
+          description: 'The timeout of the scheduled task in seconds.'
+        created_at:
+          type: string
+          format: date-time
+          description: 'The date and time when the scheduled task was created.'
+        updated_at:
+          type: string
+          format: date-time
+          description: 'The date and time when the scheduled task was last updated.'
+      type: object
+    ScheduledTaskExecution:
+      description: 'Scheduled Task Execution model'
+      properties:
+        uuid:
+          type: string
+          description: 'The unique identifier of the execution.'
+        status:
+          type: string
+          enum:
+            - success
+            - failed
+            - running
+          description: 'The status of the execution.'
+        message:
+          type: string
+          nullable: true
+          description: 'The output message of the execution.'
+        retry_count:
+          type: integer
+          description: 'The number of retries.'
+        duration:
+          type: number
+          nullable: true
+          description: 'Duration in seconds.'
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'When the execution started.'
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'When the execution finished.'
+        created_at:
+          type: string
+          format: date-time
+          description: 'When the record was created.'
+        updated_at:
+          type: string
+          format: date-time
+          description: 'When the record was last updated.'
       type: object
     Server:
       description: 'Server model'
@@ -7183,6 +8841,9 @@ components:
         delete_unused_networks:
           type: boolean
           description: 'The flag to indicate if the unused networks should be deleted.'
+        connection_timeout:
+          type: integer
+          description: 'SSH connection timeout in seconds.'
       type: object
     Service:
       description: 'Service model'
@@ -7393,6 +9054,8 @@ tags:
     description: Projects
   - name: Resources
     description: Resources
+  - name: 'Scheduled Tasks'
+    description: 'Scheduled Tasks'
   - name: 'Private Keys'
     description: 'Private Keys'
   - name: Servers

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ export default {
     ],
   },
   extensionsToTreatAsEsm: ['.ts'],
-  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  testMatch: ['<rootDir>/src/**/*.test.ts', '<rootDir>/scripts/**/*.test.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern=integration --testTimeout=60000",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "check:spec-drift": "node scripts/check-client-spec-drift.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",

--- a/scripts/__tests__/check-client-spec-drift.test.ts
+++ b/scripts/__tests__/check-client-spec-drift.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  extractSpecPaths,
+  extractClientRoutes,
+  normaliseClientRoute,
+  normaliseSpecPath,
+  segmentsMatch,
+  findUnmatchedRoutes,
+  ALLOWLIST,
+} from '../check-client-spec-drift.mjs';
+
+describe('extractSpecPaths', () => {
+  it('extracts unquoted and quoted top-level path keys from a paths: block', () => {
+    const spec = [
+      'openapi: 3.1.0',
+      'paths:',
+      '  /applications:',
+      '    get:',
+      "      tags: ['x']",
+      "  '/applications/{uuid}':",
+      '    get:',
+      '      tags: []',
+      '  "/databases/{uuid}/envs":',
+      '    get:',
+      '      tags: []',
+      'components:',
+      '  schemas: {}',
+    ].join('\n');
+
+    expect(extractSpecPaths(spec)).toEqual([
+      '/applications',
+      '/applications/{uuid}',
+      '/databases/{uuid}/envs',
+    ]);
+  });
+
+  it('throws when there is no top-level paths: key', () => {
+    expect(() => extractSpecPaths('openapi: 3.1.0\ncomponents:\n  schemas: {}\n')).toThrow(
+      /paths:/,
+    );
+  });
+});
+
+describe('extractClientRoutes', () => {
+  it('extracts template literal and string literal path arguments to this.request', () => {
+    const client = `
+      class C {
+        async a() { return this.request<Foo>('/teams'); }
+        async b(uuid: string) { return this.request<Bar>(\`/servers/\${uuid}\`); }
+        async c(uuid: string) {
+          return this.request<Baz>(
+            \`/projects/\${uuid}/environments\`,
+            { method: 'DELETE' },
+          );
+        }
+      }
+    `;
+    const routes = extractClientRoutes(client);
+    expect(routes).toEqual(
+      expect.arrayContaining(['/teams', '/servers/${uuid}', '/projects/${uuid}/environments']),
+    );
+    // getVersion() bypasses this.request() and is always injected explicitly
+    expect(routes).toContain('/version');
+  });
+});
+
+describe('normaliseClientRoute', () => {
+  it('turns a plain literal path into segments', () => {
+    expect(normaliseClientRoute('/teams')).toEqual(['teams']);
+  });
+
+  it('turns a ${var} segment preceded by a slash into a param wildcard', () => {
+    expect(normaliseClientRoute('/servers/${uuid}/domains')).toEqual(['servers', null, 'domains']);
+  });
+
+  it('strips a hardcoded query string starting at a literal ?', () => {
+    expect(
+      normaliseClientRoute(
+        '/hetzner/images?cloud_provider_token_uuid=${encodeURIComponent(tokenUuid)}',
+      ),
+    ).toEqual(['hetzner', 'images']);
+  });
+
+  it('drops a ${query}/${qs}-style suffix glued onto the previous segment', () => {
+    expect(normaliseClientRoute('/applications${query}')).toEqual(['applications']);
+    expect(normaliseClientRoute('/applications/${uuid}/start${query}')).toEqual([
+      'applications',
+      null,
+      'start',
+    ]);
+    expect(normaliseClientRoute('/services/${uuid}/restart${qs}')).toEqual([
+      'services',
+      null,
+      'restart',
+    ]);
+  });
+});
+
+describe('normaliseSpecPath', () => {
+  it('turns {param} segments into wildcards', () => {
+    expect(normaliseSpecPath('/applications/{uuid}/envs/{env_uuid}')).toEqual([
+      'applications',
+      null,
+      'envs',
+      null,
+    ]);
+  });
+});
+
+describe('segmentsMatch', () => {
+  it('matches equal-length segment lists where params act as wildcards', () => {
+    expect(segmentsMatch(['applications', null], ['applications', null])).toBe(true);
+    // a null on either side is a wildcard — position 0 matches regardless
+    expect(segmentsMatch(['applications', null], [null, 'envs'])).toBe(true);
+  });
+
+  it('does not match when literal segments differ', () => {
+    expect(segmentsMatch(['applications', null], ['databases', null])).toBe(false);
+  });
+
+  it('does not match segment lists of different lengths', () => {
+    expect(segmentsMatch(['applications'], ['applications', null])).toBe(false);
+  });
+});
+
+describe('findUnmatchedRoutes', () => {
+  const client = `
+    class C {
+      async list() { return this.request<T>(\`/applications/\${uuid}/scheduled-tasks\`); }
+      async get() { return this.request<T>('/teams'); }
+    }
+  `;
+
+  it('reports client routes with no matching spec path', () => {
+    // extractClientRoutes always injects '/version' too (getVersion() bypasses
+    // this.request()), so a spec missing both /version and scheduled-tasks
+    // should report both.
+    const specWithGapsOnly = [
+      'paths:',
+      '  /teams:',
+      '    get:',
+      '      tags: []',
+      'components:',
+    ].join('\n');
+
+    expect(findUnmatchedRoutes(client, specWithGapsOnly)).toEqual(
+      expect.arrayContaining(['/applications/${uuid}/scheduled-tasks', '/version']),
+    );
+    expect(findUnmatchedRoutes(client, specWithGapsOnly)).toHaveLength(2);
+  });
+
+  it('reports nothing once the spec covers every client route', () => {
+    const fullSpec = [
+      'paths:',
+      '  /teams:',
+      '    get:',
+      '      tags: []',
+      "  '/applications/{uuid}/scheduled-tasks':",
+      '    get:',
+      '      tags: []',
+      '  /version:',
+      '    get:',
+      '      tags: []',
+      'components:',
+    ].join('\n');
+
+    expect(findUnmatchedRoutes(client, fullSpec)).toEqual([]);
+  });
+});
+
+describe('ALLOWLIST', () => {
+  it('is an array (empty once the bundled spec is fully caught up)', () => {
+    expect(Array.isArray(ALLOWLIST)).toBe(true);
+  });
+});

--- a/scripts/check-client-spec-drift.mjs
+++ b/scripts/check-client-spec-drift.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Client-vs-spec drift check.
+ *
+ * `docs/coolify-openapi.yaml` (the upstream Coolify OpenAPI spec bundled in
+ * this repo) is meant to be ground truth for "does Coolify support X"
+ * decisions. It drifts in two directions:
+ *
+ *   1. Upstream adds/changes paths we haven't pulled in yet.
+ *      -> covered by .github/workflows/openapi-drift.yml (weekly diff
+ *         against a baseline copy of the upstream spec).
+ *   2. `src/lib/coolify-client.ts` calls a path that the bundled spec
+ *      doesn't document at all (upstream may itself be lagging, or the
+ *      spec here is stale).
+ *      -> this script.
+ *
+ * This is intentionally a lightweight, no-network check: it extracts every
+ * path template `coolify-client.ts` passes to `this.request(...)`, extracts
+ * every path key from the bundled spec's `paths:` section, normalises both
+ * to segment lists (with `${var}`/`{param}` segments treated as wildcards),
+ * and reports any client route that doesn't match a spec path by segment
+ * count + literal-segment equality. Route params don't need matching names
+ * — only position and literal segments matter.
+ *
+ * A documented allowlist covers endpoints upstream genuinely hasn't
+ * specced yet (see ALLOWLIST below). Keep it small — it's meant to shrink
+ * over time as upstream catches up, not grow.
+ *
+ * Known limitation: matching is HTTP-method-blind and params are pure
+ * wildcards, so a client literal can satisfy a spec param in the same
+ * position — e.g. the deprecated `/applications/dockercompose` route
+ * (removed upstream in v4.1.0, see #235) still "matches" via
+ * `/applications/{uuid}`. This check catches whole path *shapes* the spec
+ * has never heard of; it cannot catch a removed sibling of a parameterised
+ * route without method-aware matching, which isn't worth the complexity
+ * for the one known case.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+export const SPEC_PATH = path.join(ROOT, 'docs/coolify-openapi.yaml');
+export const CLIENT_PATH = path.join(ROOT, 'src/lib/coolify-client.ts');
+
+/**
+ * Client routes that are known to be missing from the bundled upstream
+ * spec. Every entry here should have a short reason — if upstream adds the
+ * path, remove the entry (the script will start failing loudly if you
+ * forget and the path later disappears again).
+ */
+export const ALLOWLIST = [
+  // Currently empty: refreshing docs/coolify-openapi.yaml from upstream
+  // main (see #236) closed every gap that existed at the time. Add entries
+  // here only when upstream's openapi.yaml genuinely hasn't caught up with
+  // a client-called endpoint yet.
+];
+
+/** Extract every top-level path key from the spec's `paths:` block. */
+export function extractSpecPaths(specText) {
+  const lines = specText.split('\n');
+  const pathsIdx = lines.findIndex((l) => /^paths:\s*$/.test(l));
+  if (pathsIdx === -1) {
+    throw new Error("Could not find a top-level 'paths:' key in the OpenAPI spec");
+  }
+
+  let end = lines.length;
+  for (let i = pathsIdx + 1; i < lines.length; i++) {
+    // Next top-level YAML key (column 0, e.g. `components:`) ends the block.
+    if (/^[A-Za-z]/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const keyRe = /^ {2}(?:'([^']+)'|"([^"]+)"|(\/\S+)):\s*$/;
+  const paths = [];
+  for (let i = pathsIdx + 1; i < end; i++) {
+    const m = lines[i].match(keyRe);
+    if (m) paths.push(m[1] ?? m[2] ?? m[3]);
+  }
+  return paths;
+}
+
+/**
+ * Extract every path template literal passed as the first argument to
+ * `this.request(...)` / `this.request<T>(...)` in the client source.
+ */
+export function extractClientRoutes(clientText) {
+  const callRe = /this\.request(?:<[^>]*>)?\(\s*(`[^`]*`|'[^']*'|"[^"]*")/g;
+  const routes = new Set();
+  let m;
+  while ((m = callRe.exec(clientText))) {
+    routes.add(m[1].slice(1, -1)); // strip surrounding quote/backtick
+  }
+  // getVersion() builds its URL by hand and calls fetch() directly instead
+  // of going through this.request() (the /version endpoint returns plain
+  // text, not JSON) — add it explicitly so it's still checked.
+  routes.add('/version');
+  return [...routes];
+}
+
+/**
+ * Turn a raw client route template into a list of segments, using `null`
+ * for a param/wildcard segment.
+ *
+ * `${...}` interpolations are treated as:
+ *   - a real path segment (-> null) when immediately preceded by `/`
+ *   - dropped entirely otherwise — these are query-string builders glued
+ *     onto the previous segment (e.g. `` `/applications${query}` `` where
+ *     `query` is `buildQueryString()` output: `''` or `'?...'`)
+ * Anything from a literal `?` onward (a hardcoded query string) is also
+ * stripped.
+ */
+export function normaliseClientRoute(raw) {
+  const qIdx = raw.indexOf('?');
+  const withoutQuery = qIdx === -1 ? raw : raw.slice(0, qIdx);
+  const withoutInterpolations = withoutQuery.replace(/(\/?)\$\{[^}]*\}/g, (_, slash) =>
+    slash ? '/{param}' : '',
+  );
+  return segmentsOf(withoutInterpolations);
+}
+
+/** Turn a spec path key into a list of segments, using `null` for `{param}` segments. */
+export function normaliseSpecPath(specPath) {
+  return segmentsOf(specPath);
+}
+
+function segmentsOf(p) {
+  return p
+    .split('/')
+    .filter((s) => s.length > 0)
+    .map((s) => (/^\{[^}]+\}$/.test(s) ? null : s));
+}
+
+/** Do two normalised segment lists match (params act as wildcards)? */
+export function segmentsMatch(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === null || b[i] === null) continue;
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Compare every client route against the spec's path list. Returns the
+ * client routes (raw templates) that don't match any spec path.
+ */
+export function findUnmatchedRoutes(clientText, specText) {
+  const specSegLists = extractSpecPaths(specText).map(normaliseSpecPath);
+  const clientRoutes = extractClientRoutes(clientText);
+  return clientRoutes.filter((raw) => {
+    const segs = normaliseClientRoute(raw);
+    return !specSegLists.some((specSegs) => segmentsMatch(segs, specSegs));
+  });
+}
+
+function main() {
+  const specText = fs.readFileSync(SPEC_PATH, 'utf8');
+  const clientText = fs.readFileSync(CLIENT_PATH, 'utf8');
+
+  const unmatched = findUnmatchedRoutes(clientText, specText);
+  const stillMissing = unmatched.filter((route) => !ALLOWLIST.includes(route));
+  const staleAllowlist = ALLOWLIST.filter((route) => !unmatched.includes(route));
+
+  if (stillMissing.length > 0) {
+    console.error(
+      `\nFound ${stillMissing.length} route(s) coolify-client.ts calls that are not in ${path.relative(ROOT, SPEC_PATH)}:\n`,
+    );
+    for (const route of stillMissing) console.error(`  - ${route}`);
+    console.error(
+      '\nEither the bundled spec needs refreshing from upstream, or (if upstream genuinely ' +
+        `has no spec for this endpoint yet) add it to ALLOWLIST in ${path.relative(ROOT, __filename)} with a reason.\n`,
+    );
+    process.exitCode = 1;
+  }
+
+  if (staleAllowlist.length > 0) {
+    console.error(
+      `\nALLOWLIST in ${path.relative(ROOT, __filename)} has ${staleAllowlist.length} entr${staleAllowlist.length === 1 ? 'y' : 'ies'} that now match the spec — remove them:\n`,
+    );
+    for (const route of staleAllowlist) console.error(`  - ${route}`);
+    console.error('');
+    process.exitCode = 1;
+  }
+
+  if (!process.exitCode) {
+    console.log(
+      `OK: all ${extractClientRoutes(clientText).length} client route(s) match a path in the bundled OpenAPI spec.`,
+    );
+  }
+}
+
+const isMain = process.argv[1] === __filename;
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
Closes #236

## What

`docs/coolify-openapi.yaml` was stale — missing the `scheduled-tasks`, `storages`, and `/databases/{uuid}/envs*` endpoints that `src/lib/coolify-client.ts` already calls (added in earlier PRs but never reflected in the bundled spec).

1. **Refreshed the spec** from `coollabsio/coolify` `main` (`openapi.yaml`, 3.1.0). Old bundled copy: 7,403 lines / 79 paths. New: 8,778 lines / 96 paths.
2. **Added `scripts/check-client-spec-drift.mjs`** — a no-network, no-build script that:
   - Extracts every path template passed to `this.request(...)` in `coolify-client.ts` (plus `/version`, which `getVersion()` fetches directly rather than via `this.request`).
   - Extracts every top-level path key from the spec's `paths:` block.
   - Normalises both to segment lists (`${var}` / `{param}` segments become wildcards; hardcoded query strings and `${query}`/`${qs}`-style suffixes glued onto the previous segment are stripped).
   - Matches by segment count + literal-segment equality (param names don't need to match) and fails, listing unmatched routes, if any client route has no corresponding spec path.
   - Supports a documented `ALLOWLIST` for endpoints upstream genuinely hasn't specced yet.
3. **Wired it into CI** as `npm run check:spec-drift`, a new step in `.github/workflows/ci.yml` right after lint. Left `.github/workflows/openapi-drift.yml` untouched — it covers the other drift direction (upstream spec changes vs. a baseline, over time).
4. **Unit tests** for the extraction/normalisation/matching logic in `scripts/__tests__/check-client-spec-drift.test.ts` (jest `testMatch` extended to also pick up `scripts/**/*.test.ts`).

## Coverage after the refresh

Ran the new script against the refreshed spec: **all 101 client-called routes now match a spec path.** The `ALLOWLIST` is empty — there was nothing left over that upstream hasn't specced yet. (I verified the script actually detects drift by first running it against the old stale spec, where it correctly flagged the 16 routes named in the issue — scheduled-tasks, storages, database envs, plus one the issue didn't mention: `/applications/{uuid}/previews/{pull_request_id}`, which is also now covered.)

## Note on `docs/openapi-chunks/`

There's a separate, hand-split-by-tag copy of the spec in `docs/openapi-chunks/*.yaml` (referenced by `CLAUDE.md` / contributor docs as the first place to check when adding a new endpoint — it is *not* read by `search_docs`, which fetches `https://coolify.io/docs/llms-full.txt` at runtime and never touches local files). Those chunks are equally stale relative to the now-refreshed bundled spec but regenerating them is a bigger, separate job (no existing splitter script) and out of scope for this issue. Flagging so it doesn't get lost — happy to file a follow-up issue if useful.

## Test plan

- [x] `npm test` — 377 tests passing (5 suites)
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none new besides missing-return-type warnings on the new plain-JS script, which is consistent with how `debug.js` is written)
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — verified `dist/index.js` still lands at the expected path (adding the script initially expanded tsc's inferred `rootDir` when tests imported it from under `src/`; fixed by keeping the script's test alongside it in `scripts/__tests__/` instead)
- [x] `node scripts/check-client-spec-drift.mjs` — passes clean against the refreshed spec; also manually verified it fails correctly against the old spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)