### PR TITLE
fix : masquer par défaut les variables d'env d'une base de données et respecter reveal (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`env_vars` list now masks database values by default** (#275) — the tool advertises that values are masked (`***`) unless `reveal=true` is passed, and that held for applications and services but **not** databases: `list` on a database resource returned every value in plaintext and ignored `reveal` entirely. Since database env vars are almost always credentials and connection strings, this silently routed the most sensitive secrets straight past the masking layer. `listDatabaseEnvVars` now masks by default and honors `reveal`, matching the application / service behaviour and the documented default.
+
 ## [2.14.1] - 2026-07-14
 
 ### Security

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4480,30 +4480,41 @@ describe('CoolifyClient', () => {
   // ===========================================================================
 
   describe('listDatabaseEnvVars', () => {
-    it('should list database env vars', async () => {
-      const mockEnvs = [
-        {
-          id: 1,
-          uuid: 'env-1',
-          key: 'DB_HOST',
-          value: 'localhost',
-          is_buildtime: false,
-          is_literal: false,
-          is_multiline: false,
-          is_preview: false,
-          is_shared: false,
-          is_shown_once: false,
-          created_at: '2024-01-01',
-          updated_at: '2024-01-01',
-        },
-      ];
+    const mockEnvs = [
+      {
+        id: 1,
+        uuid: 'env-1',
+        key: 'DB_PASSWORD',
+        value: 'super-secret',
+        real_value: 'super-secret',
+        is_buildtime: false,
+        is_literal: false,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+    ];
+
+    it('should list database env vars with values masked by default (#275)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
       const result = await client.listDatabaseEnvVars('db-uuid');
-      expect(result).toEqual(mockEnvs);
+      // value + real_value masked, metadata (uuid, key) preserved
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      expect(result[0]).toMatchObject({ uuid: 'env-1', key: 'DB_PASSWORD' });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/databases/db-uuid/envs',
         expect.any(Object),
       );
+    });
+
+    it('should list database env vars with real values when reveal=true (#275)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: true });
+      expect(result).toEqual(mockEnvs);
     });
   });
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -415,7 +415,7 @@ describe('CoolifyMcpServer v2', () => {
     });
 
     it('list without key returns all variables (unchanged behaviour)', async () => {
-      jest.spyOn(server['client'], 'listDatabaseEnvVars').mockResolvedValue([
+      const spy = jest.spyOn(server['client'], 'listDatabaseEnvVars').mockResolvedValue([
         { uuid: 'env-1', key: 'A', value: '***' },
         { uuid: 'env-2', key: 'B', value: '***' },
       ] as never);
@@ -426,7 +426,24 @@ describe('CoolifyMcpServer v2', () => {
         uuid: 'db-uuid',
       })) as { content: Array<{ text: string }> };
 
+      // reveal defaults to undefined → client masks (matches app/service default) (#275)
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: undefined });
       expect(JSON.parse(result.content[0].text)).toHaveLength(2);
+    });
+
+    it('forwards reveal=true to listDatabaseEnvVars (#275)', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'listDatabaseEnvVars')
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: 'hunter2' }] as never);
+
+      await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+        reveal: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: true });
     });
   });
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1575,8 +1575,12 @@ export class CoolifyClient {
   // Database Environment Variable endpoints
   // ===========================================================================
 
-  async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
-    return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+  async listDatabaseEnvVars(
+    uuid: string,
+    options?: { reveal?: boolean },
+  ): Promise<EnvironmentVariable[]> {
+    const envVars = await this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+    return options?.reveal === true ? envVars : envVars.map(maskEnvVar);
   }
 
   async createDatabaseEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1296,7 +1296,9 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
+              return wrap(async () =>
+                filterByKey(await this.client.listDatabaseEnvVars(uuid, { reveal })),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
Corrige #275.

## Problème

L'outil `env_vars` annonce que les valeurs sont masquées (`***`) par défaut et renvoyées en clair uniquement lorsque l'appelant passe `reveal=true`. C'était bien le cas pour les **applications** et les **services**, mais **pas pour les bases de données** :

- `list` sur une ressource base de données renvoyait chaque valeur **en clair**, sans masquage.
- `reveal` n'avait aucun effet — le paramètre était tout bonnement ignoré, il n'existait donc aucun moyen de demander le masquage.

Les variables d'environnement d'une base de données sont presque toujours des identifiants et des chaînes de connexion — les données les plus sensibles que ce serveur manipule — donc le chemin « base de données » passait en silence à travers toute la couche de masquage et contredisait le comportement par défaut documenté.

## Cause racine

`CoolifyClient#listDatabaseEnvVars` ne masquait jamais et ne prenait pas d'option `reveal`, et la branche `list` de l'outil `env_vars` pour les bases de données l'appelait sans transmettre `reveal` :

```ts
// client
async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
  return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
}
// outil
case 'list':
  return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
```

Les équivalents pour les applications et les services masquent tous deux par défaut et respectent `reveal`.

## Correctif

Alignement sur l'implémentation des services : `listDatabaseEnvVars` masque désormais par défaut via `maskEnvVar` et ne renvoie le clair que lorsque `reveal === true`, et l'outil lui transmet `reveal`.

## Tests

- Tests client `listDatabaseEnvVars` mis à jour : masqué par défaut (`value` + `real_value` → `***`, métadonnées préservées) et `reveal=true` renvoie bien le clair.
- Tests du handler `env_vars` ajoutés vérifiant que `reveal` est transmis au client pour la ressource base de données (à la fois le défaut `undefined` et `true`).
- `npm run build`, `npm run lint` (0 erreur) et `npm test` complet (422 tests passants) au vert.