### PR TITLE
fix: database env vars को default में mask करो और reveal flag का सम्मान करो (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`env_vars` list now masks database secrets by default** (#277) — the `list` action's database branch called `listDatabaseEnvVars(uuid)` without threading the `reveal` flag, and the client method never masked anything, so database env vars were returned in **plaintext** regardless of `reveal` — while application and service lists correctly masked by default. Database env vars are the most sensitive data this server touches (DB passwords, connection strings), so this bypassed the entire masking safeguard and contradicted the tool's documented default. `listDatabaseEnvVars` now masks `value` / `real_value` by default (mirroring `listServiceEnvVars`) and only returns plaintext when the caller passes `reveal=true`.
+
 ## [2.14.1] - 2026-07-14
 
 ### Security

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -4480,30 +4480,48 @@ describe('CoolifyClient', () => {
   // ===========================================================================
 
   describe('listDatabaseEnvVars', () => {
-    it('should list database env vars', async () => {
-      const mockEnvs = [
-        {
-          id: 1,
-          uuid: 'env-1',
-          key: 'DB_HOST',
-          value: 'localhost',
-          is_buildtime: false,
-          is_literal: false,
-          is_multiline: false,
-          is_preview: false,
-          is_shared: false,
-          is_shown_once: false,
-          created_at: '2024-01-01',
-          updated_at: '2024-01-01',
-        },
-      ];
+    const mockEnvs = [
+      {
+        id: 1,
+        uuid: 'env-1',
+        key: 'DB_PASSWORD',
+        value: 'super-secret',
+        real_value: 'super-secret',
+        is_buildtime: false,
+        is_literal: false,
+        is_multiline: false,
+        is_preview: false,
+        is_shared: false,
+        is_shown_once: false,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      },
+    ];
+
+    it('should list database env vars with values masked by default (#277)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
       const result = await client.listDatabaseEnvVars('db-uuid');
-      expect(result).toEqual(mockEnvs);
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+      // metadata preserved
+      expect(result[0]).toMatchObject({ uuid: 'env-1', key: 'DB_PASSWORD' });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/databases/db-uuid/envs',
         expect.any(Object),
       );
+    });
+
+    it('should list database env vars with values masked when reveal=false (#277)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: false });
+      expect(result[0].value).toBe('***');
+      expect(result[0].real_value).toBe('***');
+    });
+
+    it('should list database env vars with real values when reveal=true (#277)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockEnvs));
+      const result = await client.listDatabaseEnvVars('db-uuid', { reveal: true });
+      expect(result).toEqual(mockEnvs);
     });
   });
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1575,8 +1575,21 @@ export class CoolifyClient {
   // Database Environment Variable endpoints
   // ===========================================================================
 
-  async listDatabaseEnvVars(uuid: string): Promise<EnvironmentVariable[]> {
-    return this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+  /**
+   * List env vars for a database.
+   *
+   * Default behaviour masks `value` (and `real_value`) with a sentinel string
+   * so secrets are not leaked to MCP clients. Pass `reveal: true` when the
+   * caller explicitly needs the plaintext value. Database env vars are among
+   * the most sensitive data this server touches (DB credentials, connection
+   * strings), so the masking mirrors {@link listServiceEnvVars}.
+   */
+  async listDatabaseEnvVars(
+    uuid: string,
+    options?: { reveal?: boolean },
+  ): Promise<EnvironmentVariable[]> {
+    const envVars = await this.request<EnvironmentVariable[]>(`/databases/${uuid}/envs`);
+    return options?.reveal === true ? envVars : envVars.map(maskEnvVar);
   }
 
   async createDatabaseEnvVar(uuid: string, data: CreateEnvVarRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1296,7 +1296,9 @@ export class CoolifyMcpServer extends McpServer {
         } else {
           switch (action) {
             case 'list':
-              return wrap(async () => filterByKey(await this.client.listDatabaseEnvVars(uuid)));
+              return wrap(async () =>
+                filterByKey(await this.client.listDatabaseEnvVars(uuid, { reveal })),
+              );
             case 'create':
               if (!key || !value)
                 return { content: [{ type: 'text' as const, text: 'Error: key, value required' }] };


### PR DESCRIPTION
Fixes #277.

## समस्या

`env_vars` tool की description वादा करती है कि secret values **by default masked** होकर (`***`) आती हैं, और असली plaintext value सिर्फ़ तब जब caller explicitly `reveal=true` भेजे। ये बात application और service के लिए तो सही थी, पर **database के लिए टूटी हुई थी** — database की env vars हमेशा **plaintext** में आ जाती थीं, चाहे `reveal` कुछ भी हो, और वो flag बस ignore हो जाता था।

दो root causes:
1. `CoolifyClient.listDatabaseEnvVars` न कुछ mask करती थी, न ही `reveal` option लेती थी (जबकि `listServiceEnvVars` / `listApplicationEnvVars` दोनों करती हैं)।
2. `env_vars` handler का database `list` branch `listDatabaseEnvVars(uuid)` को बिना `{ reveal }` pass किए call कर रहा था।

चूँकि database की env vars इस server के छूने वाले सबसे sensitive data में से हैं (DB passwords, connection strings), ये पूरी masking layer के आर-पार निकल जाता था और tool की अपनी documented default behaviour के भी खिलाफ़ था।

## Fix

- `listDatabaseEnvVars(uuid, { reveal })` अब by default `value` / `real_value` को mask करती है, और plaintext सिर्फ़ `reveal=true` पर लौटाती है — बिल्कुल `listServiceEnvVars` की तरह।
- `env_vars` का database `list` branch अब `{ reveal }` को आगे pass करता है, application/service branches से match करते हुए।

## Fix के बाद behaviour

| Resource | Default | `reveal=true` |
|----------|---------|---------------|
| application | masked ✅ | plaintext |
| service | masked ✅ | plaintext |
| database | **masked ✅** (पहले plaintext था) | plaintext |

## Tests

`listDatabaseEnvVars` suite को update किया — masked-by-default, `reveal=false` पर masked, और `reveal=true` पर plaintext, तीनों assert करती है। पूरी suite green (422 passed)। Build + lint भी clean।