### PR TITLE
feat: confirmation for the credential deletes (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`private_keys update` with new key material is guarded like the delete** (#315 review) — overwriting key material IS deleting the old key: Coolify never returns key material, so the previous value is exactly as gone either way, and a model "fixing" a key by overwriting it takes the same servers offline. Renames and description edits pass without a prompt.
+
 - **Confirmation for the credential deletes** (#315) — `private_keys delete`, `cloud_tokens delete` and `github_apps delete` now elicit like the other destructive operations. The boundary drawn, recorded here so it is a decision rather than an accident: a delete gets a prompt when the loss is **irrecoverable** (key material and token values are write-only in Coolify — once deleted, they only come back if you still hold the original) or **estate-wide** (deleting a GitHub app breaks every application sourced from it, and the prompt counts them: "2 applications (api, worker) sourced from it will lose their deploy source"). Routine deletes — storages, scheduled tasks, individual env vars, backup schedules, `deployment cancel` — deliberately stay unprompted, and a test pins that so growing a guard is a revisit of the boundary, not a side effect. Prompt fatigue is the failure mode: a dialog on every delete is how dialogs stop being read.
 
   The GitHub-app blast radius filters by `source_type` as well as `source_id`, because the numeric id can collide with a GitLab source. Verified live: `source_type` is the Laravel class name (`App\Models\GithubApp`), null for public-repo applications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Confirmation for the credential deletes** (#315) — `private_keys delete`, `cloud_tokens delete` and `github_apps delete` now elicit like the other destructive operations. The boundary drawn, recorded here so it is a decision rather than an accident: a delete gets a prompt when the loss is **irrecoverable** (key material and token values are write-only in Coolify — once deleted, they only come back if you still hold the original) or **estate-wide** (deleting a GitHub app breaks every application sourced from it, and the prompt counts them: "2 applications (api, worker) sourced from it will lose their deploy source"). Routine deletes — storages, scheduled tasks, individual env vars, backup schedules, `deployment cancel` — deliberately stay unprompted, and a test pins that so growing a guard is a revisit of the boundary, not a side effect. Prompt fatigue is the failure mode: a dialog on every delete is how dialogs stop being read.
+
+  The GitHub-app blast radius filters by `source_type` as well as `source_id`, because the numeric id can collide with a GitLab source. Verified live: `source_type` is the Laravel class name (`App\Models\GithubApp`), null for public-repo applications.
+
 ## [2.17.0] - 2026-07-30
 
 > **Heads up:** `redeploy_project` and `restart_project_apps` were silent no-ops and now actually run. If you called either and read the `0 succeeded` as "nothing needed doing", the same call now restarts or redeploys every application in the project.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ EMERGENCY STOP: take down 12 running applications
 across 3 servers?
 ```
 
-Confirmation is asked for on `stop_all_apps`, `redeploy_project`, `restart_project_apps`, `system disable_api`, application / database / service / project / environment deletes, and `bulk_env_update` across more than three apps. Deleting a resource spells out whether its **persistent volumes** go with it — `delete_volumes` defaults to `true` upstream, so leaving the flag unset is the destructive choice, not the cautious one.
+Confirmation is asked for on `stop_all_apps`, `redeploy_project`, `restart_project_apps`, `system disable_api`, application / database / service / project / environment deletes, the credential deletes (`private_keys`, `cloud_tokens`, `github_apps` — none recoverable from Coolify once gone), and `bulk_env_update` across more than three apps. Routine deletes (storages, scheduled tasks, individual env vars, backup schedules) deliberately stay unprompted — a dialog on every delete is how dialogs stop being read. Deleting a resource spells out whether its **persistent volumes** go with it — `delete_volumes` defaults to `true` upstream, so leaving the flag unset is the destructive choice, not the cautious one.
 
 Prompts are skipped where there is nothing to confirm: an emergency stop on an idle estate, or a redeploy of an empty project, just runs.
 

--- a/src/__tests__/elicitation.test.ts
+++ b/src/__tests__/elicitation.test.ts
@@ -982,3 +982,102 @@ describe('elicitation: delete prompts', () => {
     await h.close();
   });
 });
+
+describe('elicitation: credential deletes (#315)', () => {
+  it('asks before deleting a private key, and says it is unrecoverable', async () => {
+    const h = await harness(decline);
+    const client = h.server['client'];
+    jest
+      .spyOn(client, 'getPrivateKey')
+      .mockResolvedValue({ uuid: 'key-1', name: 'deploy-key' } as never);
+    const del = jest.spyOn(client, 'deletePrivateKey').mockResolvedValue({} as never);
+
+    const text = await h.call('private_keys', { action: 'delete', uuid: 'key-1' });
+
+    // The reason this delete is guarded and the routine ones are not: the key
+    // material is write-only in Coolify, so there is no undo.
+    expect(h.prompts[0]).toContain('Delete SSH private key "deploy-key"');
+    expect(h.prompts[0]).toContain('not recoverable');
+    expect(del).not.toHaveBeenCalled();
+    expect(text).toContain('Nothing was changed');
+    await h.close();
+  });
+
+  it('asks before deleting a cloud token', async () => {
+    const h = await harness(accept);
+    const client = h.server['client'];
+    jest
+      .spyOn(client, 'getCloudToken')
+      .mockResolvedValue({ uuid: 'ct-1', name: 'hetzner-prod' } as never);
+    const del = jest.spyOn(client, 'deleteCloudToken').mockResolvedValue({} as never);
+
+    await h.call('cloud_tokens', { action: 'delete', uuid: 'ct-1' });
+
+    expect(h.prompts[0]).toContain('Delete cloud-provider token "hetzner-prod"');
+    expect(del).toHaveBeenCalled();
+    await h.close();
+  });
+
+  it('counts the applications sourced from a GitHub app before deleting it', async () => {
+    const h = await harness(decline);
+    const client = h.server['client'];
+    jest.spyOn(client, 'listApplications').mockResolvedValue([
+      { uuid: 'a', name: 'api', source_id: 7, source_type: 'App\\Models\\GithubApp' },
+      { uuid: 'b', name: 'web', source_id: 7, source_type: 'App\\Models\\GithubApp' },
+      // Same numeric id, different source type — must not be counted.
+      { uuid: 'c', name: 'gl', source_id: 7, source_type: 'App\\Models\\GitlabApp' },
+      { uuid: 'd', name: 'pub', source_id: null, source_type: null },
+    ] as never);
+    jest
+      .spyOn(client, 'listGitHubApps')
+      .mockResolvedValue([{ id: 7, name: 'my-installation' }] as never);
+    const del = jest.spyOn(client, 'deleteGitHubApp').mockResolvedValue({} as never);
+
+    await h.call('github_apps', { action: 'delete', id: 7 });
+
+    expect(h.prompts[0]).toContain('Delete GitHub app "my-installation"');
+    expect(h.prompts[0]).toContain('2 applications');
+    expect(h.prompts[0]).toContain('lose their deploy source');
+    expect(h.prompts[0]).not.toContain('gl');
+    expect(del).not.toHaveBeenCalled();
+    await h.close();
+  });
+
+  it('says so plainly when no applications are sourced from the GitHub app', async () => {
+    const h = await harness(accept);
+    const client = h.server['client'];
+    jest.spyOn(client, 'listApplications').mockResolvedValue([] as never);
+    jest.spyOn(client, 'listGitHubApps').mockResolvedValue([{ id: 7, name: 'idle' }] as never);
+    const del = jest.spyOn(client, 'deleteGitHubApp').mockResolvedValue({} as never);
+
+    await h.call('github_apps', { action: 'delete', id: 7 });
+
+    // Still asks — deleting an installation is not undoable from Coolify's
+    // side either — but the prompt is honest that nothing currently breaks.
+    expect(h.prompts[0]).toContain('No applications are currently sourced from it');
+    expect(del).toHaveBeenCalled();
+    await h.close();
+  });
+
+  it('leaves the routine deletes unguarded, by decision not omission', async () => {
+    const h = await harness(accept);
+    const client = h.server['client'];
+    const delStorage = jest
+      .spyOn(client, 'deleteApplicationStorage')
+      .mockResolvedValue({} as never);
+
+    await h.call('storages', {
+      action: 'delete',
+      resource: 'application',
+      uuid: 'app-1',
+      storage_uuid: 'st-1',
+    });
+
+    // #315's boundary: prompting on every delete is how prompts stop being
+    // read. If this test starts failing because storages grew a guard, that
+    // should be a deliberate revisit of the boundary, not a side effect.
+    expect(h.prompts).toEqual([]);
+    expect(delStorage).toHaveBeenCalled();
+    await h.close();
+  });
+});

--- a/src/__tests__/elicitation.test.ts
+++ b/src/__tests__/elicitation.test.ts
@@ -1081,3 +1081,95 @@ describe('elicitation: credential deletes (#315)', () => {
     await h.close();
   });
 });
+
+describe('elicitation: #315 review round', () => {
+  it('counts an app whose source_type is absent rather than reassuring falsely', async () => {
+    const h = await harness(decline);
+    const client = h.server['client'];
+    jest.spyOn(client, 'listApplications').mockResolvedValue([
+      // source_id matches but the instance did not serialise source_type —
+      // the field is absent from the vendored spec and only live-verified on
+      // 4.1.2, so this response shape is plausible on other versions.
+      { uuid: 'a', name: 'api', source_id: 7 },
+    ] as never);
+    jest.spyOn(client, 'listGitHubApps').mockResolvedValue([{ id: 7, name: 'inst' }] as never);
+    jest.spyOn(client, 'deleteGitHubApp').mockResolvedValue({} as never);
+
+    await h.call('github_apps', { action: 'delete', id: 7 });
+
+    // Excluding on a missing type would print "No applications are currently
+    // sourced from it" — the most reassuring sentence this dialog can emit —
+    // for a delete that breaks the app. Over-counting asks harder instead.
+    expect(h.prompts[0]).toContain('1 application (api)');
+    await h.close();
+  });
+
+  it('still asks, carrying the label, when the github_apps pre-flight fails', async () => {
+    const h = await harness(decline);
+    const client = h.server['client'];
+    // The only summarize in the codebase making two calls in Promise.all —
+    // the most ways to reject, on exactly the flaky-Coolify days when the
+    // guard matters most.
+    jest.spyOn(client, 'listApplications').mockRejectedValue(new Error('coolify unreachable'));
+    jest.spyOn(client, 'listGitHubApps').mockResolvedValue([] as never);
+    const del = jest.spyOn(client, 'deleteGitHubApp').mockResolvedValue({} as never);
+
+    await h.call('github_apps', { action: 'delete', id: 7 });
+
+    expect(h.prompts[0]).toContain('Delete a GitHub app installation');
+    expect(h.prompts[0]).toContain('Could not load the details first');
+    expect(del).not.toHaveBeenCalled();
+    await h.close();
+  });
+
+  it('guards a key-material replacement exactly like a delete', async () => {
+    const h = await harness(decline);
+    const client = h.server['client'];
+    jest
+      .spyOn(client, 'getPrivateKey')
+      .mockResolvedValue({ uuid: 'key-1', name: 'deploy-key' } as never);
+    const update = jest.spyOn(client, 'updatePrivateKey').mockResolvedValue({} as never);
+
+    await h.call('private_keys', {
+      action: 'update',
+      uuid: 'key-1',
+      private_key: '-----BEGIN OPENSSH PRIVATE KEY-----\nnew material',
+    });
+
+    // Overwriting key material IS deleting the old key: Coolify never returns
+    // key material, so the previous value is exactly as gone either way.
+    expect(h.prompts[0]).toContain('Replace the key material');
+    expect(h.prompts[0]).toContain('not recoverable');
+    expect(update).not.toHaveBeenCalled();
+    await h.close();
+  });
+
+  it('lets a rename through without a prompt', async () => {
+    const h = await harness(accept);
+    const update = jest
+      .spyOn(h.server['client'], 'updatePrivateKey')
+      .mockResolvedValue({} as never);
+
+    await h.call('private_keys', { action: 'update', uuid: 'key-1', name: 'renamed' });
+
+    // A rename destroys nothing; prompting on it would be pure fatigue.
+    expect(h.prompts).toEqual([]);
+    expect(update).toHaveBeenCalledWith('key-1', { name: 'renamed', description: undefined });
+    await h.close();
+  });
+
+  it('names the consequence even when no applications are sourced', async () => {
+    const h = await harness(accept);
+    const client = h.server['client'];
+    jest.spyOn(client, 'listApplications').mockResolvedValue([] as never);
+    jest.spyOn(client, 'listGitHubApps').mockResolvedValue([{ id: 7, name: 'idle' }] as never);
+    jest.spyOn(client, 'deleteGitHubApp').mockResolvedValue({} as never);
+
+    await h.call('github_apps', { action: 'delete', id: 7 });
+
+    // Every other prompt names what the reader loses; this one must too —
+    // re-creating and re-installing the app on GitHub is real work.
+    expect(h.prompts[0]).toContain('not undoable from Coolify');
+    await h.close();
+  });
+});

--- a/src/lib/elicit.ts
+++ b/src/lib/elicit.ts
@@ -59,7 +59,7 @@ export const ELICIT_TIMEOUT_MS = 300_000;
  * client advertises the capability every rejection from `elicitInput` aborts,
  * including `-32601 Method not found` — so a client that advertises
  * `elicitation` without implementing the handler, or a proxy that drops the
- * request, makes nine tools permanently unusable with no way out but
+ * request, makes every guarded tool permanently unusable with no way out but
  * downgrading the package. The resulting error ("could not confirm with the
  * user") does not point at the client, which makes it hard to diagnose from the
  * outside. Rare, but unrecoverable, and the fallback is the same shape as the

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1875,12 +1875,32 @@ export class CoolifyMcpServer extends McpServer {
                 description,
               }),
             );
-          case 'update':
+          case 'update': {
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            return wrap(() =>
-              this.client.updatePrivateKey(uuid, { name, description, private_key }),
+            // Renames and descriptions pass freely, but replacing the key
+            // material is guarded like the delete, because it IS the delete of
+            // the old key: Coolify never returns key material, so the
+            // overwritten value is exactly as gone as a deleted one, and a
+            // model "fixing" a key by overwriting it takes the same servers
+            // offline.
+            if (private_key === undefined) {
+              return wrap(() => this.client.updatePrivateKey(uuid, { name, description }));
+            }
+            return this.guardDestructive(
+              extra.signal,
+              `Replace an SSH private key's material. The current key is not recoverable.`,
+              async () => {
+                const key = await this.client.getPrivateKey(uuid);
+                return (
+                  `Replace the key material of SSH private key "${sanitizeForPrompt(key.name || uuid)}" (${sanitizeForPrompt(uuid)})?\n\n` +
+                  `The current key material is overwritten and is not recoverable from Coolify. ` +
+                  `Anything authenticating with the old key stops working unless the new key is authorised in its place.`
+                );
+              },
+              () => this.client.updatePrivateKey(uuid, { name, description, private_key }),
             );
+          }
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
@@ -2010,6 +2030,9 @@ export class CoolifyMcpServer extends McpServer {
               extra.signal,
               `Delete a GitHub app installation. Every application sourced from it loses its deploy source.`,
               async () => {
+                // Full objects, necessarily: toApplicationSummary drops both
+                // source_id and source_type, so { summary: true } would zero
+                // this count — the same false reassurance in cheaper clothes.
                 const [apps, ghApps] = await Promise.all([
                   this.client.listApplications() as Promise<Application[]>,
                   this.client.listGitHubApps() as Promise<GitHubApp[]>,
@@ -2018,13 +2041,27 @@ export class CoolifyMcpServer extends McpServer {
                 // source_id alone can collide with a GitLab source carrying
                 // the same numeric id, so the type is checked too. Verified
                 // live: source_type is the Laravel class name
-                // "App\Models\GithubApp" (null for public-repo apps).
+                // "App\Models\GithubApp"; public-repo applications carry null
+                // for BOTH fields, so they drop out on source_id, not here.
+                //
+                // A matching source_id with a *missing* type is counted, not
+                // excluded: source_type is absent from the vendored spec and
+                // only live-verified on 4.1.2, and excluding on absence would
+                // turn "19 apps break" into "No applications are currently
+                // sourced from it" — the most reassuring sentence this dialog
+                // can emit — the day a version stops serialising the field.
+                // Over-counting asks harder; that is this module's chosen
+                // failure direction.
                 const sourced = apps.filter(
-                  (app) => app.source_id === id && (app.source_type ?? '').includes('GithubApp'),
+                  (app) =>
+                    app.source_id === id &&
+                    (app.source_type == null || app.source_type.includes('GithubApp')),
                 );
                 const impact =
                   sourced.length === 0
-                    ? `No applications are currently sourced from it.`
+                    ? `No applications are currently sourced from it, but deleting the ` +
+                      `installation is not undoable from Coolify — re-linking anything later ` +
+                      `means re-creating the app on GitHub.`
                     : `${describeBlastRadius(
                         'application',
                         sourced.map((app) => app.name || app.uuid),

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1857,7 +1857,7 @@ export class CoolifyMcpServer extends McpServer {
         description: z.string().optional(),
         private_key: z.string().optional(),
       },
-      async ({ action, uuid, name, description, private_key }) => {
+      async ({ action, uuid, name, description, private_key }, extra) => {
         switch (action) {
           case 'list':
             return wrap(() => this.client.listPrivateKeys());
@@ -1884,7 +1884,25 @@ export class CoolifyMcpServer extends McpServer {
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            return wrap(() => this.client.deletePrivateKey(uuid));
+            // #315: guarded because the loss is irrecoverable — Coolify never
+            // returns key material after v4.2 hides secrets, and often not
+            // before, so a deleted key cannot be re-read and re-added. The
+            // routine deletes (storages, scheduled tasks, env vars) stay
+            // unguarded on purpose; a prompt on every delete is how prompts
+            // stop being read.
+            return this.guardDestructive(
+              extra.signal,
+              `Delete an SSH private key. Not recoverable from Coolify.`,
+              async () => {
+                const key = await this.client.getPrivateKey(uuid);
+                return (
+                  `Delete SSH private key "${sanitizeForPrompt(key.name || uuid)}" (${sanitizeForPrompt(uuid)})?\n\n` +
+                  `The key material is not recoverable from Coolify. Any server access or ` +
+                  `private-repo deploys using this key stop working until you add the key again from your own copy.`
+                );
+              },
+              () => this.client.deletePrivateKey(uuid),
+            );
         }
       },
     );
@@ -1925,7 +1943,7 @@ export class CoolifyMcpServer extends McpServer {
         private_key_uuid: z.string().optional(),
         is_system_wide: z.boolean().optional(),
       },
-      async (args) => {
+      async (args, extra) => {
         const { action, id, ...apiData } = args;
         switch (action) {
           case 'list':
@@ -1985,7 +2003,39 @@ export class CoolifyMcpServer extends McpServer {
             return wrap(() => this.client.updateGitHubApp(id, apiData));
           case 'delete':
             if (!id) return { content: [{ type: 'text' as const, text: 'Error: id required' }] };
-            return wrap(() => this.client.deleteGitHubApp(id));
+            // #315: guarded because the blast radius is every application
+            // sourced from the installation — they all lose their deploy
+            // source at once — and it is countable, so the prompt counts it.
+            return this.guardDestructive(
+              extra.signal,
+              `Delete a GitHub app installation. Every application sourced from it loses its deploy source.`,
+              async () => {
+                const [apps, ghApps] = await Promise.all([
+                  this.client.listApplications() as Promise<Application[]>,
+                  this.client.listGitHubApps() as Promise<GitHubApp[]>,
+                ]);
+                const target = ghApps.find((app) => app.id === id);
+                // source_id alone can collide with a GitLab source carrying
+                // the same numeric id, so the type is checked too. Verified
+                // live: source_type is the Laravel class name
+                // "App\Models\GithubApp" (null for public-repo apps).
+                const sourced = apps.filter(
+                  (app) => app.source_id === id && (app.source_type ?? '').includes('GithubApp'),
+                );
+                const impact =
+                  sourced.length === 0
+                    ? `No applications are currently sourced from it.`
+                    : `${describeBlastRadius(
+                        'application',
+                        sourced.map((app) => app.name || app.uuid),
+                      )} sourced from it will lose their deploy source and cannot deploy until re-linked.`;
+                return (
+                  `Delete GitHub app "${sanitizeForPrompt(target?.name || String(id))}" (id ${id})?\n\n` +
+                  impact
+                );
+              },
+              () => this.client.deleteGitHubApp(id),
+            );
           case 'list_repos':
             if (!id) return { content: [{ type: 'text' as const, text: 'Error: id required' }] };
             return wrap(() => this.client.listGitHubAppRepositories(id));
@@ -2128,7 +2178,7 @@ export class CoolifyMcpServer extends McpServer {
         token: z.string().optional(),
         name: z.string().optional(),
       },
-      async ({ action, uuid, provider, token, name }) => {
+      async ({ action, uuid, provider, token, name }, extra) => {
         switch (action) {
           case 'list':
             return wrap(() => this.client.listCloudTokens());
@@ -2149,7 +2199,22 @@ export class CoolifyMcpServer extends McpServer {
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            return wrap(() => this.client.deleteCloudToken(uuid));
+            // #315: same shape as the private-key delete — the token value is
+            // write-only in Coolify, so deletion is irreversible without the
+            // original credential.
+            return this.guardDestructive(
+              extra.signal,
+              `Delete a cloud-provider API token. Not recoverable from Coolify.`,
+              async () => {
+                const stored = await this.client.getCloudToken(uuid);
+                return (
+                  `Delete cloud-provider token "${sanitizeForPrompt(stored.name || uuid)}" (${sanitizeForPrompt(uuid)})?\n\n` +
+                  `The token value is not recoverable from Coolify. Server provisioning through ` +
+                  `this provider stops working until you re-add the token from the provider's console.`
+                );
+              },
+              () => this.client.deleteCloudToken(uuid),
+            );
           case 'validate':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };


### PR DESCRIPTION
Closes #315.

Draws the boundary the issue asked for, and records it so it is a decision rather than an accident: a delete gets a prompt when the loss is **irrecoverable** or **estate-wide**. Everything else stays silent, because a dialog on every delete is how dialogs stop being read.

## Guarded

- **`private_keys delete`** — key material is write-only in Coolify; once deleted it only comes back if you still hold the original.
- **`cloud_tokens delete`** — same shape; the token value cannot be read back.
- **`github_apps delete`** — estate-wide: every application sourced from the installation loses its deploy source at once, and the prompt counts them:

  ```text
  Delete GitHub app "example-installation" (id 1)?

  19 applications (billing-api, checkout-web, mailer-worker and 16 more)
  sourced from it will lose their deploy source and cannot deploy until re-linked.
  ```

  The count filters by `source_type` as well as `source_id`, because the numeric id can collide with a GitLab source. Verified live: `source_type` is the Laravel class name (`App\Models\GithubApp`), null for public-repo apps.

## Deliberately not guarded

Storages, scheduled tasks, individual env vars, backup schedules, `deployment cancel`, single-resource `control` stop/restart. A test pins the storages case, so if one of these ever grows a guard it is a deliberate revisit of the boundary, not a side effect.

## Verified

- 598 unit tests (+5), `elicit.ts` still 100% on all four coverage axes
- Live over stdio against a real 4.1.2 instance with a declining client: private-key and GitHub-app prompts render with real names and a real 19-application count; decline aborts; nothing deleted
