### PR TITLE
chore(release): 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-07-14
+
+### Security
+
+- **`env_vars` list now honors the `key` parameter** (#271, #272 — thanks [@artgas1](https://github.com/artgas1)) — the tool schema accepted `key` on every action, but the three `list` branches ignored it, so the natural "what is FOO set to?" call (`action=list`, `key=FOO`, `reveal=true`) returned **every** variable on the resource in plaintext instead of the one requested. `list` + `key` now filters the response to that single variable across application / service / database, masked or revealed; without `key` the full (masked-by-default) list is unchanged. The tool description now steers callers to always pair `reveal` with `key` so a single-value read can never dump the resource's whole secret set again.
+
 ### Documentation
 
 - **README rewritten, 462 → ~130 lines** — killed the duplicated Available Tools section (every tool was documented twice), the response-size table, workflow sermons, and mid-page plugs; depth now lives on [coolify-mcp.stumason.dev](https://coolify-mcp.stumason.dev). Removed the "98%+ test coverage" claim: jest computes coverage with `src/lib/mcp-server.ts` (the entire tool layer) excluded and enforces an 80% threshold, so the number was misleading. Remaining claims (42 tools, 85% token reduction, response-size reductions, smart lookup) were fact-checked against the codebase and CHANGELOG measurements.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "coolify-mcp",
   "display_name": "Coolify MCP",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "42 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
   "author": {
     "name": "Stuart Mason",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masonator/coolify-mcp",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@masonator/coolify-mcp",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@masonator/coolify-mcp",
   "scope": "@masonator",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "mcpName": "io.github.StuMason/coolify",
   "description": "MCP server for Coolify — 42 optimized tools for infrastructure management, diagnostics, and documentation search",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "source": "github"
   },
   "websiteUrl": "https://stumason.dev",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@masonator/coolify-mcp",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Release PR for **v2.14.1** — merging this fires the publish workflow on main: npm publish → MCPB pack → GitHub release with `coolify-mcp.mcpb` attached → MCP registry publish.

### Security

- **`env_vars` list now honors `key`** (#271, fixed in #272 by @artgas1) — `list` + `key` + `reveal` previously dumped every secret on the resource in plaintext; now returns only the requested variable.

### Documentation

- README rewrite (462 → ~130 lines) from the earlier Unreleased entry rides along.

### Release mechanics

- CHANGELOG `[Unreleased]` → `[2.14.1] - 2026-07-14`
- Version synced across `package.json` / `server.json` / `manifest.json` (via `scripts/sync-manifests.mjs`)
- Lockfile updated
- `npm test` — 420 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)