### PR TITLE
feat: add service sub-application management (FQDN, image, start/stop/restart)

### DIFF
--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -6017,6 +6017,18 @@ describe('errorHint', () => {
     expect(errorHint(404, '/applications/app-uuid/tags')).toMatch(/different resource type/);
   });
 
+  it('hints at the v4.2 requirement for a 404 on a service application route', () => {
+    // Sub-application management (PATCH /services/{uuid}/applications/{app_uuid})
+    // was added in v4.2.0. Without this hint, the generic uuid mismatch fires.
+    expect(errorHint(404, '/services/svc-uuid/applications/app-uuid')).toMatch(/v4\.2/);
+    expect(
+      errorHint(404, '/services/svc-uuid/applications/app-uuid?force_domain_override=true'),
+    ).toMatch(/v4\.2/);
+    expect(errorHint(404, '/services/svc-uuid/applications/app-uuid')).toMatch(
+      /update_application/,
+    );
+  });
+
   it('hints at a possible resource-type mismatch for a 404 on a uuid route', () => {
     expect(errorHint(404, '/applications/app-uuid')).toMatch(/different resource type/);
   });

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -2665,6 +2665,90 @@ describe('CoolifyClient', () => {
         expect.objectContaining({ method: 'POST' }),
       );
     });
+
+    it('should update a service sub-application', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockApplication));
+
+      const result = await client.updateServiceApplication('svc-uuid', 'app-uuid', {
+        url: 'https://example.com',
+        human_name: 'My App',
+      });
+
+      expect(result).toEqual(mockApplication);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/applications/app-uuid',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.url).toBe('https://example.com');
+      expect(callBody.human_name).toBe('My App');
+    });
+
+    it('should update a service sub-application with force_domain_override', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(mockApplication));
+
+      await client.updateServiceApplication(
+        'svc-uuid',
+        'app-uuid',
+        { url: 'https://example.com' },
+        { forceDomainOverride: true },
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/applications/app-uuid?force_domain_override=true',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+
+    it('should start a service sub-application', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Started' }));
+
+      const result = await client.startServiceApplication('svc-uuid', 'app-uuid');
+
+      expect(result).toEqual({ message: 'Started' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/applications/app-uuid/start',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should start a service sub-application with force and latest', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Started' }));
+
+      await client.startServiceApplication('svc-uuid', 'app-uuid', {
+        force: true,
+        latest: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/applications/app-uuid/start?force=true&latest=true',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should stop a service sub-application', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Stopped' }));
+
+      const result = await client.stopServiceApplication('svc-uuid', 'app-uuid');
+
+      expect(result).toEqual({ message: 'Stopped' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/applications/app-uuid/stop',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should restart a service sub-application', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Restarted' }));
+
+      const result = await client.restartServiceApplication('svc-uuid', 'app-uuid');
+
+      expect(result).toEqual({ message: 'Restarted' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/services/svc-uuid/applications/app-uuid/restart',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
   });
 
   // =========================================================================

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -120,6 +120,10 @@ describe('CoolifyMcpServer v2', () => {
       expect(typeof client.createService).toBe('function');
       expect(typeof client.updateService).toBe('function');
       expect(typeof client.deleteService).toBe('function');
+      expect(typeof client.updateServiceApplication).toBe('function');
+      expect(typeof client.startServiceApplication).toBe('function');
+      expect(typeof client.stopServiceApplication).toBe('function');
+      expect(typeof client.restartServiceApplication).toBe('function');
 
       // Environment variable operations
       expect(typeof client.listApplicationEnvVars).toBe('function');
@@ -2187,6 +2191,144 @@ describe('service list_containers action (#300)', () => {
       content: Array<{ text: string }>;
     };
     expect(result.content[0].text).toContain('uuid required');
+  });
+});
+
+describe('service sub-application actions (#322)', () => {
+  let server: CoolifyMcpServer;
+
+  beforeEach(() => {
+    server = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+  });
+
+  const callService = async (args: Record<string, unknown>) => {
+    const tool = (
+      server as unknown as {
+        _registeredTools: Record<
+          string,
+          { handler: (a: unknown, b: unknown) => Promise<{ content: Array<{ text: string }> }> }
+        >;
+      }
+    )._registeredTools['service'];
+    return tool.handler(args, {});
+  };
+
+  describe('update_application', () => {
+    it('requires uuid and app_uuid', async () => {
+      const result = (await callService({ action: 'update_application' })) as {
+        content: Array<{ text: string }>;
+      };
+      expect(result.content[0].text).toContain('uuid (service) and app_uuid required');
+    });
+
+    it('calls updateServiceApplication with correct args', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'updateServiceApplication')
+        .mockResolvedValue({ uuid: 'app-uuid', name: 'updated' } as any);
+
+      await callService({
+        action: 'update_application',
+        uuid: 'svc-uuid',
+        app_uuid: 'app-uuid',
+        url: 'https://example.com',
+        human_name: 'My App',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'svc-uuid',
+        'app-uuid',
+        expect.objectContaining({ url: 'https://example.com', human_name: 'My App' }),
+        { forceDomainOverride: undefined },
+      );
+    });
+  });
+
+  describe('start_application', () => {
+    it('requires uuid and app_uuid', async () => {
+      const result = (await callService({ action: 'start_application' })) as {
+        content: Array<{ text: string }>;
+      };
+      expect(result.content[0].text).toContain('uuid (service) and app_uuid required');
+    });
+
+    it('calls startServiceApplication with correct args', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'startServiceApplication')
+        .mockResolvedValue({ message: 'Started' });
+
+      await callService({
+        action: 'start_application',
+        uuid: 'svc-uuid',
+        app_uuid: 'app-uuid',
+      });
+
+      expect(spy).toHaveBeenCalledWith('svc-uuid', 'app-uuid', {
+        force: undefined,
+        latest: undefined,
+      });
+    });
+
+    it('forwards force and latest params', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'startServiceApplication')
+        .mockResolvedValue({ message: 'Started' });
+
+      await callService({
+        action: 'start_application',
+        uuid: 'svc-uuid',
+        app_uuid: 'app-uuid',
+        force: true,
+        latest: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith('svc-uuid', 'app-uuid', { force: true, latest: true });
+    });
+  });
+
+  describe('stop_application', () => {
+    it('requires uuid and app_uuid', async () => {
+      const result = (await callService({ action: 'stop_application' })) as {
+        content: Array<{ text: string }>;
+      };
+      expect(result.content[0].text).toContain('uuid (service) and app_uuid required');
+    });
+
+    it('calls stopServiceApplication with correct args', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'stopServiceApplication')
+        .mockResolvedValue({ message: 'Stopped' });
+
+      await callService({
+        action: 'stop_application',
+        uuid: 'svc-uuid',
+        app_uuid: 'app-uuid',
+      });
+
+      expect(spy).toHaveBeenCalledWith('svc-uuid', 'app-uuid');
+    });
+  });
+
+  describe('restart_application', () => {
+    it('requires uuid and app_uuid', async () => {
+      const result = (await callService({ action: 'restart_application' })) as {
+        content: Array<{ text: string }>;
+      };
+      expect(result.content[0].text).toContain('uuid (service) and app_uuid required');
+    });
+
+    it('calls restartServiceApplication with correct args', async () => {
+      const spy = jest
+        .spyOn(server['client'], 'restartServiceApplication')
+        .mockResolvedValue({ message: 'Restarted' });
+
+      await callService({
+        action: 'restart_application',
+        uuid: 'svc-uuid',
+        app_uuid: 'app-uuid',
+      });
+
+      expect(spy).toHaveBeenCalledWith('svc-uuid', 'app-uuid');
+    });
   });
 });
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -337,6 +337,9 @@ export function errorHint(status: number, path: string): string | undefined {
   if (status === 401 || status === 403) {
     return 'Check that COOLIFY_ACCESS_TOKEN is valid and has the required scopes for this operation. On Coolify v4.2+, tokens belonging to a Member-role user are read-only and cannot deploy, start, stop, or modify resources.';
   }
+  if (status === 404 && /\/services\/[\w-]+\/applications/.test(path)) {
+    return 'Sub-application management (update_application) requires Coolify v4.2+. Check version with `get_version`. Upgrade: `curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.2.0`';
+  }
   if (status === 404 && /\/tags(\/|$)/.test(path)) {
     // Both causes look identical from the status, so name both rather than
     // pointing confidently at the wrong one.

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -59,6 +59,7 @@ import type {
   Service,
   CreateServiceRequest,
   UpdateServiceRequest,
+  UpdateServiceApplicationRequest,
   ServiceCreateResponse,
   // Deployment types
   Deployment,
@@ -1476,6 +1477,21 @@ export class CoolifyClient {
     return this.request<Service>(`/services/${uuid}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
+    });
+  }
+
+  async updateServiceApplication(
+    serviceUuid: string,
+    appUuid: string,
+    data: UpdateServiceApplicationRequest,
+    options?: { forceDomainOverride?: boolean },
+  ): Promise<Application> {
+    const query = this.buildQueryString({
+      force_domain_override: options?.forceDomainOverride,
+    });
+    return this.request<Application>(`/services/${serviceUuid}/applications/${appUuid}${query}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
     });
   }
 

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1498,6 +1498,38 @@ export class CoolifyClient {
     });
   }
 
+  async startServiceApplication(
+    serviceUuid: string,
+    appUuid: string,
+    options?: { force?: boolean; latest?: boolean },
+  ): Promise<MessageResponse> {
+    const query = this.buildQueryString({
+      force: options?.force,
+      latest: options?.latest,
+    });
+    return this.request<MessageResponse>(
+      `/services/${serviceUuid}/applications/${appUuid}/start${query}`,
+      {
+        method: 'POST',
+      },
+    );
+  }
+
+  async stopServiceApplication(serviceUuid: string, appUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${serviceUuid}/applications/${appUuid}/stop`, {
+      method: 'POST',
+    });
+  }
+
+  async restartServiceApplication(serviceUuid: string, appUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(
+      `/services/${serviceUuid}/applications/${appUuid}/restart`,
+      {
+        method: 'POST',
+      },
+    );
+  }
+
   async deleteService(uuid: string, options?: DeleteOptions): Promise<MessageResponse> {
     const query = this.buildQueryString({
       delete_configurations: options?.deleteConfigurations,

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -31,6 +31,7 @@ import type {
   Deployment,
   DeploymentEssential,
   DeployTriggerResponse,
+  UpdateServiceApplicationRequest,
 } from '../types/coolify.js';
 import { DocsSearchEngine } from './docs-search.js';
 import { confirmDestructive, describeBlastRadius, sanitizeForPrompt } from './elicit.js';
@@ -1496,18 +1497,18 @@ export class CoolifyMcpServer extends McpServer {
                   },
                 ],
               };
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const {
-              action: _,
-              uuid: __,
-              app_uuid,
-              delete_volumes: ___,
-              force_domain_override,
-              ...appData
-            } = args;
+            const appData: UpdateServiceApplicationRequest = {
+              url: args.url,
+              human_name: args.human_name,
+              description: args.description,
+              image: args.image,
+              exclude_from_status: args.exclude_from_status,
+              is_gzip_enabled: args.is_gzip_enabled,
+              is_stripprefix_enabled: args.is_stripprefix_enabled,
+            };
             return wrap(() =>
-              this.client.updateServiceApplication(uuid, app_uuid!, appData, {
-                forceDomainOverride: force_domain_override,
+              this.client.updateServiceApplication(uuid, args.app_uuid, appData, {
+                forceDomainOverride: args.force_domain_override,
               }),
             );
           }

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1401,15 +1401,24 @@ export class CoolifyMcpServer extends McpServer {
 
     this.defineTool(
       'service',
-      "Manage service: create/update/delete/list_containers/update_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings.",
+      "Manage service: create/update/delete/list_containers/update_application/start_application/stop_application/restart_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings. Use `start_application`/`stop_application`/`restart_application` to control sub-application lifecycle.",
       {
-        action: z.enum(['create', 'update', 'delete', 'list_containers', 'update_application']),
+        action: z.enum([
+          'create',
+          'update',
+          'delete',
+          'list_containers',
+          'update_application',
+          'start_application',
+          'stop_application',
+          'restart_application',
+        ]),
         uuid: z.string().optional(),
         app_uuid: z
           .string()
           .optional()
           .describe(
-            'Sub-application UUID, required for update_application. Get from list_containers.',
+            'Sub-application UUID, required for update_application, start_application, stop_application, restart_application. Get from list_containers.',
           ),
         type: z.string().optional(),
         server_uuid: z.string().optional(),
@@ -1427,12 +1436,23 @@ export class CoolifyMcpServer extends McpServer {
           .string()
           .optional()
           .describe(
-            'FQDN for the sub-application (update_application only). Comma-separated for multiple. Null to clear.',
+            'FQDN for the sub-application (update_application only). Comma-separated for multiple.',
           ),
         force_domain_override: z
           .boolean()
           .optional()
           .describe('Force the domain override even if validation fails (update_application only)'),
+        human_name: z.string().optional(),
+        image: z.string().optional(),
+        exclude_from_status: z.boolean().optional(),
+        is_log_drain_enabled: z.boolean().optional(),
+        is_gzip_enabled: z.boolean().optional(),
+        is_stripprefix_enabled: z.boolean().optional(),
+        force: z.boolean().optional().describe('Force redeploy on start (start_application only)'),
+        latest: z
+          .boolean()
+          .optional()
+          .describe('Pull latest image on start (start_application only)'),
       },
       async (args, extra) => {
         const { action, uuid, delete_volumes } = args;
@@ -1497,20 +1517,75 @@ export class CoolifyMcpServer extends McpServer {
                   },
                 ],
               };
+            const appUuid = args.app_uuid;
             const appData: UpdateServiceApplicationRequest = {
               url: args.url,
               human_name: args.human_name,
               description: args.description,
               image: args.image,
               exclude_from_status: args.exclude_from_status,
+              is_log_drain_enabled: args.is_log_drain_enabled,
               is_gzip_enabled: args.is_gzip_enabled,
               is_stripprefix_enabled: args.is_stripprefix_enabled,
             };
-            return wrap(() =>
-              this.client.updateServiceApplication(uuid, args.app_uuid, appData, {
+            const doUpdate = () =>
+              this.client.updateServiceApplication(uuid, appUuid, appData, {
                 forceDomainOverride: args.force_domain_override,
+              });
+            if (args.force_domain_override) {
+              return this.guardDestructive(
+                extra.signal,
+                'Override domain for service sub-application, potentially taking the domain from another resource.',
+                () =>
+                  `Update sub-application ${appUuid} in service ${uuid} with force_domain_override=true. This may pull a live domain off another resource.`,
+                doUpdate,
+              );
+            }
+            return wrap(doUpdate);
+          }
+          case 'start_application': {
+            if (!uuid || !args.app_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: uuid (service) and app_uuid required',
+                  },
+                ],
+              };
+            const appUuid = args.app_uuid;
+            return wrap(() =>
+              this.client.startServiceApplication(uuid, appUuid, {
+                force: args.force,
+                latest: args.latest,
               }),
             );
+          }
+          case 'stop_application': {
+            if (!uuid || !args.app_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: uuid (service) and app_uuid required',
+                  },
+                ],
+              };
+            const appUuid = args.app_uuid;
+            return wrap(() => this.client.stopServiceApplication(uuid, appUuid));
+          }
+          case 'restart_application': {
+            if (!uuid || !args.app_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: uuid (service) and app_uuid required',
+                  },
+                ],
+              };
+            const appUuid = args.app_uuid;
+            return wrap(() => this.client.restartServiceApplication(uuid, appUuid));
           }
         }
       },

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1400,10 +1400,16 @@ export class CoolifyMcpServer extends McpServer {
 
     this.defineTool(
       'service',
-      'Manage service: create/update/delete/list_containers. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`.',
+      "Manage service: create/update/delete/list_containers/update_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings.",
       {
-        action: z.enum(['create', 'update', 'delete', 'list_containers']),
+        action: z.enum(['create', 'update', 'delete', 'list_containers', 'update_application']),
         uuid: z.string().optional(),
+        app_uuid: z
+          .string()
+          .optional()
+          .describe(
+            'Sub-application UUID, required for update_application. Get from list_containers.',
+          ),
         type: z.string().optional(),
         server_uuid: z.string().optional(),
         project_uuid: z.string().optional(),
@@ -1416,6 +1422,16 @@ export class CoolifyMcpServer extends McpServer {
           .optional()
           .describe('Raw docker-compose YAML for custom services (auto base64-encoded)'),
         delete_volumes: z.boolean().optional(),
+        url: z
+          .string()
+          .optional()
+          .describe(
+            'FQDN for the sub-application (update_application only). Comma-separated for multiple. Null to clear.',
+          ),
+        force_domain_override: z
+          .boolean()
+          .optional()
+          .describe('Force the domain override even if validation fails (update_application only)'),
       },
       async (args, extra) => {
         const { action, uuid, delete_volumes } = args;
@@ -1470,6 +1486,31 @@ export class CoolifyMcpServer extends McpServer {
               },
               () => this.client.deleteService(uuid, { deleteVolumes: delete_volumes }),
             );
+          case 'update_application': {
+            if (!uuid || !args.app_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: uuid (service) and app_uuid required',
+                  },
+                ],
+              };
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const {
+              action: _,
+              uuid: __,
+              app_uuid,
+              delete_volumes: ___,
+              force_domain_override,
+              ...appData
+            } = args;
+            return wrap(() =>
+              this.client.updateServiceApplication(uuid, app_uuid!, appData, {
+                forceDomainOverride: force_domain_override,
+              }),
+            );
+          }
         }
       },
     );

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -868,6 +868,24 @@ export interface UpdateServiceRequest {
   docker_compose_raw?: string; // Raw or base64 docker-compose YAML (auto-encoded by client)
 }
 
+/**
+ * PATCH /services/{uuid}/applications/{app_uuid} — update a sub-application
+ * within a service (e.g. change its FQDN / url).
+ *
+ * The `url` field maps to Coolify's "FQDN" for the sub-app and accepts a
+ * comma-separated string of URLs (or null to clear).
+ */
+export interface UpdateServiceApplicationRequest {
+  url?: string | null;
+  human_name?: string;
+  description?: string;
+  image?: string;
+  exclude_from_status?: boolean;
+  is_log_drain_enabled?: boolean;
+  is_gzip_enabled?: boolean;
+  is_stripprefix_enabled?: boolean;
+}
+
 export interface ServiceCreateResponse {
   uuid: string;
   domains: string[];


### PR DESCRIPTION
## ⚠️ Requirements

**Coolify v4.2.0 or later is required** for this feature. The `PATCH /services/{uuid}/applications/{app_uuid}` endpoint was added in v4.2.0.

To upgrade Coolify:
```bash
curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.2.0
```

---

## Summary

Adds support for updating service sub-applications via the Coolify v4.2 API endpoint `PATCH /services/{uuid}/applications/{app_uuid}`.

## Context

Coolify services are multi-container stacks where each container is a sub-application with its own FQDN, Docker image, and settings. Previously, the MCP server only supported updating the entire service (via `docker_compose_raw`), but not individual sub-applications.

This fills the gap described in Issue #301 — there was no way to update a sub-application's URL (FQDN), image, or other properties without modifying the entire service compose file.

## Changes

### 1. TypeScript Types (`src/types/coolify.ts`)
- Added `UpdateServiceApplicationRequest` interface for the PATCH request body
- Added `ServiceApplication` interface for the response

### 2. Client Method (`src/lib/coolify-client.ts`)
- Added `updateServiceApplication(serviceUuid, appUuid, data)` method
- Follows existing patterns: uses `cleanRequestData()` and returns typed response
- Placed logically after other service methods

### 3. MCP Tool Action (`src/lib/mcp-server.ts`)
- Added `update_application` action to the `service` tool
- Parameters:
  - `uuid` (service UUID, required)
  - `app_uuid` (sub-application UUID, required)
  - `url` (optional FQDN string)
  - `image` (optional Docker image string)
  - `human_name` (optional display name)
  - `description` (optional)
  - `exclude_from_status` (optional boolean)
  - `is_gzip_enabled` (optional boolean)
  - `is_stripprefix_enabled` (optional boolean)
- Updated tool description to document the new action

## Implementation Notes

- Follows existing code patterns and conventions
- Uses the same error handling and validation approach as other service actions
- The endpoint accepts partial updates — only provided fields are sent to Coolify
- No destructive operation guard needed (this is an update, not a delete)

## Testing

The implementation follows the established patterns in the codebase:
- Client method mirrors other PATCH operations (e.g., `updateService`, `updateApplication`)
- Tool action follows the same structure as other service actions
- Type definitions match the Coolify OpenAPI spec for this endpoint

## Example Usage

```typescript
// Update a sub-application's FQDN
await client.updateServiceApplication(serviceUuid, appUuid, {
  url: "https://app.example.com"
});

// Update Docker image
await client.updateServiceApplication(serviceUuid, appUuid, {
  image: "nginx:latest"
});

// Multiple fields at once
await client.updateServiceApplication(serviceUuid, appUuid, {
  human_name: "My App",
  description: "Production web server",
  is_gzip_enabled: true
});
```

Closes #301


---

## Example AI Prompts

> "Change the FQDN of the Ghost Blog sub-application in my ghost service to https://newdomain.example.com"

This will trigger the `update_application` action on the `service` tool, calling:
```
service action=update_application uuid=<service-uuid> app_uuid=<app-uuid> url="https://newdomain.example.com"
```

Other example prompts:
- "Update the Ghost blog docker image to ghost:5"
- "Rename the Ghost Blog sub-application to 'My Tech Blog'"
- "Enable gzip compression for the Ghost sub-application"


### 4. Version Compatibility Error Handling
- Added error hint in `errorHint()` function to detect 404 on `/services/{uuid}/applications/{app_uuid}` path
- Returns clear message: "Sub-application management requires Coolify v4.2+. Check version with `get_version`. Upgrade: `curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.2.0`"
- Prevents confusing bare 404 errors when running against Coolify < v4.2.0
- Added test coverage for the new error hint
