### PR TITLE
feat: custom_network_aliases (#254) + MCPB one-click bundle + MCP registry auto-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,15 @@ jobs:
         if: steps.version.outputs.exists == 'false'
         run: npm publish --access public
 
+      - name: Build MCPB bundle
+        if: steps.version.outputs.exists == 'false'
+        run: |
+          # Rebuild node_modules with production deps only (dist/ is already built);
+          # --ignore-scripts skips the husky prepare hook, which is a dev dependency
+          rm -rf node_modules
+          npm ci --omit=dev --ignore-scripts
+          npx --yes @anthropic-ai/mcpb pack . coolify-mcp.mcpb
+
       - name: Extract changelog for version
         if: steps.version.outputs.exists == 'false'
         id: changelog
@@ -80,9 +89,25 @@ jobs:
             ---
 
             📦 [View on npm](https://www.npmjs.com/package/@masonator/coolify-mcp/v/${{ steps.version.outputs.current }})
+
+            🖱️ One-click Claude Desktop install: download `coolify-mcp.mcpb` below and drag it into Settings → Extensions.
+          files: coolify-mcp.mcpb
           draft: false
           prerelease: false
           generate_release_notes: false
+
+      - name: Publish to MCP Registry
+        if: steps.version.outputs.exists == 'false'
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          # npm propagation can lag right after publish — retry a few times
+          for i in 1 2 3; do
+            ./mcp-publisher publish && exit 0
+            echo "Registry publish attempt $i failed; retrying in 30s..."
+            sleep 30
+          done
+          exit 1
 
       - name: Skip publish (version exists)
         if: steps.version.outputs.exists == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ coverage/
 
 # Playwright MCP runtime artefacts (screenshots, snapshots)
 .playwright-mcp/
+*.mcpb

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,32 @@
+# MCPB bundle contents: manifest.json, dist/, production node_modules/,
+# package.json, README.md, LICENSE. Everything else stays out.
+src/
+docs/
+site/
+skills/
+scripts/
+coverage/
+.github/
+.husky/
+.claude/
+.cursor/
+*.md
+!README.md
+*.mcpb
+server.json
+repomix-output.xml
+.repomixignore
+debug.js
+Dockerfile
+Dockerfile.docs
+.dockerignore
+eslint.config.js
+jest.config.js
+tsconfig.json
+.prettierrc
+.lintstagedrc.json
+.markdownlint-cli2.jsonc
+.gitignore
+package-lock.json
+.env
+.env.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`custom_network_aliases` on `application` update** (#254) — gives an app container a stable DNS name for app-to-app traffic on a shared network. App containers get `<uuid>-<deploy-suffix>` container names that change every deploy (only databases get a uuid hostname), so this field is the only way to wire e.g. `ASR_URL=http://edator-asr:9000` between apps. Added to `UpdateApplicationRequest` and the `application` tool schema (update only — Coolify's create endpoints don't accept it).
+- **MCPB bundle for one-click Claude Desktop install** — every release now attaches `coolify-mcp.mcpb` to the GitHub release; drag it into Claude Desktop Settings → Extensions and enter your Coolify URL + token. Built from `manifest.json` via `@anthropic-ai/mcpb` in the publish workflow. No Node install or JSON config editing needed.
+- **Automated MCP Registry publishing** — the publish workflow now pushes `server.json` to registry.modelcontextprotocol.io via `mcp-publisher` (GitHub OIDC) on every release, so the registry listing can no longer go stale.
+
+### Fixed
+
+- **`server.json` drift** — the registry manifest was stuck at 2.7.3 / "38 tools" while npm was on 2.13.0 / 42 tools. Now synced, and `npm version` runs `scripts/sync-manifests.mjs` to bump `server.json` + `manifest.json` in the same commit; `src/__tests__/manifests.test.ts` fails CI if they ever diverge from `package.json` again.
+
 ## [2.13.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ The server uses **85% fewer tokens** than a naive implementation (6,600 vs 43,00
 - A running Coolify instance (tested with v4.0.0-beta.460)
 - Coolify API access token (generate in Coolify Settings > API)
 
-### Claude Desktop
+### Claude Desktop — one-click install (recommended)
+
+Download [`coolify-mcp.mcpb`](https://github.com/StuMason/coolify-mcp/releases/latest/download/coolify-mcp.mcpb) from the latest release and drag it into Claude Desktop **Settings → Extensions**. You'll be prompted for your Coolify URL and API token — no config file editing, no Node install required.
+
+### Claude Desktop — manual config
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,51 @@
+{
+  "manifest_version": "0.2",
+  "name": "coolify-mcp",
+  "display_name": "Coolify MCP",
+  "version": "2.13.0",
+  "description": "42 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
+  "author": {
+    "name": "Stuart Mason",
+    "url": "https://stumason.dev"
+  },
+  "homepage": "https://stumason.dev",
+  "documentation": "https://github.com/StuMason/coolify-mcp#readme",
+  "support": "https://github.com/StuMason/coolify-mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/StuMason/coolify-mcp"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/index.js"],
+      "env": {
+        "COOLIFY_BASE_URL": "${user_config.coolify_base_url}",
+        "COOLIFY_ACCESS_TOKEN": "${user_config.coolify_access_token}"
+      }
+    }
+  },
+  "user_config": {
+    "coolify_base_url": {
+      "type": "string",
+      "title": "Coolify Base URL",
+      "description": "URL of your Coolify instance, e.g. https://coolify.example.com",
+      "required": true
+    },
+    "coolify_access_token": {
+      "type": "string",
+      "title": "Coolify API Token",
+      "description": "API token from Keys & Tokens in your Coolify dashboard",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=20"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "format:check": "prettier --check .",
     "prepare": "husky",
     "prepublishOnly": "npm test && npm run lint",
+    "version": "node scripts/sync-manifests.mjs && prettier --write server.json manifest.json && git add server.json manifest.json",
     "start": "node dist/index.js"
   },
   "keywords": [

--- a/scripts/sync-manifests.mjs
+++ b/scripts/sync-manifests.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Keeps server.json (MCP registry) and manifest.json (MCPB bundle) versions
+ * in lockstep with package.json. Wired into the npm `version` lifecycle so
+ * `npm version patch|minor|major` bumps all three files in the same commit.
+ * Guarded by src/__tests__/manifests.test.ts.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+
+const serverJson = JSON.parse(readFileSync('server.json', 'utf8'));
+serverJson.version = pkg.version;
+for (const p of serverJson.packages ?? []) {
+  p.version = pkg.version;
+}
+writeFileSync('server.json', JSON.stringify(serverJson, null, 2) + '\n');
+
+const manifest = JSON.parse(readFileSync('manifest.json', 'utf8'));
+manifest.version = pkg.version;
+writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+
+console.log(`Synced server.json + manifest.json to v${pkg.version}`);

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.StuMason/coolify",
-  "description": "38 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
+  "description": "42 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
   "repository": {
     "url": "https://github.com/StuMason/coolify-mcp",
     "source": "github"
   },
   "websiteUrl": "https://stumason.dev",
-  "version": "2.7.3",
+  "version": "2.13.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@masonator/coolify-mcp",
-      "version": "2.7.3",
+      "version": "2.13.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1533,6 +1533,17 @@ describe('CoolifyClient', () => {
       expect(callBody.base_directory).toBe('/apps/api');
     });
 
+    it('should pass custom_network_aliases through updateApplication (#254)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockApplication));
+
+      await client.updateApplication('app-uuid', {
+        custom_network_aliases: 'edator-asr',
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.custom_network_aliases).toBe('edator-asr');
+    });
+
     it('should pass destination_uuid through in createApplicationPublic', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
 

--- a/src/__tests__/manifests.test.ts
+++ b/src/__tests__/manifests.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Guards against the distribution manifests drifting from package.json —
+ * server.json sat at 2.7.3 while npm was on 2.13.0 because nothing enforced
+ * the sync. scripts/sync-manifests.mjs (npm `version` lifecycle) keeps them
+ * aligned; this test fails the build if they ever diverge again.
+ */
+const read = (file: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+
+describe('distribution manifests', () => {
+  const pkg = read('package.json') as unknown as {
+    version: string;
+    mcpName: string;
+    description: string;
+  };
+
+  it('server.json (MCP registry) matches package.json', () => {
+    const serverJson = read('server.json') as unknown as {
+      name: string;
+      version: string;
+      packages: Array<{ identifier: string; version: string }>;
+    };
+    expect(serverJson.version).toBe(pkg.version);
+    expect(serverJson.name).toBe(pkg.mcpName);
+    for (const p of serverJson.packages) {
+      expect(p.version).toBe(pkg.version);
+    }
+  });
+
+  it('manifest.json (MCPB bundle) matches package.json', () => {
+    const manifest = read('manifest.json') as unknown as { version: string; server: unknown };
+    expect(manifest.version).toBe(pkg.version);
+    expect(manifest.server).toBeDefined();
+  });
+});

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -664,6 +664,21 @@ describe('CoolifyMcpServer v2', () => {
       expect(updateData).not.toHaveProperty('action');
       expect(updateData).not.toHaveProperty('uuid');
     });
+
+    it('forwards custom_network_aliases through update (#254)', async () => {
+      const spy = jest.spyOn(server['client'], 'updateApplication').mockResolvedValue({} as never);
+
+      await callApplication(server, {
+        action: 'update',
+        uuid: 'app-uuid',
+        custom_network_aliases: 'edator-asr',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'app-uuid',
+        expect.objectContaining({ custom_network_aliases: 'edator-asr' }),
+      );
+    });
   });
 
   describe('database tool handler', () => {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -623,6 +623,12 @@ export class CoolifyMcpServer extends McpServer {
         domains: z.string().optional(),
         custom_docker_run_options: z.string().optional(),
         custom_labels: z.string().optional(),
+        custom_network_aliases: z
+          .string()
+          .optional()
+          .describe(
+            'Comma-separated DNS aliases for app-to-app traffic (update only). App containers have no stable uuid hostname — only databases do.',
+          ),
         instant_deploy: z.boolean().optional(),
         // Health check fields
         health_check_enabled: z.boolean().optional(),

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -384,6 +384,9 @@ export interface UpdateApplicationRequest {
   domains?: string;
   custom_docker_run_options?: string;
   custom_labels?: string;
+  // App containers get no stable uuid DNS hostname (only databases do);
+  // this is the only way to give an app a fixed name for app-to-app traffic.
+  custom_network_aliases?: string;
   git_repository?: string;
   git_branch?: string;
   git_commit_sha?: string;


### PR DESCRIPTION
## Summary

Housekeeping sweep — closes #254 and fixes the stale-distribution problem.

### `custom_network_aliases` on `application` update (closes #254)
- Added to `UpdateApplicationRequest` + the `application` tool zod schema (update only — Coolify's create endpoints don't accept it, matching the `dockerfile_target_build` precedent).
- Field description documents the gotcha that cost two failed E2E runs: app containers get no stable uuid DNS hostname (only databases do).
- Tests: client PATCH pass-through + MCP tool forwarding.

### server.json drift fix + permanent sync
- `server.json` was advertising **2.7.3 / "38 tools"** on the MCP registry while npm was on **2.13.0 / 42 tools**. Now synced.
- `npm version` runs `scripts/sync-manifests.mjs` (+ prettier) so `server.json` + `manifest.json` bump in the same commit as `package.json`.
- New `manifests.test.ts` fails CI if the three ever diverge again.

### MCPB bundle — one-click Claude Desktop install
- New `manifest.json` (validated with `mcpb validate`) + `.mcpbignore`.
- Publish workflow packs `coolify-mcp.mcpb` (prod-only `node_modules`, ~3 MB) and attaches it to every GitHub release.
- README: drag-into-Settings→Extensions install section with a stable `releases/latest/download` link.

### MCP Registry auto-publish
- Publish workflow pushes `server.json` to registry.modelcontextprotocol.io via `mcp-publisher` (GitHub OIDC, retries for npm propagation lag) after each release — the listing can't go stale again.

## Verification

- `npm test`: 410/410 pass (3 new tests)
- `npm run lint` / `npm run build`: clean (12 pre-existing warnings untouched)
- `mcpb validate manifest.json`: passes
- Packed a bundle with the exact CI recipe, unpacked it, and booted it: answers MCP `initialize` with `coolify 2.13.0` — src/docs correctly excluded, 2144 files / 9.3 MB unpacked
- Note: the registry-publish CI step can only be truly exercised on the next real release

🤖 Generated with [Claude Code](https://claude.com/claude-code)