### PR TITLE
fix: mask database env var secrets by default (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`env_vars` list now masks database secrets by default** (#274) — the tool description promised every resource type masks values as `***` unless `reveal=true` is passed, but the database `list` branch called `listDatabaseEnvVars` with no options, so `CoolifyClient.listDatabaseEnvVars` returned **plaintext** straight away and the `reveal` flag was ignored entirely. Database env vars routinely hold DB passwords and connection strings, so this was the highest-value leak of the three. `listDatabaseEnvVars` now masks `value`/`real_value` by default (mirroring the application/service methods) and the `env_vars` handler forwards `reveal` to it, so databases finally match the documented default: masked unless the caller explicitly opts into plaintext.
+
 ## [2.14.1] - 2026-07-14
 
 ### Security

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4480,30 +4480,41 @@ describe('CoolifyClient', () => {
   // ===========================================================================
 
   describe('listDatabaseEnvVars', () => {
-    it('should list database env vars', async () => {
-      const mockEnvs = [
-        {
-          id: 1,
-          uuid: 'env-1',
-          key: 'DB_HOST',
-          value: 'localhost',
-          is_buildtime: false,
-          is_literal: false,
-          is_multiline: false,
-          is_preview: false,
-          is_shared: false,
-          is_shown_once: false,
-          created_at: '2024-01-01',
-          updated_at: '2024-01-01',
-        },
-      ];
+    const mockEnvs = [
+      {
+        id: 1,
+        uuid: 'env-1',
+        key: 'DB_PASSWORD',
+        value: 'super-secret',
+        real_value: 'super-secret',
+        is_buildtime: false,
+        is_literal: false,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+    ];
+
+    it('should list database env vars with values masked by default (#274)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
       const result = await client.listDatabaseEnvVars('db-uuid');
-      expect(result).toEqual(mockEnvs);
+      // value and real_value masked, metadata preserved
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      expect(result[0]).toMatchObject({ uuid: 'env-1', key: 'DB_PASSWORD' });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/databases/db-uuid/envs',
         expect.any(Object),
       );
+    });
+
+    it('should list database env vars with real values when reveal=true (#274)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: true });
+      expect(result).toEqual(mockEnvs);
     });
   });
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -428,6 +428,21 @@ describe('CoolifyMcpServer v2', () => {
 
       expect(JSON.parse(result.content[0].text)).toHaveLength(2);
     });
+
+    it('forwards reveal to listDatabaseEnvVars so masking can be opted out (#274)', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'listDatabaseEnvVars')
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: 'hunter2' }] as never);
+
+      await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+        reveal: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: true });
+    });
   });
 
   describe('system tool handler', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1575,8 +1575,20 @@ export class CoolifyClient {
   // Database Environment Variable endpoints
   // ===========================================================================
 
-  async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
-    return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+  /**
+   * List env vars for a database.
+   *
+   * Default behaviour masks `value` (and `real_value`) with a sentinel string
+   * so secrets are not leaked to MCP clients. Pass `reveal: true` when the
+   * caller explicitly needs the plaintext value. Database env vars routinely
+   * hold DB credentials and connection strings, so masking matters most here.
+   */
+  async listDatabaseEnvVars(
+    uuid: string,
+    options?: { reveal?: boolean },
+  ): Promise<EnvironmentVariable[]> {
+    const envVars = await this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+    return options?.reveal === true ? envVars : envVars.map(maskEnvVar);
   }
 
   async createDatabaseEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1296,7 +1296,9 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
+              return wrap(async () =>
+                filterByKey(await this.client.listDatabaseEnvVars(uuid, { reveal })),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
## Summary

Closes #274.

The `env_vars` tool promises that secret values are **masked by default** (`***`) unless the caller passes `reveal=true`. Applications and services honored this; **databases did not**. `CoolifyClient.listDatabaseEnvVars` returned plaintext straight away, and the `env_vars` handler never forwarded `reveal` to it — so the flag was silently ignored and there was no way to even ask for masking.

Database env vars routinely hold DB passwords and connection strings, making this the highest-value leak of the three resource types, and it silently contradicted the tool's own documented default.

## Fix

- `listDatabaseEnvVars(uuid, { reveal })` now masks `value`/`real_value` by default via `maskEnvVar`, mirroring `listServiceEnvVars`. Plaintext only when `reveal: true`.
- The `env_vars` database `list` branch now forwards `reveal` to the client.

## Tests

- Client: masked-by-default and `reveal=true` returns plaintext.
- Handler: `reveal` is forwarded to `listDatabaseEnvVars`.
- Full suite: 422 passing, lint clean.

## Behaviour

| Resource | Before (default) | After (default) |
|---|---|---|
| Application list | masked ✅ | masked ✅ |
| Service list | masked ✅ | masked ✅ |
| Database list | **plaintext ❌** | masked ✅ |