### PR TITLE
fix: маскировать env-переменные БД по умолчанию и учитывать reveal (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`env_vars` list now masks database secrets by default** (#276) — the `application` and `service` list branches masked values (`***`) unless `reveal=true` was passed, but the `database` branch called `listDatabaseEnvVars` with no options, so it returned every value in **plaintext** and silently ignored `reveal`. Database env vars are the most sensitive data the server touches (passwords, connection strings), so this was the exact leak the masking layer exists to prevent, and it directly contradicted the tool's documented default. `listDatabaseEnvVars` now masks `value`/`real_value` by default and honors `reveal`, matching the application and service behaviour.
+
 ## [2.14.1] - 2026-07-14
 
 ### Security

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4480,30 +4480,48 @@ describe('CoolifyClient', () => {
   // ===========================================================================
 
   describe('listDatabaseEnvVars', () => {
-    it('should list database env vars', async () => {
-      const mockEnvs = [
-        {
-          id: 1,
-          uuid: 'env-1',
-          key: 'DB_HOST',
-          value: 'localhost',
-          is_buildtime: false,
-          is_literal: false,
-          is_multiline: false,
-          is_preview: false,
-          is_shared: false,
-          is_shown_once: false,
-          created_at: '2024-01-01',
-          updated_at: '2024-01-01',
-        },
-      ];
+    const mockEnvs = [
+      {
+        id: 1,
+        uuid: 'env-1',
+        key: 'DB_PASSWORD',
+        value: 'super-secret',
+        real_value: 'super-secret',
+        is_buildtime: false,
+        is_literal: false,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+    ];
+
+    it('should list database env vars with values masked by default (#276)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
       const result = await client.listDatabaseEnvVars('db-uuid');
-      expect(result).toEqual(mockEnvs);
+      // value and real_value masked, metadata preserved
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      expect(result[0]).toMatchObject({ uuid: 'env-1', key: 'DB_PASSWORD' });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/databases/db-uuid/envs',
         expect.any(Object),
       );
+    });
+
+    it('should list database env vars with real values when reveal=true (#276)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: true });
+      expect(result).toEqual(mockEnvs);
+    });
+
+    it('should mask database env vars when reveal=false (#276)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: false });
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
     });
   });
 

--- a/src/__tests__/integration/smoke.integration.test.ts
+++ b/src/__tests__/integration/smoke.integration.test.ts
@@ -42,6 +42,36 @@ describeFn('Smoke Integration Tests', () => {
     }, 10000);
   });
 
+  describe('database env var masking (#276)', () => {
+    it('masks database env var values by default and reveals with reveal=true', async () => {
+      const databases = await client.listDatabases();
+      if (databases.length === 0) {
+        console.warn('No databases on instance — skipping database env var masking smoke test');
+        return;
+      }
+
+      const uuid = databases[0].uuid;
+      const masked = await client.listDatabaseEnvVars(uuid);
+      const revealed = await client.listDatabaseEnvVars(uuid, { reveal: true });
+
+      if (masked.length === 0) {
+        console.warn(`Database ${uuid} has no env vars — skipping masking assertions`);
+        return;
+      }
+
+      // Default (no reveal): every value must be the mask sentinel, never plaintext.
+      for (const v of masked) {
+        expect(v.value).toBe('***');
+        if ('real_value' in v && v.real_value !== undefined) {
+          expect(v.real_value).toBe('***');
+        }
+      }
+
+      // reveal=true: at least one value should differ from the mask (real secret).
+      expect(revealed.some((v) => v.value !== '***')).toBe(true);
+    }, 15000);
+  });
+
   describe('error handling', () => {
     it('should handle validation errors with string messages (issue #107)', async () => {
       // Creating a service with docker_compose_raw but no type triggers

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -428,6 +428,35 @@ describe('CoolifyMcpServer v2', () => {
 
       expect(JSON.parse(result.content[0].text)).toHaveLength(2);
     });
+
+    it('database list forwards reveal to listDatabaseEnvVars (#276)', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'listDatabaseEnvVars')
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: 'hunter2' }] as never);
+
+      await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+        reveal: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: true });
+    });
+
+    it('database list defaults reveal to undefined so values are masked (#276)', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'listDatabaseEnvVars')
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: '***' }] as never);
+
+      await callEnvVars(server, {
+        resource: 'database',
+        action: 'list',
+        uuid: 'db-uuid',
+      });
+
+      expect(spy).toHaveBeenCalledWith('db-uuid', { reveal: undefined });
+    });
   });
 
   describe('system tool handler', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1575,8 +1575,21 @@ export class CoolifyClient {
   // Database Environment Variable endpoints
   // ===========================================================================
 
-  async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
-    return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+  /**
+   * List env vars for a database.
+   *
+   * Default behaviour masks `value` (and `real_value`) with a sentinel string
+   * so secrets are not leaked to MCP clients. Pass `reveal: true` when the
+   * caller explicitly needs the plaintext value. Database env vars are among
+   * the most sensitive the server touches (credentials, connection strings),
+   * so this mirrors the masking on {@link listServiceEnvVars}.
+   */
+  async listDatabaseEnvVars(
+    uuid: string,
+    options?: { reveal?: boolean },
+  ): Promise<EnvironmentVariable[]> {
+    const envVars = await this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+    return options?.reveal === true ? envVars : envVars.map(maskEnvVar);
   }
 
   async createDatabaseEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1296,7 +1296,9 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
+              return wrap(async () =>
+                filterByKey(await this.client.listDatabaseEnvVars(uuid, { reveal })),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
Закрывает #276.

## Суть проблемы

Действие `list` инструмента `env_vars` обещает (в собственном описании инструмента), что значения секретов **по умолчанию маскируются как `***`** и отдаются в открытом виде только при явном `reveal=true`. Для приложений и сервисов это так и работает. **Для баз данных — нет:**

- `CoolifyClient.listDatabaseEnvVars(uuid)` вызывался без опций и не содержал логики маскирования — возвращал сырой ответ API, то есть все значения **в открытом виде**.
- Флаг `reveal` никуда не пробрасывался и просто игнорировался: `true`, `false` или отсутствие флага давали один и тот же открытый текст.

Env-переменные базы данных — самые чувствительные данные, к которым прикасается этот сервер (пароли, строки подключения), поэтому баг обходил ровно ту защиту, ради которой существует слой маскирования, и молча противоречил заявленному в документации поведению по умолчанию.

## Исправление

- `listDatabaseEnvVars` теперь принимает `options?: { reveal?: boolean }` и по умолчанию маскирует `value` / `real_value` через `maskEnvVar`, отдавая открытый текст только при `reveal === true` — идентично `listServiceEnvVars`.
- Ветка `database` → `list` инструмента `env_vars` теперь пробрасывает `reveal` в клиент.

## Тесты

- **Клиент** (`coolify-client.test.ts`): маска по умолчанию, `reveal=true` возвращает открытый текст, `reveal=false` маскирует. Обновлён старый тест «should list database env vars», который ожидал открытый текст.
- **Инструмент** (`mcp-server.test.ts`): `reveal` пробрасывается в `listDatabaseEnvVars`; вызов по умолчанию передаёт `reveal: undefined`, поэтому значения остаются замаскированными.
- **Смоук** (`smoke.integration.test.ts`): находит живую базу данных, проверяет, что список по умолчанию полностью замаскирован, а `reveal=true` возвращает реальные значения.

`npm test` → 424 теста проходят. `npm run build` / `npm run lint` чисто (только ранее существовавшие предупреждения).

## О проверке на живом инстансе

Живую репродукцию на момент ревью воспроизвести не удалось: инстанс из `.env` отдаёт HTTP 503, а на доступном netcup-эстейте у обеих баз (Dragonfly/Redis) не заданы env-переменные. Корневая причина однозначна по коду и полностью покрыта юнит-тестами; добавленный смоук-тест прогонит сценарий вживую, как только будет доступна БД с переменными.