### PR TITLE
security: mask db passwords, connection URLs, and compose bodies on list_resources include_full (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Security
 
-- **`custom_network_aliases` on `application` update** (#254) — gives an app container a stable DNS name for app-to-app traffic on a shared network. App containers get `<uuid>-<deploy-suffix>` container names that change every deploy (only databases get a uuid hostname), so this field is the only way to wire e.g. `ASR_URL=http://edator-asr:9000` between apps. Added to `UpdateApplicationRequest` and the `application` tool schema (update only — Coolify's create endpoints don't accept it).
-- **MCPB bundle for one-click Claude Desktop install** — every release now attaches `coolify-mcp.mcpb` to the GitHub release; drag it into Claude Desktop Settings → Extensions and enter your Coolify URL + token. Built from `manifest.json` via `@anthropic-ai/mcpb` in the publish workflow. No Node install or JSON config editing needed.
-- **Automated MCP Registry publishing** — the publish workflow now pushes `server.json` to registry.modelcontextprotocol.io via `mcp-publisher` (GitHub OIDC) on every release, so the registry listing can no longer go stale.
-
-### Fixed
-
-- **`server.json` drift** — the registry manifest was stuck at 2.7.3 / "38 tools" while npm was on 2.13.0 / 42 tools. Now synced, and `npm version` runs `scripts/sync-manifests.mjs` to bump `server.json` + `manifest.json` in the same commit; `src/__tests__/manifests.test.ts` fails CI if they ever diverge from `package.json` again.
+- **`list_resources include_full` masks database passwords, connection URLs, compose bodies, and nested env vars** (#209) — a source audit of Coolify v4.1.2 found that no `Standalone*` model defines `$hidden` and Laravel serializes `encrypted` casts as decrypted plaintext, so every database row on `/api/v1/resources` carried its password in the clear. `SENSITIVE_RESOURCE_FIELDS` now additionally masks: the nine database password columns (`postgres_password`, `mysql_password`, `mysql_root_password`, `mariadb_password`, `mariadb_root_password`, `mongo_initdb_root_password`, `redis_password`, `keydb_password`, `dragonfly_password`, `clickhouse_admin_password`), the `internal_db_url` / `external_db_url` appends that embed the password in a connection URL on all eight database types (the only place Redis's password surfaces — its column was moved to env vars in 2024), compose bodies (`docker_compose_raw`, `docker_compose`, `docker_compose_pr_raw`, `docker_compose_pr`) since Coolify resolves `SERVICE_PASSWORD_*` placeholders into them, and `custom_labels` (Traefik basic-auth htpasswd hashes). A defensive walker also masks `value` / `real_value` on any nested `environment_variables[]` collection — absent at v4.1.2 but a leak vector on versions that inline it. `reveal: true` still round-trips plaintext. Mirrors the #204 / #206 posture.
 
 ## [2.13.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`custom_network_aliases` on `application` update** (#254) — gives an app container a stable DNS name for app-to-app traffic on a shared network. App containers get `<uuid>-<deploy-suffix>` container names that change every deploy (only databases get a uuid hostname), so this field is the only way to wire e.g. `ASR_URL=http://edator-asr:9000` between apps. Added to `UpdateApplicationRequest` and the `application` tool schema (update only — Coolify's create endpoints don't accept it).
+- **MCPB bundle for one-click Claude Desktop install** — every release now attaches `coolify-mcp.mcpb` to the GitHub release; drag it into Claude Desktop Settings → Extensions and enter your Coolify URL + token. Built from `manifest.json` via `@anthropic-ai/mcpb` in the publish workflow. No Node install or JSON config editing needed.
+- **Automated MCP Registry publishing** — the publish workflow now pushes `server.json` to registry.modelcontextprotocol.io via `mcp-publisher` (GitHub OIDC) on every release, so the registry listing can no longer go stale.
+
+### Fixed
+
+- **`server.json` drift** — the registry manifest was stuck at 2.7.3 / "38 tools" while npm was on 2.13.0 / 42 tools. Now synced, and `npm version` runs `scripts/sync-manifests.mjs` to bump `server.json` + `manifest.json` in the same commit; `src/__tests__/manifests.test.ts` fails CI if they ever diverge from `package.json` again.
+
 ### Security
 
 - **`list_resources include_full` masks database passwords, connection URLs, compose bodies, and nested env vars** (#209) — a source audit of Coolify v4.1.2 found that no `Standalone*` model defines `$hidden` and Laravel serializes `encrypted` casts as decrypted plaintext, so every database row on `/api/v1/resources` carried its password in the clear. `SENSITIVE_RESOURCE_FIELDS` now additionally masks: the nine database password columns (`postgres_password`, `mysql_password`, `mysql_root_password`, `mariadb_password`, `mariadb_root_password`, `mongo_initdb_root_password`, `redis_password`, `keydb_password`, `dragonfly_password`, `clickhouse_admin_password`), the `internal_db_url` / `external_db_url` appends that embed the password in a connection URL on all eight database types (the only place Redis's password surfaces — its column was moved to env vars in 2024), compose bodies (`docker_compose_raw`, `docker_compose`, `docker_compose_pr_raw`, `docker_compose_pr`) since Coolify resolves `SERVICE_PASSWORD_*` placeholders into them, and `custom_labels` (Traefik basic-auth htpasswd hashes). A defensive walker also masks `value` / `real_value` on any nested `environment_variables[]` collection — absent at v4.1.2 but a leak vector on versions that inline it. `reveal: true` still round-trips plaintext. Mirrors the #204 / #206 posture.

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -5170,6 +5170,23 @@ describe('CoolifyClient', () => {
         expect(envs[1].value).toBeNull();
       });
 
+      it('passes non-object environment_variables entries through untouched', async () => {
+        // Defensive-walker guard: if a Coolify version emits something other
+        // than objects in the collection, don't crash and don't alter it.
+        const weird = {
+          ...fluffyResource,
+          environment_variables: [null, 'FOO=bar', { uuid: 'env-1', key: 'K', value: 'v' }],
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([weird]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        const envs = first.environment_variables as Array<unknown>;
+        expect(envs[0]).toBeNull();
+        expect(envs[1]).toBe('FOO=bar');
+        expect((envs[2] as Record<string, unknown>).value).toBe('***');
+      });
+
       it('reveal=true round-trips the #209 fields as plaintext', async () => {
         const dbResource = {
           ...fluffyResource,

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4977,12 +4977,20 @@ describe('CoolifyClient', () => {
       expect('status' in result[0]).toBe(false);
     });
 
-    it('returns the raw Coolify payload when include_full is true', async () => {
+    it('returns the full Coolify payload when include_full is true (sensitive fields masked)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse([fluffyResource]));
       const result = await client.listResources({ include_full: true });
-      expect(result).toEqual([fluffyResource]);
+      // custom_labels is masked by default since #209; everything else round-trips
+      expect(result).toEqual([{ ...fluffyResource, custom_labels: '***' }]);
       const [first] = result as Array<Record<string, unknown>>;
       expect(first.config_hash).toBe(fluffyResource.config_hash);
+    });
+
+    it('round-trips the raw payload with include_full + reveal', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([fluffyResource]));
+      const result = await client.listResources({ include_full: true, reveal: true });
+      expect(result).toEqual([fluffyResource]);
+      const [first] = result as Array<Record<string, unknown>>;
       expect(first.custom_labels).toBe(fluffyResource.custom_labels);
     });
 
@@ -5068,6 +5076,119 @@ describe('CoolifyClient', () => {
         mockFetch.mockResolvedValueOnce(mockResponse([sensitiveResource]));
         const result = await client.listResources({ reveal: true });
         expect(Object.keys(result[0]).sort()).toEqual(['name', 'status', 'type', 'uuid']);
+      });
+
+      // #209 — database rows on /resources serialize their passwords decrypted
+      // (no Coolify model defines $hidden; encrypted casts decrypt on toArray).
+      it('masks database password fields on include_full=true (#209)', async () => {
+        const dbResource = {
+          ...fluffyResource,
+          postgres_password: 'pg-secret',
+          mysql_password: 'my-secret',
+          mysql_root_password: 'my-root-secret',
+          mariadb_password: 'maria-secret',
+          mariadb_root_password: 'maria-root-secret',
+          mongo_initdb_root_password: 'mongo-secret',
+          redis_password: 'redis-secret',
+          keydb_password: 'keydb-secret',
+          dragonfly_password: 'dragonfly-secret',
+          clickhouse_admin_password: 'click-secret',
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([dbResource]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        expect(first.postgres_password).toBe('***');
+        expect(first.mysql_password).toBe('***');
+        expect(first.mysql_root_password).toBe('***');
+        expect(first.mariadb_password).toBe('***');
+        expect(first.mariadb_root_password).toBe('***');
+        expect(first.mongo_initdb_root_password).toBe('***');
+        expect(first.redis_password).toBe('***');
+        expect(first.keydb_password).toBe('***');
+        expect(first.dragonfly_password).toBe('***');
+        expect(first.clickhouse_admin_password).toBe('***');
+      });
+
+      // #209 — internal/external_db_url appends embed the password in a
+      // connection URL on every db type; Redis's password leaks ONLY here.
+      it('masks internal_db_url and external_db_url on include_full=true (#209)', async () => {
+        const redisResource = {
+          ...fluffyResource,
+          internal_db_url: 'redis://default:redis-secret@abc123:6379/0',
+          external_db_url: 'redis://default:redis-secret@db.example.com:6379/0',
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([redisResource]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        expect(first.internal_db_url).toBe('***');
+        expect(first.external_db_url).toBe('***');
+      });
+
+      // #209 — Coolify resolves SERVICE_PASSWORD_* into docker_compose, and
+      // Traefik basic-auth labels in custom_labels carry htpasswd hashes.
+      it('masks compose bodies and custom_labels on include_full=true (#209)', async () => {
+        const serviceResource = {
+          ...fluffyResource,
+          docker_compose_raw: 'c2VydmljZXM6IHt9',
+          docker_compose: 'services:\n  db:\n    environment:\n      PASSWORD: resolved',
+          docker_compose_pr_raw: 'c2VydmljZXM6IHt9',
+          docker_compose_pr: 'services: {}',
+          custom_labels: 'dHJhZWZpay5iYXNpY2F1dGg9aHRwYXNzd2Q=',
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([serviceResource]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        expect(first.docker_compose_raw).toBe('***');
+        expect(first.docker_compose).toBe('***');
+        expect(first.docker_compose_pr_raw).toBe('***');
+        expect(first.docker_compose_pr).toBe('***');
+        expect(first.custom_labels).toBe('***');
+      });
+
+      // #209 — defensive: v4.1.2 never inlines environment_variables[] on
+      // /resources rows, but if a version/fork does, the nested copy must not
+      // bypass the env_vars pipeline's masking.
+      it('masks value/real_value on a nested environment_variables[] collection (#209)', async () => {
+        const withNestedEnvs = {
+          ...fluffyResource,
+          environment_variables: [
+            { uuid: 'env-1', key: 'API_KEY', value: 'plain-secret', real_value: 'real-secret' },
+            { uuid: 'env-2', key: 'EMPTY', value: null },
+          ],
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([withNestedEnvs]));
+        const [first] = (await client.listResources({ include_full: true })) as Array<
+          Record<string, unknown>
+        >;
+        const envs = first.environment_variables as Array<Record<string, unknown>>;
+        expect(envs[0].key).toBe('API_KEY');
+        expect(envs[0].value).toBe('***');
+        expect(envs[0].real_value).toBe('***');
+        expect(envs[1].value).toBeNull();
+      });
+
+      it('reveal=true round-trips the #209 fields as plaintext', async () => {
+        const dbResource = {
+          ...fluffyResource,
+          postgres_password: 'pg-secret',
+          internal_db_url: 'postgres://u:pg-secret@host:5432/db',
+          docker_compose: 'services: {}',
+          environment_variables: [{ uuid: 'env-1', key: 'API_KEY', value: 'plain-secret' }],
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse([dbResource]));
+        const [first] = (await client.listResources({
+          include_full: true,
+          reveal: true,
+        })) as Array<Record<string, unknown>>;
+        expect(first.postgres_password).toBe('pg-secret');
+        expect(first.internal_db_url).toBe('postgres://u:pg-secret@host:5432/db');
+        expect(first.docker_compose).toBe('services: {}');
+        expect((first.environment_variables as Array<Record<string, unknown>>)[0].value).toBe(
+          'plain-secret',
+        );
       });
     });
   });

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -437,19 +437,58 @@ function toResourceListItemEssential(item: ResourceListItemFull): ResourceListIt
  * deploy webhooks — anyone with one can forge deploys for that repo
  * independently of the Coolify API token. `http_basic_auth_password` is the
  * password gating front-of-app access.
+ *
+ * The database and compose entries come from a source audit of Coolify
+ * v4.1.2 (#209): no Standalone* model defines `$hidden`, and Laravel
+ * serializes `encrypted` casts as decrypted plaintext, so every database row
+ * on `/resources` carries its password in the clear. `internal_db_url` /
+ * `external_db_url` are appended accessors that embed the password in a
+ * connection URL on all eight database types — including Redis, whose
+ * password surfaces ONLY through those URLs (the column was moved to env
+ * vars). Compose bodies are masked because Coolify resolves
+ * `SERVICE_PASSWORD_*` placeholders into `docker_compose`, and
+ * `custom_labels` because Traefik basic-auth labels carry htpasswd hashes.
  */
 const SENSITIVE_RESOURCE_FIELDS = [
+  // Webhook + basic-auth (#204 / #206)
   'manual_webhook_secret_github',
   'manual_webhook_secret_gitlab',
   'manual_webhook_secret_gitea',
   'manual_webhook_secret_bitbucket',
   'http_basic_auth_password',
+  // Database passwords (#209) — serialized decrypted at the API
+  'postgres_password',
+  'mysql_password',
+  'mysql_root_password',
+  'mariadb_password',
+  'mariadb_root_password',
+  'mongo_initdb_root_password',
+  'redis_password',
+  'keydb_password',
+  'dragonfly_password',
+  'clickhouse_admin_password',
+  // Connection-URL appends (#209) — embed the password on every db type
+  'internal_db_url',
+  'external_db_url',
+  // Compose bodies + Traefik labels (#209) — carry resolved credentials
+  'docker_compose_raw',
+  'docker_compose',
+  'docker_compose_pr_raw',
+  'docker_compose_pr',
+  'custom_labels',
 ] as const;
 
 /**
  * Replace each {@link SENSITIVE_RESOURCE_FIELDS} entry with `'***'` on a full
  * resource row. Null/undefined values are preserved (since `null` conveys
  * "no secret set" and matters to callers); only populated values get masked.
+ *
+ * Also walks a nested `environment_variables[]` collection if one is present
+ * and masks `value` / `real_value` on each entry (mirroring {@link maskEnvVar}).
+ * Coolify v4.1.2 never inlines env vars on `/resources` rows — the relation
+ * is lazy and the controller never loads it — but other versions or forks
+ * might, and the nested copy would otherwise bypass the env_vars pipeline's
+ * masking entirely (#209).
  */
 function maskResourceItemFull(item: ResourceListItemFull): ResourceListItemFull {
   const masked: ResourceListItemFull = { ...item };
@@ -457,6 +496,15 @@ function maskResourceItemFull(item: ResourceListItemFull): ResourceListItemFull 
     if (masked[field] != null) {
       masked[field] = MASKED_VALUE;
     }
+  }
+  if (Array.isArray(masked.environment_variables)) {
+    masked.environment_variables = masked.environment_variables.map((entry) => {
+      if (entry === null || typeof entry !== 'object') return entry;
+      const env = { ...(entry as Record<string, unknown>) };
+      if (env.value != null) env.value = MASKED_VALUE;
+      if (env.real_value != null) env.real_value = MASKED_VALUE;
+      return env;
+    });
   }
   return masked;
 }

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -2076,7 +2076,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'system',
-      'System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload. When `include_full: true`, webhook HMAC secrets and basic-auth password are masked unless `reveal: true` is also set (matches the `env_vars` `reveal` ergonomics).',
+      'System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload. When `include_full: true`, credentials are masked unless `reveal: true` is also set (matches the `env_vars` `reveal` ergonomics): webhook HMAC secrets, basic-auth password, database passwords, internal/external_db_url connection strings, compose bodies, custom_labels, and nested env-var values.',
       {
         action: z.enum(['health', 'list_resources', 'enable_api', 'disable_api']),
         include_full: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Closes #209 — the follow-up audit of `system({ action: 'list_resources', include_full: true })` sensitive surfaces.

## Method: source audit instead of live sampling

Rather than hitting a live instance (which only shows the resource types that happen to be deployed), this audit read the Coolify **v4.1.2 source** — `ResourcesController`, all 8 `Standalone*` database models, `Application`, and `Service`. Ground truth findings:

- **No model in the `/resources` path defines `$hidden`** — every attribute serializes.
- **Laravel serializes `encrypted` casts as decrypted plaintext** in `toArray()` — so `postgres_password`, `mysql_root_password`, etc. come back in the clear on every database row.
- **`internal_db_url` / `external_db_url` are `$appends` accessors on all eight database types** that embed the password in a connection URL. This is the sneaky one: **Redis's password leaks ONLY through these URLs** (its column was moved to env vars in migration `2024_10_16`), so masking password columns alone would miss it.
- `mariadb_root_password` isn't even encrypted-cast upstream (unlike the mysql equivalent) — same exposure either way at the API.
- **Nested `environment_variables[]` is confirmed ABSENT at v4.1.2** — the relation is lazy and the controller never loads it. Good news for the issue's main suspect.

## Changes

`SENSITIVE_RESOURCE_FIELDS` gains (all masked to `'***'` on `include_full: true` unless `reveal: true`):

- 9 database password columns (postgres, mysql ×2, mariadb ×2, mongo, keydb, dragonfly, clickhouse) + `redis_password` defensively
- `internal_db_url`, `external_db_url`
- `docker_compose_raw`, `docker_compose`, `docker_compose_pr_raw`, `docker_compose_pr` — Coolify resolves `SERVICE_PASSWORD_*` placeholders into resolved compose
- `custom_labels` — Traefik basic-auth labels carry htpasswd hashes

Plus a defensive **nested `environment_variables[]` walker** (masks `value`/`real_value` per entry, mirroring `maskEnvVar`) in case any Coolify version/fork inlines the relation — the nested copy would otherwise bypass the env_vars pipeline entirely.

Null values stay null (`null` = "no secret set" is signal). Full compose/config content remains available via `get_application` / `get_service` / `reveal: true`.

## Out of scope (per the issue)

- `dockerfile`, `custom_nginx_configuration`, `*_conf`, `init_scripts` — config, not credentials; left visible.
- Field renaming/API tidy.

## Verification

- `npm test`: 412/412 (6 new tests: password columns, URL appends, compose/labels, nested env walker, reveal round-trips)
- One existing test updated: exact raw round-trip assertion now lives under `reveal: true` (which is the behavior that round-trips post-#209)
- Recommend a live `/smoke-test` after merge as belt-and-braces — this PR's ground truth is the v4.1.2 source, pinned to the estate's current version

🤖 Generated with [Claude Code](https://claude.com/claude-code)