### PR TITLE
ci: hidden-agenda scan — the #250 pattern is now a build failure

### DIFF
--- a/.github/workflows/hidden-agenda.yml
+++ b/.github/workflows/hidden-agenda.yml
@@ -1,0 +1,17 @@
+# Fails CI if repo content addresses or instructs AI agents invisibly
+# (hidden HTML comments, concealed elements, invisible unicode).
+# Why this exists: https://github.com/StuMason/coolify-mcp/issues/250
+name: hidden-agenda
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: StuMason/hidden-agenda@v0
+        with:
+          fail-on: error


### PR DESCRIPTION
Adds [hidden-agenda](https://github.com/StuMason/hidden-agenda) (born from #250) to CI. It fails the build on:

- hidden HTML comments/elements that address or instruct AI agents (the exact #250 pattern — verified: scanning the pre-#251 README exits 1 with four rules firing)
- URLs offered only to machine readers
- invisible unicode (zero-width, bidi, tag-block ASCII smuggling)

Current main scans clean (75 files, 0 findings). The repo that had the comment is now the repo that can't have it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)