### PR TITLE
ci: fix mcp-publisher download URL + manual registry re-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'package.json'
+  # Manual re-run of the MCP Registry publish only (e.g. after a failed
+  # registry step) — the npm/MCPB/release steps stay skipped because the
+  # version already exists on npm.
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -97,9 +101,11 @@ jobs:
           generate_release_notes: false
 
       - name: Publish to MCP Registry
-        if: steps.version.outputs.exists == 'false'
+        if: steps.version.outputs.exists == 'false' || github.event_name == 'workflow_dispatch'
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).tar.gz" | tar xz mcp-publisher
+          # Asset naming is goreleaser-style (linux_amd64), NOT uname-style
+          # (linux_x86_64) — hardcode since GitHub runners are always linux/amd64
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
           ./mcp-publisher login github-oidc
           # npm propagation can lag right after publish — retry a few times
           for i in 1 2 3; do


### PR DESCRIPTION
## Summary

The v2.14.0 publish run succeeded through npm → MCPB → GitHub release, but the final **Publish to MCP Registry** step failed on the `mcp-publisher` download: the registry repo's release assets are named goreleaser-style (`mcp-publisher_linux_amd64.tar.gz`), while the documented `uname -m` install pattern produces `linux_x86_64` → 404.

- Hardcode `linux_amd64` (GitHub-hosted runners are always linux/amd64)
- Add `workflow_dispatch` + step condition so the registry publish can be re-run for an already-released version — npm/MCPB/release steps stay skipped via the existing version-exists gate

After merge I'll dispatch the workflow to push `server.json` @ 2.14.0 to registry.modelcontextprotocol.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)