### PR TITLE
feat: annotate all 43 tools and migrate off the deprecated tool() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **Correction to the issue's premise:** #260 said annotations were zero-cost because they ride the existing `tools/list` response. They ride it, but they are not free — spelling out every hint measured at ~751 tokens against a ~6,600 token budget. Only non-default hints are emitted now (per spec: `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=true`), which halves it to ~415 tokens, with a test that fails if the defaults creep back in.
 
-### Added
-
 - **`logs` tool: container logs for databases and services, not just applications** (#300) — `diagnose_app` could explain an unhealthy application by reading its logs, but the same question about a database or a service had no answer and sent you to the Coolify UI, which is exactly the moment you want logs.
 
   Added as **one consolidated `logs` tool** with a `resource` parameter (`application` / `database` / `service`), matching the `env_vars` and `control` pattern, rather than three or four sibling tools — the token budget is the point of the v2.0.0 design. `application_logs` still works and is marked superseded in its description; it will be removed in v3. Also adds `show_timestamps`, which upstream has always supported and this client never sent.
@@ -27,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Log endpoints returned an object behind a `string` type** (#300) — `getApplicationLogs` was declared `Promise<string>` but handed back Coolify's `{ logs: "..." }` envelope unchanged, so any caller doing string work on it would have failed at runtime. Confirmed against a live Coolify instance; the unit tests had mocked a bare string, which is why it went unnoticed. Responses are now unwrapped to a plain string, with bare strings still accepted for older instances.
 
+- **Corrected the documented behaviour of `search_docs`** — `site/concepts/how-it-works.md` described it as "a local MiniSearch index over `docs/openapi-chunks/`". It actually fetches Coolify's published `llms-full.txt` at runtime and indexes that; it has never read the chunks.
+
 ### Changed
 
 - **Re-vendored `docs/coolify-openapi.yaml` from upstream, now covering Coolify v4.2** (#302) — the bundled spec is ground truth for "does Coolify support X" and predated v4.2, so it was missing **42 paths** (nothing was removed). The additions line up with the open v4.2 issues: tags on applications/databases/services (#298), `/move` between environments (#299), database, service and per-container logs (#300), service application and database management (#301), and destinations (#302). Also new and not previously tracked: volume backup schedules on storages, and DigitalOcean/Vultr server provisioning alongside Hetzner firewalls and networks. Five new schemas: `VolumeBackupScheduleRequest`, `VolumeBackupScheduleResponse`, `ApplicationSetting`, `Destination`, `Tag`.
@@ -34,10 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/openapi-chunks/` is now generated, not hand-maintained** (#302) — the chunks are a developer reference that CLAUDE.md and the contributing guide both point at, but they were curated by hand and silently went stale the moment the spec was re-vendored, which made the reference a trap. `npm run build:chunks` regenerates them from the bundled spec by first path segment, and `npm run check:chunk-drift` fails CI if they diverge. New `destinations-api`, `tags-api` and `cloud-providers-api` chunks; every path and schema in the spec is carried exactly once, asserted by tests.
 
 - **The vendored spec is byte-identical to upstream again** — Prettier had reformatted it at some point, so `git diff` against a fresh upstream download showed whitespace churn rather than real API changes. `docs/coolify-openapi.yaml` and the generated chunks are now in `.prettierignore`, which also means re-vendoring is a clean overwrite.
-
-### Fixed
-
-- **Corrected the documented behaviour of `search_docs`** — `site/concepts/how-it-works.md` described it as "a local MiniSearch index over `docs/openapi-chunks/`". It actually fetches Coolify's published `llms-full.txt` at runtime and indexes that; it has never read the chunks.
 
 ## [2.15.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tool annotations on all 43 tools, and migration off the deprecated `tool()` API** (#260) — every tool now declares `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`. These are spec-stable since 2025-03-26 and already change client behaviour: Claude Code parallel-dispatches tools marked read-only, and VS Code Copilot stops raising confirmation dialogs for reads. 21 tools are read-only, 20 destructive, 2 neither (`hetzner` provisions but only ever adds; `validate_server` is idempotent).
+
+  Registration moved from the SDK's deprecated `tool()` overloads to `registerTool()`, which is also the shape SDK v2 keeps, so this is prep for #259. All 43 call sites go through one `defineTool` wrapper that looks annotations up from a single table — a tool missing from it **throws at construction** rather than silently shipping unannotated. The classification lives in one auditable place rather than scattered across 43 call sites, and tests assert the table and the registered tools stay exactly in step.
+
+  **Correction to the issue's premise:** #260 said annotations were zero-cost because they ride the existing `tools/list` response. They ride it, but they are not free — spelling out every hint measured at ~751 tokens against a ~6,600 token budget. Only non-default hints are emitted now (per spec: `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=true`), which halves it to ~415 tokens, with a test that fails if the defaults creep back in.
+
+### Added
+
 - **`logs` tool: container logs for databases and services, not just applications** (#300) — `diagnose_app` could explain an unhealthy application by reading its logs, but the same question about a database or a service had no answer and sent you to the Coolify UI, which is exactly the moment you want logs.
 
   Added as **one consolidated `logs` tool** with a `resource` parameter (`application` / `database` / `service`), matching the `env_vars` and `control` pattern, rather than three or four sibling tools — the token budget is the point of the v2.0.0 design. `application_logs` still works and is marked superseded in its description; it will be removed in v3. Also adds `show_timestamps`, which upstream has always supported and this client never sent.

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -7,6 +7,8 @@
  */
 import { createRequire } from 'module';
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import {
   CoolifyMcpServer,
   TOOL_ANNOTATIONS,
@@ -1791,20 +1793,51 @@ describe('tool annotations (#260)', () => {
     expect(registered['hetzner'].annotations).toMatchObject({ destructiveHint: false });
   });
 
-  // #260 claimed annotations were free because they ride the existing
-  // tools/list response. They ride it, but they are not free — and this repo's
-  // headline is a ~6,600 token tool list, so the number needs a guard.
-  it('keeps the annotation payload small by emitting only non-default hints', () => {
-    const withAnnotations = Object.entries(registered).map(([name, t]) => ({
-      name,
-      annotations: t.annotations,
-    }));
-    const without = Object.entries(registered).map(([name]) => ({ name }));
-    const addedBytes = JSON.stringify(withAnnotations).length - JSON.stringify(without).length;
+  // Everything above reads _registeredTools, which verifies registration but
+  // not the wire format. These two drive a real client over an in-memory
+  // transport, so they assert what a client actually receives.
+  describe('over a real tools/list round trip', () => {
+    const listTools = async () => {
+      const srv = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+      const client = new Client({ name: 'test', version: '0' });
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+      await Promise.all([srv.connect(serverTransport), client.connect(clientTransport)]);
+      const { tools } = await client.listTools();
+      await client.close();
+      return tools;
+    };
 
-    // Spelling out spec defaults (readOnlyHint=false, openWorldHint=true, ...)
-    // more than doubled this. Fails loudly if someone reintroduces them.
-    expect(addedBytes).toBeLessThan(2000);
+    it('delivers annotations to the client, not just to the registry', async () => {
+      const tools = await listTools();
+
+      expect(tools).toHaveLength(Object.keys(TOOL_ANNOTATIONS).length);
+      const unannotated = tools.filter((t) => !t.annotations).map((t) => t.name);
+      expect(unannotated).toEqual([]);
+
+      const logs = tools.find((t) => t.name === 'logs');
+      expect(logs?.annotations?.readOnlyHint).toBe(true);
+      const stopAll = tools.find((t) => t.name === 'stop_all_apps');
+      expect(stopAll?.annotations?.destructiveHint).toBe(true);
+    });
+
+    // #260 claimed annotations were free because they ride the existing
+    // tools/list response. They ride it, but they are not free — and this
+    // repo's headline is a ~6,600 token tool list, so the number needs a guard.
+    // Measured on the real payload rather than a reconstruction of it.
+    it('keeps the annotation payload small by emitting only non-default hints', async () => {
+      const tools = await listTools();
+      const withAnnotations = JSON.stringify(tools).length;
+      const without = JSON.stringify(
+        tools.map(({ annotations: _annotations, ...rest }) => rest),
+      ).length;
+      const addedBytes = withAnnotations - without;
+
+      // Asserted per tool, not as a fixed ceiling: a fixed total would trip on
+      // roughly the 52nd tool and blame the spec defaults for what was
+      // actually just growth. All four hints spelled out is ~90 bytes/tool, so
+      // 50 catches the thing being guarded against and survives new tools.
+      expect(addedBytes / tools.length).toBeLessThan(50);
+    });
   });
 
   it('refuses to register a tool missing from the annotations table', () => {

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -9,6 +9,7 @@ import { createRequire } from 'module';
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import {
   CoolifyMcpServer,
+  TOOL_ANNOTATIONS,
   VERSION,
   truncateLogs,
   getApplicationActions,
@@ -1667,6 +1668,155 @@ describe('truncateLogs', () => {
 // =============================================================================
 // Action Generators Tests
 // =============================================================================
+
+describe('tool annotations (#260)', () => {
+  let server: CoolifyMcpServer;
+  let registered: Record<string, { annotations?: Record<string, boolean> }>;
+
+  beforeEach(() => {
+    server = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+    registered = (
+      server as unknown as {
+        _registeredTools: Record<string, { annotations?: Record<string, boolean> }>;
+      }
+    )._registeredTools;
+  });
+
+  it('annotates every registered tool', () => {
+    const unannotated = Object.entries(registered)
+      .filter(([, t]) => !t.annotations)
+      .map(([name]) => name);
+    expect(unannotated).toEqual([]);
+  });
+
+  it('keeps the annotations table and the registered tools exactly in step', () => {
+    // Either direction is a bug: a table entry with no tool is dead config, a
+    // tool with no entry cannot register at all (defineTool throws).
+    expect(Object.keys(TOOL_ANNOTATIONS).sort()).toEqual(Object.keys(registered).sort());
+  });
+
+  it('never marks a tool both read-only and destructive', () => {
+    const contradictory = Object.entries(registered)
+      .filter(([, t]) => t.annotations?.readOnlyHint && t.annotations?.destructiveHint)
+      .map(([name]) => name);
+    expect(contradictory).toEqual([]);
+  });
+
+  it('marks the read-only surface, which is what clients parallel-dispatch', () => {
+    const readOnly = Object.entries(registered)
+      .filter(([, t]) => t.annotations?.readOnlyHint === true)
+      .map(([name]) => name)
+      .sort();
+
+    expect(readOnly).toEqual(
+      [
+        'application_logs',
+        'diagnose_app',
+        'diagnose_server',
+        'find_issues',
+        'get_application',
+        'get_database',
+        'get_infrastructure_overview',
+        'get_mcp_version',
+        'get_server',
+        'get_service',
+        'get_version',
+        'list_applications',
+        'list_databases',
+        'list_deployments',
+        'list_servers',
+        'list_services',
+        'logs',
+        'search_docs',
+        'server_domains',
+        'server_resources',
+        'teams',
+      ].sort(),
+    );
+  });
+
+  it('marks every tool with a delete, stop or replace action as destructive', () => {
+    const destructive = Object.entries(registered)
+      .filter(([, t]) => t.annotations?.destructiveHint === true)
+      .map(([name]) => name)
+      .sort();
+
+    expect(destructive).toEqual(
+      [
+        'application',
+        'bulk_env_update',
+        'cloud_tokens',
+        'control',
+        'database',
+        'database_backups',
+        'deploy',
+        'deployment',
+        'env_vars',
+        'environments',
+        'github_apps',
+        'private_keys',
+        'projects',
+        'redeploy_project',
+        'restart_project_apps',
+        'scheduled_tasks',
+        'service',
+        'stop_all_apps',
+        'storages',
+        'system',
+      ].sort(),
+    );
+  });
+
+  it('treats get_mcp_version as the one tool touching nothing external', () => {
+    // Everything else reaches the Coolify API; this returns a local constant.
+    expect(registered['get_mcp_version'].annotations?.openWorldHint).toBe(false);
+    const openWorld = Object.entries(registered).filter(
+      ([, t]) => t.annotations?.openWorldHint === false,
+    );
+    expect(openWorld).toHaveLength(1);
+  });
+
+  it('marks validate_server idempotent rather than destructive', () => {
+    // Re-running a validation converges on the same state, so a client has no
+    // reason to gate it behind confirmation.
+    expect(registered['validate_server'].annotations).toMatchObject({
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+  });
+
+  it('does not mark hetzner destructive — every action is additive', () => {
+    // It provisions paid servers, which is consequential, but destructiveHint
+    // means "may replace or remove", not "may cost money".
+    expect(registered['hetzner'].annotations).toMatchObject({ destructiveHint: false });
+  });
+
+  // #260 claimed annotations were free because they ride the existing
+  // tools/list response. They ride it, but they are not free — and this repo's
+  // headline is a ~6,600 token tool list, so the number needs a guard.
+  it('keeps the annotation payload small by emitting only non-default hints', () => {
+    const withAnnotations = Object.entries(registered).map(([name, t]) => ({
+      name,
+      annotations: t.annotations,
+    }));
+    const without = Object.entries(registered).map(([name]) => ({ name }));
+    const addedBytes = JSON.stringify(withAnnotations).length - JSON.stringify(without).length;
+
+    // Spelling out spec defaults (readOnlyHint=false, openWorldHint=true, ...)
+    // more than doubled this. Fails loudly if someone reintroduces them.
+    expect(addedBytes).toBeLessThan(2000);
+  });
+
+  it('refuses to register a tool missing from the annotations table', () => {
+    const define = (
+      server as unknown as {
+        defineTool: (n: string, d: string, s: object, cb: () => unknown) => void;
+      }
+    ).defineTool.bind(server);
+
+    expect(() => define('totally_new_tool', 'x', {}, () => ({}))).toThrow(/TOOL_ANNOTATIONS/);
+  });
+});
 
 describe('logs tool (#300)', () => {
   let server: CoolifyMcpServer;

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -6,6 +6,9 @@
 import { createRequire } from 'module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { z } from 'zod';
 import {
   CoolifyClient,
@@ -272,7 +275,119 @@ interface DeployWaitResult {
   additional_deployment_uuids?: string[];
 }
 
+/**
+ * Tool annotations, spec-stable since 2025-03-26 and honoured by SDK 1.x
+ * `registerTool`. They ride the existing `tools/list` response, so they cost no
+ * extra tokens.
+ *
+ * Kept as one table rather than scattered across 43 call sites so the safety
+ * classification of the whole surface can be audited in one place — which is
+ * the point of it. Tests assert this map and the registered tools stay 1:1.
+ *
+ * Semantics (per spec):
+ * - `readOnlyHint` — the tool does not modify its environment at all.
+ * - `destructiveHint` — may perform destructive updates, as opposed to purely
+ *   additive ones. Only meaningful when `readOnlyHint` is false.
+ * - `idempotentHint` — repeated calls with the same arguments have no
+ *   additional effect. Only meaningful when `readOnlyHint` is false.
+ * - `openWorldHint` — interacts with an external entity (here, the Coolify API).
+ *
+ * Consolidated tools take worst-case values: any tool with a `delete` action is
+ * destructive even though most of its actions are not.
+ */
+// Only non-default hints are emitted. Per spec the defaults are
+// readOnlyHint=false, destructiveHint=true, idempotentHint=false and
+// openWorldHint=true, so spelling those out costs tokens on every tools/list
+// and tells a compliant client nothing it did not already assume.
+// `destructiveHint: true` is the deliberate exception: it is the default, but
+// it is also the safety signal, and stating it explicitly is worth the bytes.
+const READ_ONLY: ToolAnnotations = { readOnlyHint: true };
+const DESTRUCTIVE: ToolAnnotations = { destructiveHint: true };
+
+export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
+  // --- Read-only -----------------------------------------------------------
+  get_version: READ_ONLY,
+  // Local constant, no API call — the one tool that touches nothing external.
+  get_mcp_version: { readOnlyHint: true, openWorldHint: false },
+  get_infrastructure_overview: READ_ONLY,
+  list_servers: READ_ONLY,
+  list_applications: READ_ONLY,
+  list_databases: READ_ONLY,
+  list_services: READ_ONLY,
+  list_deployments: READ_ONLY,
+  get_server: READ_ONLY,
+  get_application: READ_ONLY,
+  get_database: READ_ONLY,
+  get_service: READ_ONLY,
+  server_resources: READ_ONLY,
+  server_domains: READ_ONLY,
+  diagnose_app: READ_ONLY,
+  diagnose_server: READ_ONLY,
+  find_issues: READ_ONLY,
+  search_docs: READ_ONLY,
+  application_logs: READ_ONLY,
+  logs: READ_ONLY,
+  teams: READ_ONLY,
+
+  // --- Destructive: every one of these has a delete, stop, or replace ------
+  application: DESTRUCTIVE,
+  database: DESTRUCTIVE,
+  service: DESTRUCTIVE,
+  projects: DESTRUCTIVE,
+  environments: DESTRUCTIVE,
+  env_vars: DESTRUCTIVE,
+  private_keys: DESTRUCTIVE,
+  github_apps: DESTRUCTIVE,
+  cloud_tokens: DESTRUCTIVE,
+  storages: DESTRUCTIVE,
+  scheduled_tasks: DESTRUCTIVE,
+  database_backups: DESTRUCTIVE,
+  // stop/restart take a running resource down.
+  control: DESTRUCTIVE,
+  // A deploy replaces the running containers, so it is a destructive update
+  // rather than an additive one.
+  deploy: DESTRUCTIVE,
+  // `cancel` kills an in-flight deployment.
+  deployment: DESTRUCTIVE,
+  stop_all_apps: DESTRUCTIVE,
+  bulk_env_update: DESTRUCTIVE,
+  redeploy_project: DESTRUCTIVE,
+  restart_project_apps: DESTRUCTIVE,
+  // `disable_api` cuts off API access entirely.
+  system: DESTRUCTIVE,
+
+  // --- Writes that are neither read-only nor destructive -------------------
+  // Provisions servers and spends real money, but every action is additive:
+  // it creates, it never replaces or removes.
+  hetzner: { destructiveHint: false },
+  // Re-running a validation converges on the same state.
+  validate_server: { destructiveHint: false, idempotentHint: true },
+};
+
 export class CoolifyMcpServer extends McpServer {
+  /**
+   * Register a tool, attaching its annotations from {@link TOOL_ANNOTATIONS}.
+   *
+   * Wraps SDK `registerTool` (the legacy `tool()` overloads are deprecated) so
+   * annotations cannot be forgotten at a call site: every tool goes through
+   * here, and a name missing from the table throws at construction rather than
+   * silently shipping unannotated.
+   */
+  private defineTool<Args extends ZodRawShapeCompat>(
+    name: string,
+    description: string,
+    inputSchema: Args,
+    cb: ToolCallback<Args>,
+  ): void {
+    const annotations = TOOL_ANNOTATIONS[name];
+    if (!annotations) {
+      throw new Error(
+        `Tool "${name}" has no entry in TOOL_ANNOTATIONS. Add one — clients use these hints to decide whether a call needs confirmation.`,
+      );
+    }
+    this.registerTool(name, { description, inputSchema, annotations }, cb);
+  }
+
   private readonly client: CoolifyClient;
   private readonly docsSearch: DocsSearchEngine = new DocsSearchEngine();
 
@@ -378,11 +493,11 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Meta (2 tools)
     // =========================================================================
-    this.tool('get_version', 'Coolify API version', {}, async () =>
+    this.defineTool('get_version', 'Coolify API version', {}, async () =>
       wrap(() => this.client.getVersion()),
     );
 
-    this.tool('get_mcp_version', 'MCP server version', {}, async () => ({
+    this.defineTool('get_mcp_version', 'MCP server version', {}, async () => ({
       content: [
         {
           type: 'text' as const,
@@ -394,7 +509,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Infrastructure Overview (1 tool)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'get_infrastructure_overview',
       'Overview of all resources with counts',
       {},
@@ -444,28 +559,28 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Diagnostics (3 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'diagnose_app',
       'App diagnostics by UUID/name/domain',
       { query: z.string() },
       async ({ query }) => wrap(() => this.client.diagnoseApplication(query)),
     );
 
-    this.tool(
+    this.defineTool(
       'diagnose_server',
       'Server diagnostics by UUID/name/IP',
       { query: z.string() },
       async ({ query }) => wrap(() => this.client.diagnoseServer(query)),
     );
 
-    this.tool('find_issues', 'Scan infrastructure for problems', {}, async () =>
+    this.defineTool('find_issues', 'Scan infrastructure for problems', {}, async () =>
       wrap(() => this.client.findInfrastructureIssues()),
     );
 
     // =========================================================================
     // Servers (5 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'list_servers',
       'List servers (summary)',
       { page: z.number().optional(), per_page: z.number().optional() },
@@ -473,19 +588,22 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.listServers({ page, per_page, summary: true })),
     );
 
-    this.tool('get_server', 'Server details', { uuid: z.string() }, async ({ uuid }) =>
+    this.defineTool('get_server', 'Server details', { uuid: z.string() }, async ({ uuid }) =>
       wrap(() => this.client.getServer(uuid)),
     );
 
-    this.tool('server_resources', 'Resources on server', { uuid: z.string() }, async ({ uuid }) =>
-      wrap(() => this.client.getServerResources(uuid)),
+    this.defineTool(
+      'server_resources',
+      'Resources on server',
+      { uuid: z.string() },
+      async ({ uuid }) => wrap(() => this.client.getServerResources(uuid)),
     );
 
-    this.tool('server_domains', 'Domains on server', { uuid: z.string() }, async ({ uuid }) =>
+    this.defineTool('server_domains', 'Domains on server', { uuid: z.string() }, async ({ uuid }) =>
       wrap(() => this.client.getServerDomains(uuid)),
     );
 
-    this.tool(
+    this.defineTool(
       'validate_server',
       'Validate server connection',
       { uuid: z.string() },
@@ -495,7 +613,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Projects (1 tool - consolidated CRUD)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'projects',
       'Manage projects: list/get/create/update/delete',
       {
@@ -533,7 +651,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Environments (1 tool - consolidated CRUD)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'environments',
       'Manage environments: list/get/create/delete (get includes dragonfly/keydb/clickhouse DBs missing from API)',
       {
@@ -568,7 +686,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Applications (4 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'list_applications',
       'List apps (summary)',
       { page: z.number().optional(), per_page: z.number().optional() },
@@ -581,14 +699,14 @@ export class CoolifyMcpServer extends McpServer {
         ),
     );
 
-    this.tool('get_application', 'App details', { uuid: z.string() }, async ({ uuid }) =>
+    this.defineTool('get_application', 'App details', { uuid: z.string() }, async ({ uuid }) =>
       wrapWithActions(
         () => this.client.getApplication(uuid),
         (app) => getApplicationActions(app.uuid, app.status),
       ),
     );
 
-    this.tool(
+    this.defineTool(
       'application',
       'Manage app: create/update/delete/delete_preview',
       {
@@ -942,7 +1060,7 @@ export class CoolifyMcpServer extends McpServer {
       },
     );
 
-    this.tool(
+    this.defineTool(
       'logs',
       "Get container logs for an application, database, or service. A service is a multi-container stack, so resource='service' requires `container` — the sub-service name, which you can list with the `service` tool's `list_containers` action. Use `lines` to bound the output and `show_timestamps` when you need to correlate events across resources (not supported on service containers).",
       {
@@ -981,7 +1099,7 @@ export class CoolifyMcpServer extends McpServer {
       },
     );
 
-    this.tool(
+    this.defineTool(
       'application_logs',
       'Get app logs. Superseded by `logs` (resource=application), which also covers databases and services — prefer that. Kept for compatibility and scheduled for removal in v3.',
       { uuid: z.string(), lines: z.number().optional() },
@@ -991,7 +1109,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Databases (3 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'list_databases',
       'List databases (summary)',
       { page: z.number().optional(), per_page: z.number().optional() },
@@ -999,11 +1117,11 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.listDatabases({ page, per_page, summary: true })),
     );
 
-    this.tool('get_database', 'Database details', { uuid: z.string() }, async ({ uuid }) =>
+    this.defineTool('get_database', 'Database details', { uuid: z.string() }, async ({ uuid }) =>
       wrap(() => this.client.getDatabase(uuid)),
     );
 
-    this.tool(
+    this.defineTool(
       'database',
       'Manage database: create/delete',
       {
@@ -1087,7 +1205,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Services (3 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'list_services',
       'List services (summary)',
       { page: z.number().optional(), per_page: z.number().optional() },
@@ -1095,11 +1213,11 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.listServices({ page, per_page, summary: true })),
     );
 
-    this.tool('get_service', 'Service details', { uuid: z.string() }, async ({ uuid }) =>
+    this.defineTool('get_service', 'Service details', { uuid: z.string() }, async ({ uuid }) =>
       wrap(() => this.client.getService(uuid)),
     );
 
-    this.tool(
+    this.defineTool(
       'service',
       'Manage service: create/update/delete/list_containers. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`.',
       {
@@ -1170,7 +1288,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Resource Control (1 tool - start/stop/restart for all types)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'control',
       'Start/stop/restart app, database, or service',
       {
@@ -1239,7 +1357,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Environment Variables (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'env_vars',
       "Manage env vars for app, service, or database. Values are masked by default (returned as '***') to avoid leaking secrets to MCP clients; pass reveal=true on the list action when the caller explicitly needs the plaintext (e.g. 'what is FOO set to?'). On list, pass key to return only that variable — always combine reveal with key so only the requested value (not every secret on the resource) is exposed. Set is_buildtime=false (and/or is_runtime=true) for runtime-only vars to avoid Dockerfile ARG issues with multiline values like PEM keys. Preview vs production: is_preview marks a variable as applying to preview (pull-request) deployments rather than production. These are SEPARATE scopes — the same key can legitimately exist in both with different values, and that is normal configuration, not a mistake to reconcile. Check is_preview on each entry before concluding a variable is set wrong, and pass is_preview on create/update to target the preview scope (omit it to target production).",
       {
@@ -1413,7 +1531,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Deployments (3 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'list_deployments',
       'List deployments (summary)',
       { page: z.number().optional(), per_page: z.number().optional() },
@@ -1426,7 +1544,7 @@ export class CoolifyMcpServer extends McpServer {
         ),
     );
 
-    this.tool(
+    this.defineTool(
       'deploy',
       'Deploy by tag/UUID',
       {
@@ -1467,7 +1585,7 @@ export class CoolifyMcpServer extends McpServer {
       },
     );
 
-    this.tool(
+    this.defineTool(
       'deployment',
       'Manage deployment: get/cancel/list_for_app. Logs excluded by default on all actions — for get use `lines` (paginated tail), for list_for_app use `include_logs: true` to include raw build-log blobs.',
       {
@@ -1540,7 +1658,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Private Keys (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'private_keys',
       'Manage SSH keys: list/get/create/update/delete',
       {
@@ -1585,7 +1703,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // GitHub Apps (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'github_apps',
       'Manage GitHub Apps: list/get/create/update/delete/list_repos/list_branches',
       {
@@ -1695,7 +1813,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Database Backups (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'database_backups',
       'Manage backups: list_schedules/get_schedule/list_executions/get_execution/create/update/delete/delete_execution',
       {
@@ -1783,7 +1901,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Teams (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'teams',
       'Manage teams: list/get/get_members/get_current/get_current_members',
       {
@@ -1811,7 +1929,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Cloud Tokens (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'cloud_tokens',
       'Manage cloud provider tokens (Hetzner/DigitalOcean): list/get/create/update/delete/validate',
       {
@@ -1854,7 +1972,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Storages (1 tool - consolidated for app/db/service)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'storages',
       'Manage persistent/file storages for app, database, or service: list/create/update/delete',
       {
@@ -1968,7 +2086,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Scheduled Tasks (1 tool - consolidated for app/service)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'scheduled_tasks',
       'Manage scheduled tasks for app or service: list/create/update/delete/list_executions/run_once. ' +
         "list_executions: the command's stdout comes back in the execution's message field. " +
@@ -2082,7 +2200,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Hetzner Cloud (1 tool - consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'hetzner',
       'Hetzner cloud: list_locations/list_server_types/list_images/list_ssh_keys/create_server',
       {
@@ -2172,7 +2290,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // System (1 tool - health/list_resources/api_control consolidated)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'system',
       'System operations: health/list_resources/enable_api/disable_api. `list_resources` defaults to an essential projection (uuid/name/type/status) to keep token budgets sane on instances with many resources; pass `include_full: true` for the raw Coolify payload. When `include_full: true`, credentials are masked unless `reveal: true` is also set (matches the `env_vars` `reveal` ergonomics): webhook HMAC secrets, basic-auth password, database passwords, internal/external_db_url connection strings, compose bodies, custom_labels, and nested env-var values.',
       {
@@ -2197,7 +2315,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Documentation Search (1 tool)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'search_docs',
       'Search Coolify documentation for how-to guides, configuration, troubleshooting',
       {
@@ -2217,14 +2335,14 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     // Batch Operations (4 tools)
     // =========================================================================
-    this.tool(
+    this.defineTool(
       'restart_project_apps',
       'Restart all apps in project',
       { project_uuid: z.string() },
       async ({ project_uuid }) => wrap(() => this.client.restartProjectApps(project_uuid)),
     );
 
-    this.tool(
+    this.defineTool(
       'bulk_env_update',
       'Update env var across multiple apps',
       {
@@ -2238,7 +2356,7 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.bulkEnvUpdate(app_uuids, key, value, is_buildtime, is_runtime)),
     );
 
-    this.tool(
+    this.defineTool(
       'stop_all_apps',
       'EMERGENCY: Stop all running apps',
       { confirm: z.literal(true) },
@@ -2249,7 +2367,7 @@ export class CoolifyMcpServer extends McpServer {
       },
     );
 
-    this.tool(
+    this.defineTool(
       'redeploy_project',
       'Redeploy all apps in project',
       { project_uuid: z.string(), force: z.boolean().optional() },

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -277,8 +277,10 @@ interface DeployWaitResult {
 
 /**
  * Tool annotations, spec-stable since 2025-03-26 and honoured by SDK 1.x
- * `registerTool`. They ride the existing `tools/list` response, so they cost no
- * extra tokens.
+ * `registerTool`. They ride the existing `tools/list` response but are NOT
+ * free: ~415 tokens as emitted here, and ~751 with the spec defaults spelled
+ * out. Measured, not assumed — see the byte-budget test in mcp-server.test.ts
+ * before re-adding any default hint.
  *
  * Kept as one table rather than scattered across 43 call sites so the safety
  * classification of the whole surface can be audited in one place — which is
@@ -294,6 +296,14 @@ interface DeployWaitResult {
  *
  * Consolidated tools take worst-case values: any tool with a `delete` action is
  * destructive even though most of its actions are not.
+ *
+ * That worst-casing has a real cost worth naming: `env_vars` list, `deployment`
+ * get/list_for_app and `system` health/list_resources are pure reads sitting
+ * under destructive tools, so they lose parallel dispatch and gain confirmation
+ * prompts. Inherent to consolidation, and not worth splitting tools over — but
+ * it matters for the V3 read-only mode (#303), because filtering on this map
+ * would drop those read actions too, which is not what someone asking for
+ * read-only access expects. Gate that on action, not just on the tool.
  */
 // Only non-default hints are emitted. Per spec the defaults are
 // readOnlyHint=false, destructiveHint=true, idempotentHint=false and
@@ -301,10 +311,13 @@ interface DeployWaitResult {
 // and tells a compliant client nothing it did not already assume.
 // `destructiveHint: true` is the deliberate exception: it is the default, but
 // it is also the safety signal, and stating it explicitly is worth the bytes.
-const READ_ONLY: ToolAnnotations = { readOnlyHint: true };
-const DESTRUCTIVE: ToolAnnotations = { destructiveHint: true };
+// Frozen because twenty tools share the DESTRUCTIVE reference and registerTool
+// stores it on the registered tool — one stray mutation would silently
+// reclassify all of them.
+const READ_ONLY = Object.freeze({ readOnlyHint: true }) satisfies ToolAnnotations;
+const DESTRUCTIVE = Object.freeze({ destructiveHint: true }) satisfies ToolAnnotations;
 
-export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
+export const TOOL_ANNOTATIONS = {
   // --- Read-only -----------------------------------------------------------
   get_version: READ_ONLY,
   // Local constant, no API call — the one tool that touches nothing external.
@@ -362,19 +375,31 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   hetzner: { destructiveHint: false },
   // Re-running a validation converges on the same state.
   validate_server: { destructiveHint: false, idempotentHint: true },
-};
+} satisfies Record<string, ToolAnnotations>;
+
+/**
+ * Every tool name known to the annotations table. `defineTool` takes this
+ * rather than `string`, so registering a tool that has no annotations is a
+ * compile error instead of a runtime throw. The throw stays as a backstop for
+ * anything reaching the method dynamically.
+ */
+export type ToolName = keyof typeof TOOL_ANNOTATIONS;
 
 export class CoolifyMcpServer extends McpServer {
+  private readonly client: CoolifyClient;
+  private readonly docsSearch: DocsSearchEngine = new DocsSearchEngine();
+
   /**
    * Register a tool, attaching its annotations from {@link TOOL_ANNOTATIONS}.
    *
    * Wraps SDK `registerTool` (the legacy `tool()` overloads are deprecated) so
-   * annotations cannot be forgotten at a call site: every tool goes through
-   * here, and a name missing from the table throws at construction rather than
-   * silently shipping unannotated.
+   * annotations cannot be forgotten at a call site. `name` is typed to the
+   * table's own keys, so a tool with no annotations fails `tsc` rather than
+   * throwing when someone runs the server; the runtime throw remains as a
+   * backstop for dynamic callers.
    */
   private defineTool<Args extends ZodRawShapeCompat>(
-    name: string,
+    name: ToolName,
     description: string,
     inputSchema: Args,
     cb: ToolCallback<Args>,
@@ -387,9 +412,6 @@ export class CoolifyMcpServer extends McpServer {
     }
     this.registerTool(name, { description, inputSchema, annotations }, cb);
   }
-
-  private readonly client: CoolifyClient;
-  private readonly docsSearch: DocsSearchEngine = new DocsSearchEngine();
 
   constructor(config: CoolifyConfig) {
     super({ name: 'coolify', version: VERSION });


### PR DESCRIPTION
Closes #260. Not stacked — branches off `main` directly.

## What

All 43 tools now declare `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`, and registration moves off the SDK's **deprecated** `tool()` overloads to `registerTool()`.

Client behaviour this changes today, on SDK 1.x, with no upgrade:

- Claude Code parallel-dispatches tools marked read-only — 21 of ours currently serialise when they could fan out
- VS Code Copilot raises confirmation dialogs for anything not marked read-only, so reads stop getting prompts they don't deserve
- ChatGPT dev mode badges READ/WRITE from these

`registerTool` is also the shape SDK v2 keeps, so this is #259 prep that pays off immediately.

## Classification

**21 read-only**, **20 destructive**, **2 neither** — each checked against the tool's actual action enum, not its name.

The two that aren't obvious:

- **`hetzner`** — provisions paid servers, which is consequential, but every action is additive: it creates, it never replaces or removes. `destructiveHint` means "may perform destructive updates", not "may cost money", so it's `false`. Flagging it since it's the one I'd expect pushback on.
- **`validate_server`** — a write (`POST`), but re-running converges on the same state, so `idempotentHint: true` and not destructive. No reason for a client to gate it behind confirmation.

Consolidated tools take worst-case values: `env_vars` is destructive because it has a `delete`, even though most of its actions aren't.

## One table, not 43 call sites

Annotations live in a single `TOOL_ANNOTATIONS` map, and all 43 registrations go through one `defineTool` wrapper that looks them up. A tool missing from the table **throws at construction** rather than silently shipping unannotated.

The point of annotations is that the safety posture of the surface is auditable — that's much easier to review as one table than as 43 scattered literals, and it makes the V3 `readonly` mode (#303) a one-line filter over this map rather than a hand-maintained list that drifts.

## Correction to the issue

#260 says annotations are "zero token cost — they ride the existing tools/list response". They ride it, but they are **not free**. Measured:

| | tokens added to `tools/list` |
| --- | --- |
| Every hint spelled out | **~751** |
| Non-default hints only | **~415** |

Against a ~6,600 token budget that's 11% versus 6%. Per spec the defaults are `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=true`, so emitting those tells a compliant client nothing it didn't already assume.

`destructiveHint: true` is the deliberate exception — it *is* the default, but it's also the safety signal, and stating it explicitly is worth the bytes. There's a test asserting the payload stays under 2000 bytes so the defaults can't creep back in.

## Testing

- **488 tests pass** (478 before, 10 new). Coverage 98.3% statements / 99.55% functions.
- Every registered tool has annotations; the table and the registered set are asserted equal **in both directions** (a table entry with no tool is dead config; a tool with no entry can't register).
- No tool is both read-only and destructive.
- The read-only and destructive sets are asserted by explicit name list, so a future tool silently landing in the wrong bucket fails.
- `get_mcp_version` is the only `openWorldHint: false` — it returns a local constant while everything else reaches the Coolify API.
- `defineTool` throws for an unknown tool name.
- The token-budget guard above.

Verified against the built server that all 43 tools actually carry annotations through to registration, rather than trusting the source.
