### PR TITLE
fix: honor key filter on env_vars list so reveal exposes only the requested variable

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -369,6 +369,65 @@ describe('CoolifyMcpServer v2', () => {
       })) as { content: Array<{ text: string }> };
       expect(result.content[0].text).toContain('key, value required');
     });
+
+    it('list with key returns only the matching variable', async () => {
+      jest.spyOn(server['client'], 'listApplicationEnvVars').mockResolvedValue([
+        { uuid: 'env-1', key: 'NODE_ENV', value: '***', is_buildtime: false, is_runtime: true },
+        { uuid: 'env-2', key: 'SECRET_TOKEN', value: '***', is_buildtime: false, is_runtime: true },
+      ]);
+
+      const result = (await callEnvVars(server, {
+        resource: 'application',
+        action: 'list',
+        uuid: 'app-uuid',
+        key: 'NODE_ENV',
+      })) as { content: Array<{ text: string }> };
+
+      const vars = JSON.parse(result.content[0].text) as Array<{ key: string }>;
+      expect(vars).toHaveLength(1);
+      expect(vars[0].key).toBe('NODE_ENV');
+    });
+
+    it('list with key + reveal exposes only the requested value', async () => {
+      const spy = jest.spyOn(server['client'], 'listServiceEnvVars').mockResolvedValue([
+        { uuid: 'env-1', key: 'FLAG', value: 'true', is_buildtime: false, is_runtime: true },
+        {
+          uuid: 'env-2',
+          key: 'DB_PASSWORD',
+          value: 'hunter2',
+          is_buildtime: false,
+          is_runtime: true,
+        },
+      ] as never);
+
+      const result = (await callEnvVars(server, {
+        resource: 'service',
+        action: 'list',
+        uuid: 'svc-uuid',
+        key: 'FLAG',
+        reveal: true,
+      })) as { content: Array<{ text: string }> };
+
+      expect(spy).toHaveBeenCalledWith('svc-uuid', { reveal: true });
+      expect(result.content[0].text).not.toContain('hunter2');
+      const vars = JSON.parse(result.content[0].text) as Array<{ key: string; value: string }>;
+      expect(vars).toEqual([expect.objectContaining({ key: 'FLAG', value: 'true' })]);
+    });
+
+    it('list without key returns all variables (unchanged behaviour)', async () => {
+      jest.spyOn(server['client'], 'listDatabaseEnvVars').mockResolvedValue([
+        { uuid: 'env-1', key: 'A', value: '***' },
+        { uuid: 'env-2', key: 'B', value: '***' },
+      ] as never);
+
+      const result = (await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+      })) as { content: Array<{ text: string }> };
+
+      expect(JSON.parse(result.content[0].text)).toHaveLength(2);
+    });
   });
 
   describe('system tool handler', () => {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1183,7 +1183,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.tool(
       'env_vars',
-      "Manage env vars for app, service, or database. Values are masked by default (returned as '***') to avoid leaking secrets to MCP clients; pass reveal=true on the list action when the caller explicitly needs the plaintext (e.g. 'what is FOO set to?'). Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.",
+      "Manage env vars for app, service, or database. Values are masked by default (returned as '***') to avoid leaking secrets to MCP clients; pass reveal=true on the list action when the caller explicitly needs the plaintext (e.g. 'what is FOO set to?'). On list, pass key to return only that variable — always combine reveal with key so only the requested value (not every secret on the resource) is exposed. Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys.",
       {
         resource: z.enum(['application', 'service', 'database']),
         action: z.enum(['list', 'create', 'update', 'delete', 'bulk_update']),
@@ -1221,11 +1221,19 @@ export class CoolifyMcpServer extends McpServer {
         reveal,
         data,
       }) => {
+        // On `list`, an optional `key` narrows the response to that single
+        // variable. This matters most with reveal=true: without it, asking
+        // for one value dumps every secret on the resource to the MCP client.
+        const filterByKey = <T extends { key: string }>(vars: T[]): T[] =>
+          key ? vars.filter((v) => v.key === key) : vars;
+
         if (resource === 'application') {
           switch (action) {
             case 'list':
-              return wrap(() =>
-                this.client.listApplicationEnvVars(uuid, { summary: true, reveal }),
+              return wrap(async () =>
+                filterByKey(
+                  await this.client.listApplicationEnvVars(uuid, { summary: true, reveal }),
+                ),
               );
             case 'create':
               if (!key || !value)
@@ -1261,7 +1269,9 @@ export class CoolifyMcpServer extends McpServer {
         } else if (resource === 'service') {
           switch (action) {
             case 'list':
-              return wrap(() => this.client.listServiceEnvVars(uuid, { reveal }));
+              return wrap(async () =>
+                filterByKey(await this.client.listServiceEnvVars(uuid, { reveal })),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };
@@ -1286,7 +1296,7 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(() => this.client.listDatabaseEnvVars(uuid));
+              return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
Fixes #271

## Problem

The `env_vars` tool schema accepts `key` on every action, but the `list` branches ignored it and always returned the full env list. Combined with `reveal: true`, a caller asking "what is FLAG set to?" received every secret on the resource (API keys, DB passwords, private keys) in plaintext into the MCP client context.

## Fix

- `action=list` now filters the response to the requested `key` across all three resources (application / service / database). Filtering happens in the tool handler after the client fetch, so it applies to both masked and revealed projections.
- Tool description documents the `key` + `reveal` pattern ("always combine reveal with key so only the requested value is exposed").
- Behaviour without `key` is unchanged (full list, masked by default).

## Tests

Three new cases in `mcp-server.test.ts`:
- `list` + `key` returns only the matching variable (application)
- `list` + `key` + `reveal` — response contains the requested value and does **not** contain the other variable's plaintext (service)
- `list` without `key` still returns all variables (database)

`npm test` — 420 passed, `npm run lint` — 0 errors, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)