### PR TITLE
feat: container logs for databases and services, via one consolidated logs tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`logs` tool: container logs for databases and services, not just applications** (#300) — `diagnose_app` could explain an unhealthy application by reading its logs, but the same question about a database or a service had no answer and sent you to the Coolify UI, which is exactly the moment you want logs.
+
+  Added as **one consolidated `logs` tool** with a `resource` parameter (`application` / `database` / `service`), matching the `env_vars` and `control` pattern, rather than three or four sibling tools — the token budget is the point of the v2.0.0 design. `application_logs` still works and is marked superseded in its description; it will be removed in v3. Also adds `show_timestamps`, which upstream has always supported and this client never sent.
+
+  A service is a multi-container stack, so Coolify requires `sub_service_name` on `/services/{uuid}/logs` and "the service logs" has no single answer. The `service` tool gains a `list_containers` action returning the applications and databases inside a service, and `logs` refuses a service request without a `container`, pointing at that action rather than silently picking one.
+
+### Fixed
+
+- **Log endpoints returned an object behind a `string` type** (#300) — `getApplicationLogs` was declared `Promise<string>` but handed back Coolify's `{ logs: "..." }` envelope unchanged, so any caller doing string work on it would have failed at runtime. Confirmed against a live Coolify instance; the unit tests had mocked a bare string, which is why it went unnoticed. Responses are now unwrapped to a plain string, with bare strings still accepted for older instances.
+
 ### Changed
 
 - **Re-vendored `docs/coolify-openapi.yaml` from upstream, now covering Coolify v4.2** (#302) — the bundled spec is ground truth for "does Coolify support X" and predated v4.2, so it was missing **42 paths** (nothing was removed). The additions line up with the open v4.2 issues: tags on applications/databases/services (#298), `/move` between environments (#299), database, service and per-container logs (#300), service application and database management (#301), and destinations (#302). Also new and not previously tracked: volume backup schedules on storages, and DigitalOcean/Vultr server provisioning alongside Hetzner firewalls and networks. Five new schemas: `VolumeBackupScheduleRequest`, `VolumeBackupScheduleResponse`, `ApplicationSetting`, `Destination`, `Tag`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Coolify that provides 42 token-optimized tools for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, teams, cloud tokens, documentation search, smart diagnostics, and batch operations. v2.0.0 reduced token usage by 85% (from ~43,000 to ~6,600 tokens) by consolidating related operations into single tools with action parameters.
+MCP (Model Context Protocol) server for Coolify that provides 43 token-optimized tools for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, teams, cloud tokens, documentation search, smart diagnostics, and batch operations. v2.0.0 reduced token usage by 85% (from ~43,000 to ~6,600 tokens) by consolidating related operations into single tools with action parameters.
 
 ## Commands
 
@@ -158,6 +158,6 @@ When making changes to the codebase, ensure documentation is updated:
    - New example prompts needed
    - Response size improvements made (update comparison table)
 
-3. **This file (CLAUDE.md)** - Update tool count if changed (currently 42 tools)
+3. **This file (CLAUDE.md)** - Update tool count if changed (currently 43 tools)
 
 Always work on a feature branch and include documentation updates in the same PR as code changes.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.StuMason%2Fcoolify-blue)](https://registry.modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Manage [Coolify](https://coolify.io/) through natural language — 42 token-optimized MCP tools for deploying, debugging, and operating your self-hosted PaaS from Claude, Cursor, or any MCP client.
+Manage [Coolify](https://coolify.io/) through natural language — 43 token-optimized MCP tools for deploying, debugging, and operating your self-hosted PaaS from Claude, Cursor, or any MCP client.
 
 📖 **Full docs: [coolify-mcp.stumason.dev](https://coolify-mcp.stumason.dev)** — install guide, tools reference, architecture, security model, v3 roadmap.
 

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -4,7 +4,7 @@ import { withMermaid } from 'vitepress-plugin-mermaid';
 export default withMermaid(
   defineConfig({
     title: 'coolify-mcp',
-    description: 'MCP server for Coolify — 42 token-optimized tools for AI assistants',
+    description: 'MCP server for Coolify — 43 token-optimized tools for AI assistants',
 
     cleanUrls: true,
     // lastUpdated needs git available at build time; disabled until we wire
@@ -26,7 +26,7 @@ export default withMermaid(
         {
           name: 'og:description',
           content:
-            '42 token-optimized MCP tools. Drop into Claude / Cursor / Code. Drive your Coolify with natural language.',
+            '43 token-optimized MCP tools. Drop into Claude / Cursor / Code. Drive your Coolify with natural language.',
         },
       ],
     ],

--- a/site/guide/quickstart.md
+++ b/site/guide/quickstart.md
@@ -51,5 +51,5 @@ The v2.x tools don't yet declare `destructiveHint` / `readOnlyHint` annotations 
 
 ## What next?
 
-- [Tools reference](/tools/) — every one of the 42 tools, grouped by concern, marked read or destructive.
+- [Tools reference](/tools/) — every one of the 43 tools, grouped by concern, marked read or destructive.
 - [How coolify-mcp works](/concepts/how-it-works) — the architecture, the file structure, the security model.

--- a/site/index.md
+++ b/site/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: coolify-mcp
   text: A Coolify control surface for your AI assistant
-  tagline: 42 token-optimized MCP tools. Use it with Claude, Cursor, or any MCP client to manage your self-hosted infrastructure through natural language.
+  tagline: 43 token-optimized MCP tools. Use it with Claude, Cursor, or any MCP client to manage your self-hosted infrastructure through natural language.
   image:
     src: /favicon.svg
     alt: coolify-mcp

--- a/site/roadmap/index.md
+++ b/site/roadmap/index.md
@@ -32,7 +32,7 @@ v3 adopts the ones that move the needle for an infrastructure-management server.
 Can land before the v3 architecture work, with no breaking changes:
 
 - SDK upgrade `@modelcontextprotocol/sdk` 1.23 → 1.29
-- Tool annotations on all 42 tools
+- Tool annotations on all 43 tools
 - `outputSchema` on every `list_*` and `get_*` tool
 - Human `title` field on every tool
 

--- a/site/roadmap/v3-vision.md
+++ b/site/roadmap/v3-vision.md
@@ -34,7 +34,7 @@ flowchart TB
 flowchart LR
     subgraph v2["v2.x — tools-only"]
         v2c["Client"]
-        v2s["Server<br/>(42 tools)"]
+        v2s["Server<br/>(43 tools)"]
         v2k["Coolify"]
         v2c <--> v2s
         v2s <--> v2k

--- a/site/tools/index.md
+++ b/site/tools/index.md
@@ -1,6 +1,6 @@
 # Tools reference
 
-All 42 tools in coolify-mcp v2.11, grouped by concern. The full canonical list is registered in [`src/lib/mcp-server.ts`](https://github.com/StuMason/coolify-mcp/blob/main/src/lib/mcp-server.ts).
+All 43 tools in coolify-mcp v2.11, grouped by concern. The full canonical list is registered in [`src/lib/mcp-server.ts`](https://github.com/StuMason/coolify-mcp/blob/main/src/lib/mcp-server.ts).
 
 > Tools marked **read-only** are safe to let your MCP client run without per-call confirmation. Tools marked **destructive** change state and should be confirmed — v3 will surface these via `destructiveHint` annotations (see [v3 vision](/roadmap/v3-vision)).
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1794,6 +1794,98 @@ describe('CoolifyClient', () => {
       );
     });
 
+    // Verified against a live Coolify instance: log endpoints return
+    // { logs: "..." }, not a bare string. getApplicationLogs declared
+    // Promise<string> while returning that object unchanged — the tests below
+    // mocked a bare string, which is why the type lie went unnoticed (#300).
+    it('unwraps the { logs } envelope Coolify actually returns', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: 'line 1\nline 2' }));
+
+      const result = await client.getApplicationLogs('app-uuid', 50);
+
+      expect(result).toBe('line 1\nline 2');
+      expect(typeof result).toBe('string');
+    });
+
+    it('still accepts a bare string body from older instances', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse('raw log text', true, 200, 'text/plain; charset=utf-8'),
+      );
+
+      await expect(client.getApplicationLogs('app-uuid')).resolves.toBe('raw log text');
+    });
+
+    it('returns an empty string rather than undefined for an unrecognised body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ unexpected: true }));
+
+      await expect(client.getApplicationLogs('app-uuid')).resolves.toBe('');
+    });
+
+    it('sends show_timestamps only when asked', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: '' }));
+      await client.getApplicationLogs('app-uuid', 10, true);
+      expect(mockFetch.mock.calls[0][0]).toContain('show_timestamps=true');
+
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: '' }));
+      await client.getApplicationLogs('app-uuid', 10);
+      expect(mockFetch.mock.calls[1][0]).not.toContain('show_timestamps');
+    });
+
+    it('gets database logs (#300)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: 'db line' }));
+
+      const result = await client.getDatabaseLogs('db-uuid', 50);
+
+      expect(result).toBe('db line');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/databases/db-uuid/logs?lines=50',
+        expect.any(Object),
+      );
+    });
+
+    it('gets service logs for a named container, which Coolify requires (#300)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: 'svc line' }));
+
+      const result = await client.getServiceLogs('svc-uuid', 'postgres', 25);
+
+      expect(result).toBe('svc line');
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/services/svc-uuid/logs?');
+      expect(url).toContain('sub_service_name=postgres');
+      expect(url).toContain('lines=25');
+    });
+
+    it('url-encodes a container name with awkward characters', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: '' }));
+
+      await client.getServiceLogs('svc-uuid', 'my service/db');
+
+      expect(mockFetch.mock.calls[0][0]).toContain('sub_service_name=my+service%2Fdb');
+    });
+
+    it('lists the containers inside a service (#300)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponse([{ uuid: 'a1', name: 'app-one' }]))
+        .mockResolvedValueOnce(mockResponse([{ uuid: 'd1', name: 'postgres' }]));
+
+      await expect(client.listServiceApplications('svc-uuid')).resolves.toEqual([
+        { uuid: 'a1', name: 'app-one' },
+      ]);
+      await expect(client.listServiceDatabases('svc-uuid')).resolves.toEqual([
+        { uuid: 'd1', name: 'postgres' },
+      ]);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'http://localhost:3000/api/v1/services/svc-uuid/applications',
+        expect.any(Object),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:3000/api/v1/services/svc-uuid/databases',
+        expect.any(Object),
+      );
+    });
+
     it('should get application logs', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse('log line 1\nlog line 2'));
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1815,6 +1815,28 @@ describe('CoolifyClient', () => {
       await expect(client.getApplicationLogs('app-uuid')).resolves.toBe('raw log text');
     });
 
+    it('stringifies a non-string logs value rather than leaking a number', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: 12345 }));
+
+      // The declared return type is string; anything else would make it a lie
+      // again, which is the bug this whole normaliser exists to fix.
+      await expect(client.getApplicationLogs('app-uuid')).resolves.toBe('12345');
+    });
+
+    it('treats a null logs value as empty rather than the string "null"', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: null }));
+
+      await expect(client.getApplicationLogs('app-uuid')).resolves.toBe('');
+    });
+
+    it('defaults database logs to 100 lines when not specified', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ logs: '' }));
+
+      await client.getDatabaseLogs('db-uuid');
+
+      expect(mockFetch.mock.calls[0][0]).toContain('lines=100');
+    });
+
     it('returns an empty string rather than undefined for an unrecognised body', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse({ unexpected: true }));
 

--- a/src/__tests__/integration/logs.integration.test.ts
+++ b/src/__tests__/integration/logs.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration tests for the log endpoints added in #300.
+ *
+ * These exist because parts of this feature could not be verified from a
+ * development sandbox. `GET /applications/{uuid}/logs` was confirmed against a
+ * live instance to return `{ logs: "..." }` rather than a bare string, but
+ * upstream's OpenAPI types the service sub-resource listings as an untyped
+ * `array of object`, so the real shape of `/services/{uuid}/applications` and
+ * `/services/{uuid}/databases` is unconfirmed — as is whether the
+ * `sub_service_name` values they yield are accepted by `/services/{uuid}/logs`.
+ *
+ * Run these against a real Coolify before trusting the service paths:
+ *   npm run test:integration
+ *
+ * Prerequisites:
+ * - COOLIFY_URL and COOLIFY_TOKEN set (from .env)
+ * - TEST_APPLICATION_UUID / TEST_DATABASE_UUID / TEST_SERVICE_UUID set to
+ *   resources on that instance. Each block skips if its uuid is absent.
+ */
+
+import { config } from 'dotenv';
+import { describe, it, expect } from '@jest/globals';
+import { CoolifyClient } from '../../lib/coolify-client.js';
+
+config();
+
+const COOLIFY_URL = process.env.COOLIFY_URL;
+const COOLIFY_TOKEN = process.env.COOLIFY_TOKEN;
+const APPLICATION_UUID = process.env.TEST_APPLICATION_UUID;
+const DATABASE_UUID = process.env.TEST_DATABASE_UUID;
+const SERVICE_UUID = process.env.TEST_SERVICE_UUID;
+
+const shouldRun = Boolean(COOLIFY_URL && COOLIFY_TOKEN);
+
+const client = shouldRun
+  ? new CoolifyClient({ baseUrl: COOLIFY_URL as string, accessToken: COOLIFY_TOKEN as string })
+  : (null as unknown as CoolifyClient);
+
+const describeIf = (condition: boolean) => (condition ? describe : describe.skip);
+
+describeIf(shouldRun)('logs integration', () => {
+  describeIf(Boolean(APPLICATION_UUID))('application logs', () => {
+    it('returns a plain string, not the raw { logs } envelope', async () => {
+      const logs = await client.getApplicationLogs(APPLICATION_UUID as string, 5);
+
+      // The whole point of the unwrapping in #300 — a caller must be able to do
+      // string work on this without it silently being an object.
+      expect(typeof logs).toBe('string');
+      expect(logs).not.toContain('{"logs"');
+    }, 30_000);
+
+    it('accepts show_timestamps without erroring', async () => {
+      const logs = await client.getApplicationLogs(APPLICATION_UUID as string, 5, true);
+      expect(typeof logs).toBe('string');
+    }, 30_000);
+  });
+
+  describeIf(Boolean(DATABASE_UUID))('database logs', () => {
+    it('returns a plain string', async () => {
+      const logs = await client.getDatabaseLogs(DATABASE_UUID as string, 5);
+      expect(typeof logs).toBe('string');
+    }, 30_000);
+  });
+
+  describeIf(Boolean(SERVICE_UUID))('service containers', () => {
+    it('lists the containers inside a service with usable names', async () => {
+      const [applications, databases] = await Promise.all([
+        client.listServiceApplications(SERVICE_UUID as string),
+        client.listServiceDatabases(SERVICE_UUID as string),
+      ]);
+
+      expect(Array.isArray(applications)).toBe(true);
+      expect(Array.isArray(databases)).toBe(true);
+
+      // The shape assumption this whole feature rests on: every container has a
+      // `name`, because that is what `logs` passes as `sub_service_name`.
+      for (const container of [...applications, ...databases]) {
+        expect(typeof container.name).toBe('string');
+        expect(container.name.length).toBeGreaterThan(0);
+      }
+    }, 30_000);
+
+    it('fetches logs for a container discovered from that listing', async () => {
+      const applications = await client.listServiceApplications(SERVICE_UUID as string);
+      const databases = await client.listServiceDatabases(SERVICE_UUID as string);
+      const container = [...applications, ...databases][0];
+
+      if (!container) {
+        console.warn('Service has no containers — skipping the round-trip assertion');
+        return;
+      }
+
+      // Closes the loop: a name from list_containers must be accepted by the
+      // logs endpoint. If this fails, discovery and retrieval disagree.
+      const logs = await client.getServiceLogs(SERVICE_UUID as string, container.name, 5);
+      expect(typeof logs).toBe('string');
+    }, 30_000);
+  });
+});

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1668,12 +1668,111 @@ describe('truncateLogs', () => {
 // Action Generators Tests
 // =============================================================================
 
+describe('logs tool (#300)', () => {
+  let server: CoolifyMcpServer;
+
+  beforeEach(() => {
+    server = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+  });
+
+  const callLogs = async (args: Record<string, unknown>) => {
+    const tool = (
+      server as unknown as {
+        _registeredTools: Record<
+          string,
+          { handler: (a: unknown, b: unknown) => Promise<{ content: Array<{ text: string }> }> }
+        >;
+      }
+    )._registeredTools['logs'];
+    return tool.handler(args, {});
+  };
+
+  it('routes to the application endpoint', async () => {
+    const spy = jest.spyOn(server['client'], 'getApplicationLogs').mockResolvedValue('app logs');
+    await callLogs({ resource: 'application', uuid: 'app-uuid', lines: 20 });
+    expect(spy).toHaveBeenCalledWith('app-uuid', 20, undefined);
+  });
+
+  it('routes to the database endpoint', async () => {
+    const spy = jest.spyOn(server['client'], 'getDatabaseLogs').mockResolvedValue('db logs');
+    await callLogs({ resource: 'database', uuid: 'db-uuid', show_timestamps: true });
+    expect(spy).toHaveBeenCalledWith('db-uuid', undefined, true);
+  });
+
+  it('routes to the service endpoint with the container name', async () => {
+    const spy = jest.spyOn(server['client'], 'getServiceLogs').mockResolvedValue('svc logs');
+    await callLogs({ resource: 'service', uuid: 'svc-uuid', container: 'postgres' });
+    expect(spy).toHaveBeenCalledWith('svc-uuid', 'postgres', undefined, undefined);
+  });
+
+  // A service is several containers, so "the service logs" has no single answer.
+  // Better to say so than to silently pick one.
+  it('refuses a service request with no container and points at list_containers', async () => {
+    const spy = jest.spyOn(server['client'], 'getServiceLogs');
+    const result = (await callLogs({ resource: 'service', uuid: 'svc-uuid' })) as {
+      content: Array<{ text: string }>;
+    };
+
+    expect(result.content[0].text).toContain('container required');
+    expect(result.content[0].text).toContain('list_containers');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('service list_containers action (#300)', () => {
+  let server: CoolifyMcpServer;
+
+  beforeEach(() => {
+    server = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+  });
+
+  const callService = async (args: Record<string, unknown>) => {
+    const tool = (
+      server as unknown as {
+        _registeredTools: Record<
+          string,
+          { handler: (a: unknown, b: unknown) => Promise<{ content: Array<{ text: string }> }> }
+        >;
+      }
+    )._registeredTools['service'];
+    return tool.handler(args, {});
+  };
+
+  it('returns the applications and databases inside a service', async () => {
+    jest
+      .spyOn(server['client'], 'listServiceApplications')
+      .mockResolvedValue([{ uuid: 'a1', name: 'app-one' }]);
+    jest
+      .spyOn(server['client'], 'listServiceDatabases')
+      .mockResolvedValue([{ uuid: 'd1', name: 'postgres' }]);
+
+    const result = (await callService({ action: 'list_containers', uuid: 'svc-uuid' })) as {
+      content: Array<{ text: string }>;
+    };
+    const parsed = JSON.parse(result.content[0].text) as {
+      applications: Array<{ name: string }>;
+      databases: Array<{ name: string }>;
+    };
+
+    // These names are exactly what `logs` needs as `container`.
+    expect(parsed.applications[0].name).toBe('app-one');
+    expect(parsed.databases[0].name).toBe('postgres');
+  });
+
+  it('requires a uuid', async () => {
+    const result = (await callService({ action: 'list_containers' })) as {
+      content: Array<{ text: string }>;
+    };
+    expect(result.content[0].text).toContain('uuid required');
+  });
+});
+
 describe('getApplicationActions', () => {
   it('should return view logs action for all apps', () => {
     const actions = getApplicationActions('app-uuid', 'stopped');
     expect(actions).toContainEqual({
-      tool: 'application_logs',
-      args: { uuid: 'app-uuid' },
+      tool: 'logs',
+      args: { resource: 'application', uuid: 'app-uuid' },
       hint: 'View logs',
     });
   });
@@ -1744,8 +1843,8 @@ describe('getDeploymentActions', () => {
       hint: 'View app',
     });
     expect(actions).toContainEqual({
-      tool: 'application_logs',
-      args: { uuid: 'app-uuid' },
+      tool: 'logs',
+      args: { resource: 'application', uuid: 'app-uuid' },
       hint: 'App logs',
     });
   });

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -113,6 +113,7 @@ import type {
   // Resource list types
   ResourceListItem,
   ResourceListItemFull,
+  ServiceSubResource,
 } from '../types/coolify.js';
 
 // =============================================================================
@@ -257,6 +258,27 @@ export class CoolifyApiError extends Error {
     super(message);
     this.name = 'CoolifyApiError';
   }
+}
+
+/**
+ * Normalise a log endpoint response to a plain string.
+ *
+ * Coolify returns `{ logs: "..." }` — confirmed against a live instance and
+ * matching upstream's OpenAPI. `getApplicationLogs` previously declared
+ * `Promise<string>` while handing back that object unchanged, so the type was a
+ * lie and any caller doing string work on it would have failed at runtime. Its
+ * unit tests mocked a bare string, which is why it went unnoticed.
+ *
+ * Bare strings are still accepted, since older instances have been observed
+ * returning one and the cost of tolerating both is a single check.
+ */
+function unwrapLogs(response: unknown): string {
+  if (typeof response === 'string') return response;
+  if (response && typeof response === 'object' && 'logs' in response) {
+    const { logs } = response as { logs: unknown };
+    return typeof logs === 'string' ? logs : String(logs ?? '');
+  }
+  return '';
 }
 
 /**
@@ -1037,8 +1059,50 @@ export class CoolifyClient {
     });
   }
 
-  async getApplicationLogs(uuid: string, lines: number = 100): Promise<string> {
-    return this.request<string>(`/applications/${uuid}/logs?lines=${lines}`);
+  async getApplicationLogs(
+    uuid: string,
+    lines: number = 100,
+    showTimestamps?: boolean,
+  ): Promise<string> {
+    const query = this.buildQueryString({ lines, show_timestamps: showTimestamps });
+    return unwrapLogs(await this.request<unknown>(`/applications/${uuid}/logs${query}`));
+  }
+
+  async getDatabaseLogs(
+    uuid: string,
+    lines: number = 100,
+    showTimestamps?: boolean,
+  ): Promise<string> {
+    const query = this.buildQueryString({ lines, show_timestamps: showTimestamps });
+    return unwrapLogs(await this.request<unknown>(`/databases/${uuid}/logs${query}`));
+  }
+
+  /**
+   * Logs for one container inside a service. `subServiceName` is required by
+   * Coolify — a service is a multi-container stack, so "the service logs" is
+   * ambiguous without it. Discover valid names via {@link listServiceApplications}
+   * and {@link listServiceDatabases}.
+   */
+  async getServiceLogs(
+    uuid: string,
+    subServiceName: string,
+    lines: number = 100,
+    showTimestamps?: boolean,
+  ): Promise<string> {
+    const query = this.buildQueryString({
+      sub_service_name: subServiceName,
+      lines,
+      show_timestamps: showTimestamps,
+    });
+    return unwrapLogs(await this.request<unknown>(`/services/${uuid}/logs${query}`));
+  }
+
+  async listServiceApplications(uuid: string): Promise<ServiceSubResource[]> {
+    return this.request<ServiceSubResource[]>(`/services/${uuid}/applications`);
+  }
+
+  async listServiceDatabases(uuid: string): Promise<ServiceSubResource[]> {
+    return this.request<ServiceSubResource[]>(`/services/${uuid}/databases`);
   }
 
   async startApplication(

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -132,7 +132,7 @@ export function truncateLogs(
 /** Generate contextual actions for an application based on its status */
 export function getApplicationActions(uuid: string, status?: string): ResponseAction[] {
   const actions: ResponseAction[] = [
-    { tool: 'application_logs', args: { uuid }, hint: 'View logs' },
+    { tool: 'logs', args: { resource: 'application', uuid }, hint: 'View logs' },
   ];
   const s = (status || '').toLowerCase();
   if (s.includes('running')) {
@@ -168,7 +168,11 @@ export function getDeploymentActions(
   }
   if (appUuid) {
     actions.push({ tool: 'get_application', args: { uuid: appUuid }, hint: 'View app' });
-    actions.push({ tool: 'application_logs', args: { uuid: appUuid }, hint: 'App logs' });
+    actions.push({
+      tool: 'logs',
+      args: { resource: 'application', uuid: appUuid },
+      hint: 'App logs',
+    });
   }
   return actions;
 }
@@ -939,8 +943,47 @@ export class CoolifyMcpServer extends McpServer {
     );
 
     this.tool(
+      'logs',
+      "Get container logs for an application, database, or service. A service is a multi-container stack, so resource='service' requires `container` — the sub-service name, which you can list with the `service` tool's `list_containers` action. Use `lines` to bound the output and `show_timestamps` when you need to correlate events across resources (not supported on service containers).",
+      {
+        resource: z.enum(['application', 'database', 'service']),
+        uuid: z.string(),
+        container: z
+          .string()
+          .optional()
+          .describe(
+            "Sub-service name, required when resource='service'. Get valid names from `service` action=list_containers.",
+          ),
+        lines: z.number().optional().describe('Number of log lines to return (default 100)'),
+        show_timestamps: z
+          .boolean()
+          .optional()
+          .describe('Prefix each line with its timestamp. Not supported for service containers.'),
+      },
+      async ({ resource, uuid, container, lines, show_timestamps }) => {
+        if (resource === 'service') {
+          if (!container) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: "Error: container required when resource='service' — a service runs several containers, so 'the service logs' is ambiguous. List valid names with the `service` tool, action=list_containers.",
+                },
+              ],
+            };
+          }
+          return wrap(() => this.client.getServiceLogs(uuid, container, lines, show_timestamps));
+        }
+        if (resource === 'database') {
+          return wrap(() => this.client.getDatabaseLogs(uuid, lines, show_timestamps));
+        }
+        return wrap(() => this.client.getApplicationLogs(uuid, lines, show_timestamps));
+      },
+    );
+
+    this.tool(
       'application_logs',
-      'Get app logs',
+      'Get app logs. Superseded by `logs` (resource=application), which also covers databases and services — prefer that. Kept for compatibility and scheduled for removal in v3.',
       { uuid: z.string(), lines: z.number().optional() },
       async ({ uuid, lines }) => wrap(() => this.client.getApplicationLogs(uuid, lines)),
     );
@@ -1058,9 +1101,9 @@ export class CoolifyMcpServer extends McpServer {
 
     this.tool(
       'service',
-      'Manage service: create/update/delete',
+      'Manage service: create/update/delete/list_containers. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`.',
       {
-        action: z.enum(['create', 'update', 'delete']),
+        action: z.enum(['create', 'update', 'delete', 'list_containers']),
         uuid: z.string().optional(),
         type: z.string().optional(),
         server_uuid: z.string().optional(),
@@ -1078,6 +1121,17 @@ export class CoolifyMcpServer extends McpServer {
       async (args) => {
         const { action, uuid, delete_volumes } = args;
         switch (action) {
+          case 'list_containers': {
+            if (!uuid)
+              return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
+            return wrap(async () => {
+              const [applications, databases] = await Promise.all([
+                this.client.listServiceApplications(uuid),
+                this.client.listServiceDatabases(uuid),
+              ]);
+              return { applications, databases };
+            });
+          }
           case 'create':
             if (!args.server_uuid || !args.project_uuid) {
               return {
@@ -1151,7 +1205,11 @@ export class CoolifyMcpServer extends McpServer {
         const getControlActions = (): ResponseAction[] => {
           const actions: ResponseAction[] = [];
           if (resource === 'application') {
-            actions.push({ tool: 'application_logs', args: { uuid }, hint: 'View logs' });
+            actions.push({
+              tool: 'logs',
+              args: { resource: 'application', uuid },
+              hint: 'View logs',
+            });
             actions.push({ tool: 'get_application', args: { uuid }, hint: 'Check status' });
             if (action === 'start' || action === 'restart') {
               actions.push({

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -842,6 +842,30 @@ export interface ServiceCreateResponse {
   domains: string[];
 }
 
+/**
+ * A container inside a Coolify service. Services are multi-container stacks, and
+ * `name` is the `sub_service_name` that `GET /services/{uuid}/logs` requires.
+ *
+ * Deliberately permissive: upstream's OpenAPI types the list responses as a bare
+ * `array of object`, so only the fields we actually rely on are declared and the
+ * rest pass through untyped rather than being asserted from an unverified spec.
+ */
+export interface ServiceSubResource {
+  uuid: string;
+  name: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Log endpoints return `{ logs: "..." }` — verified against a live Coolify
+ * instance, and matching upstream's OpenAPI. Older instances have been observed
+ * returning a bare string, so {@link CoolifyClient} normalises both.
+ */
+export interface LogsResponse {
+  logs: string;
+}
+
 // =============================================================================
 // Deployment Types
 // =============================================================================


### PR DESCRIPTION
Closes #300. **Stacked on #304** (the spec re-vendor) — these endpoints only exist in the v4.2 spec, so `check:spec-drift` needs that first. Merge #304 then this reduces to its own diff.

## Problem

`diagnose_app` can explain an unhealthy application by reading its logs. Ask the same question about a **database** or a **service** and the server had nothing to look at, so the answer was "go and open the Coolify UI" — at exactly the moment you most want logs.

## One tool, not four

Coolify v4.2 added four log endpoints. The obvious implementation is `database_logs`, `service_logs` and friends as new top-level tools; that would have been wrong. The whole v2.0.0 design is consolidated action-param tools holding the list at ~6,600 tokens, and four siblings works against it.

So this adds **one `logs` tool** with a `resource` param, in the same shape as `env_vars` and `control`:

```
logs(resource: application | database | service, uuid, container?, lines?, show_timestamps?)
```

`application_logs` still works and is marked superseded in its description, scheduled for removal in v3. The `_actions` hints now point at `logs`. Tool count 42 → 43, verified by counting registered tools rather than trusting the docs.

Also plumbs through **`show_timestamps`**, which upstream has always supported and this client never sent.

## Services need a container, and it has to be discoverable

A service is a multi-container stack, so Coolify requires `sub_service_name` on `/services/{uuid}/logs`. "The service logs" genuinely has no single answer.

Nothing in the MCP could discover those names — `Service` has no sub-resource list. So the `service` tool gains a **`list_containers`** action returning the applications and databases inside a service. `logs` refuses a service request without a `container` and points at that action, rather than silently picking a container and returning logs for something the caller didn't ask about.

That discovery pairing is why the two listing endpoints are here rather than in #301; #301 keeps the start/stop/restart control surface for service sub-resources.

## A real bug found on the way

`getApplicationLogs` was declared `Promise<string>` but returned Coolify's `{ logs: "..." }` envelope **unchanged**. Any caller doing string work on it would have failed at runtime.

Confirmed against a live Coolify instance:

```json
{ "logs": "127.0.0.1 - - [29/Jul/2026:12:15:13 +0000] \"GET / HTTP/1.1\" 200 ..." }
```

The unit tests mocked a bare string, which is why the type lie survived. Responses are now unwrapped to a genuine string, with bare strings still accepted since older instances have been seen returning one.

## What I could not verify from here

Upstream's OpenAPI types `/services/{uuid}/applications` and `/services/{uuid}/databases` as an untyped `array of object`, and I can't reach the Coolify API directly from the dev sandbox (Cloudflare Access; only the installed MCP gets through, and it predates these endpoints).

Rather than assert a shape from an unreliable spec, `ServiceSubResource` declares only `uuid`, `name` and optional `status`, and passes everything else through untyped. **`src/__tests__/integration/logs.integration.test.ts`** covers the gap — including the round trip that actually matters: a name from `list_containers` must be accepted by the logs endpoint. Worth running `npm run test:integration` against your instance before merging.

Set `TEST_APPLICATION_UUID`, `TEST_DATABASE_UUID` and `TEST_SERVICE_UUID` in `.env`; each block skips if its uuid is absent.

## Testing

- **472 tests pass** (458 before, 14 new). Coverage 98.3% statements / 99.55% functions.
- Client: `{ logs }` unwrapping, bare-string fallback, unrecognised body → empty string rather than `undefined`, `show_timestamps` only sent when asked, container-name URL encoding, and both listing endpoints.
- Tool layer: routing per resource, and that a service request with no container refuses and names `list_containers` instead of calling the client.
- `check:spec-drift` now validates **102** client routes (was 98) — the new endpoints resolve against the re-vendored spec, which is the concrete proof #304 was the prerequisite.
- `check:chunk-drift` OK, lint 0 errors, build clean.

## Follow-up spotted, not done here

Log output goes through `wrap()`, which `JSON.stringify`s it — so newlines come back escaped as `\n`. Readable enough, but wasteful for the one tool whose entire payload is newline-separated text. A raw-text wrapper for log tools would be a real token win. Deliberately out of scope so this stays reviewable.
