### PR TITLE
ci: run Claude review and the interactive workflow on Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,4 +51,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-sonnet-4-6 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-5 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-opus-5
             --allowedTools "Bash(gh:*),Bash(npm:*),Bash(composer:*)"
             --system-prompt "You can create PRs with 'gh pr create', merge with 'gh pr merge', and comment with 'gh issue comment'. Use gh CLI for all GitHub operations."


### PR DESCRIPTION
Bumps both Claude workflows to `claude-opus-5`.

| Workflow | Was | Now |
| --- | --- | --- |
| `claude-code-review.yml` (every PR) | `claude-sonnet-4-6` | `claude-opus-5` |
| `claude.yml` (interactive `@claude`) | `claude-opus-4-7` | `claude-opus-5` |

The review workflow is the one that matters — it runs on every PR, and its findings have already caught real defects this week: a terminal method cache in the v4.2 fallback (#296) and an unverified `is_preview` assumption on service env vars (#297). Both were fixed before merge.

I bumped `claude.yml` too since it was a version behind on the same intent. Say the word if you only wanted the review one and I'll revert that half.

Workflow-only change — no source, no tests affected.