### PR TITLE
fix: mask database env vars by default and honor reveal (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`env_vars` list now masks database secrets by default** (#276) — the `application` and `service` list branches masked values (`***`) unless `reveal=true` was passed, but the `database` branch called `listDatabaseEnvVars` with no options, so it returned every value in **plaintext** and silently ignored `reveal`. Database env vars are the most sensitive data the server touches (passwords, connection strings), so this was the exact leak the masking layer exists to prevent, and it directly contradicted the tool's documented default. `listDatabaseEnvVars` now masks `value`/`real_value` by default and honors `reveal`, matching the application and service behaviour.
+
 ## [2.14.1] - 2026-07-14
 
 ### Security

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4480,30 +4480,48 @@ describe('CoolifyClient', () => {
   // ===========================================================================
 
   describe('listDatabaseEnvVars', () => {
-    it('should list database env vars', async () => {
-      const mockEnvs = [
-        {
-          id: 1,
-          uuid: 'env-1',
-          key: 'DB_HOST',
-          value: 'localhost',
-          is_buildtime: false,
-          is_literal: false,
-          is_multiline: false,
-          is_preview: false,
-          is_shared: false,
-          is_shown_once: false,
-          created_at: '2024-01-01',
-          updated_at: '2024-01-01',
-        },
-      ];
+    const mockEnvs = [
+      {
+        id: 1,
+        uuid: 'env-1',
+        key: 'DB_PASSWORD',
+        value: 'super-secret',
+        real_value: 'super-secret',
+        is_buildtime: false,
+        is_literal: false,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+    ];
+
+    it('should list database env vars with values masked by default (#276)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
       const result = await client.listDatabaseEnvVars('db-uuid');
-      expect(result).toEqual(mockEnvs);
+      // value and real_value masked, metadata preserved
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      expect(result[0]).toMatchObject({ uuid: 'env-1', key: 'DB_PASSWORD' });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/databases/db-uuid/envs',
         expect.any(Object),
       );
+    });
+
+    it('should list database env vars with real values when reveal=true (#276)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: true });
+      expect(result).toEqual(mockEnvs);
+    });
+
+    it('should mask database env vars when reveal=false (#276)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: false });
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
     });
   });
 

--- a/src/__tests__/integration/smoke.integration.test.ts
+++ b/src/__tests__/integration/smoke.integration.test.ts
@@ -42,6 +42,36 @@ describeFn('Smoke Integration Tests', () => {
     }, 10000);
   });
 
+  describe('database env var masking (#276)', () => {
+    it('masks database env var values by default and reveals with reveal=true', async () => {
+      const databases = await client.listDatabases();
+      if (databases.length === 0) {
+        console.warn('No databases on instance — skipping database env var masking smoke test');
+        return;
+      }
+
+      const uuid = databases[0].uuid;
+      const masked = await client.listDatabaseEnvVars(uuid);
+      const revealed = await client.listDatabaseEnvVars(uuid, { reveal: true });
+
+      if (masked.length === 0) {
+        console.warn(`Database ${uuid} has no env vars — skipping masking assertions`);
+        return;
+      }
+
+      // Default (no reveal): every value must be the mask sentinel, never plaintext.
+      for (const v of masked) {
+        expect(v.value).toBe('***');
+        if ('real_value' in v && v.real_value !== undefined) {
+          expect(v.real_value).toBe('***');
+        }
+      }
+
+      // reveal=true: at least one value should differ from the mask (real secret).
+      expect(revealed.some((v) => v.value !== '***')).toBe(true);
+    }, 15000);
+  });
+
   describe('error handling', () => {
     it('should handle validation errors with string messages (issue #107)', async () => {
       // Creating a service with docker_compose_raw but no type triggers

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -428,6 +428,35 @@ describe('CoolifyMcpServer v2', () => {
 
       expect(JSON.parse(result.content[0].text)).toHaveLength(2);
     });
+
+    it('database list forwards reveal to listDatabaseEnvVars (#276)', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'listDatabaseEnvVars')
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: 'hunter2' }] as never);
+
+      await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+        reveal: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: true });
+    });
+
+    it('database list defaults reveal to undefined so values are masked (#276)', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'listDatabaseEnvVars')
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: '***' }] as never);
+
+      await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+      });
+
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: undefined });
+    });
   });
 
   describe('system tool handler', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1575,8 +1575,21 @@ export class CoolifyClient {
   // Database Environment Variable endpoints
   // ===========================================================================
 
-  async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
-    return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+  /**
+   * List env vars for a database.
+   *
+   * Default behaviour masks `value` (and `real_value`) with a sentinel string
+   * so secrets are not leaked to MCP clients. Pass `reveal: true` when the
+   * caller explicitly needs the plaintext value. Database env vars are among
+   * the most sensitive the server touches (credentials, connection strings),
+   * so this mirrors the masking on {@link listServiceEnvVars}.
+   */
+  async listDatabaseEnvVars(
+    uuid: string,
+    options?: { reveal?: boolean },
+  ): Promise<EnvironmentVariable[]> {
+    const envVars = await this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+    return options?.reveal === true ? envVars : envVars.map(maskEnvVar);
   }
 
   async createDatabaseEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1296,7 +1296,9 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
+              return wrap(async () =>
+                filterByKey(await this.client.listDatabaseEnvVars(uuid, { reveal })),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
Fixes #276.

## The bug

The `env_vars` `list` action promises (in its own tool description) that secret values are **masked as `***` by default** and returned in plaintext only when the caller passes `reveal=true`. Applications and services honour this. **Databases did not:**

- `CoolifyClient.listDatabaseEnvVars(uuid)` was called with no options and contained no masking logic — it returned the raw API response, i.e. every value in **plaintext**.
- The `reveal` flag was never plumbed through, so it was silently ignored: `true`, `false`, or omitted all returned the same plaintext.

Database env vars are the most sensitive data this server touches (passwords, connection strings), so this bypassed the exact protection the masking layer exists to provide, and quietly contradicted the documented default.

## The fix

- `listDatabaseEnvVars` now takes `options?: { reveal?: boolean }` and masks `value` / `real_value` by default via `maskEnvVar`, revealing plaintext only when `reveal === true` — identical to `listServiceEnvVars`.
- The `env_vars` tool's `database` → `list` branch now forwards `reveal` to the client.

## Tests

- **Client** (`coolify-client.test.ts`): masked-by-default, `reveal=true` returns plaintext, `reveal=false` masks. Updated the pre-existing "should list database env vars" test that asserted plaintext.
- **Tool** (`mcp-server.test.ts`): `reveal` is forwarded to `listDatabaseEnvVars`; default call passes `reveal: undefined` so values stay masked.
- **Smoke** (`smoke.integration.test.ts`): finds a live database, asserts default list is fully masked and `reveal=true` returns real values.

`npm test` → 424 passing. `npm run build` / `npm run lint` clean (only pre-existing warnings).

## Verification notes

Live smoke reproduction was blocked at review time: the instance in `.env` is returning HTTP 503, and the reachable netcup estate's two databases (Dragonfly/Redis) have no env vars set. The root cause is unambiguous from the code and fully covered by unit tests; the added smoke test will exercise it end-to-end once a database with env vars is reachable.