### PR TITLE
fix: stop_all_apps schema breaks every Google Gemini request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Every Google Gemini request failed while this server was connected.** `stop_all_apps` declared `confirm: z.literal(true)`, which zod emits as `const: true`; `@ai-sdk/google` rewrites a JSON Schema `const` into `enum: [const]` when it converts the tool list, and Google's `enum` accepts strings only. `generateContent` answered `400 Invalid value at 'tools[0].function_declarations[42].parameters.properties[0].value.enum[0]' (TYPE_STRING), true` — and it rejects the **request**, not the offending declaration, so all 44 tools went down with the one. The symptom is a client that cannot make a single Gemini call until it disables this tool by name, which does not look like a schema problem from the outside. Anthropic and the OpenAI-compatible providers accepted the same list unchanged, which is why it survived from #261 to here.
+
+  `confirm` is now `z.boolean()` and the handler's existing `confirm !== true` check is the gate. **Nothing is loosened**: a literal only ever required the model to type `true`, and a model willing to stop the estate types it either way — the real confirmation is the #261 elicitation prompt, in front of a human, and it is untouched. Anything that is not a boolean (`"true"`, `1`, omitted) is still refused by the parser before the handler runs, and `false` is refused before any Coolify call is made.
+
+  A test now walks every tool's schema over a real `tools/list` round trip and fails on any non-string `enum` or `const`, so the next literal is caught at the tool that adds it rather than by a provider six models away.
+
 ## [2.18.0] - 2026-07-31
 
 ### Added

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1853,6 +1853,128 @@ describe('tool annotations (#260)', () => {
   });
 });
 
+/**
+ * One tool's schema can take the whole tool list down on a provider.
+ *
+ * Google's `generateContent` requires every `enum` entry to be a string and
+ * rejects the entire request when one is not — not the offending tool, the
+ * request, so all 44 go with it. `@ai-sdk/google` rewrites a JSON Schema
+ * `const` into `enum: [const]` on the way out, and zod emits `z.literal(true)`
+ * as `const: true`, which is how a single confirmation parameter on
+ * `stop_all_apps` made every Gemini model unusable while Anthropic and the
+ * OpenAI-compatible providers accepted the same list unchanged.
+ *
+ * Walks what a client receives rather than the zod shapes, because the emitted
+ * JSON is what goes on the wire, and asserts across every tool rather than the
+ * one that broke — the next literal will be added somewhere else.
+ */
+describe('tool schemas as a provider receives them', () => {
+  const listTools = async () => {
+    const srv = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+    const client = new Client({ name: 'test', version: '0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([srv.connect(serverTransport), client.connect(clientTransport)]);
+    const { tools } = await client.listTools();
+    await client.close();
+    return tools;
+  };
+
+  /** Paths of every `enum` entry and `const` in `node` that is not a string. */
+  const nonStringConstants = (node: unknown, path: string): string[] => {
+    if (node === null || typeof node !== 'object') return [];
+    if (Array.isArray(node)) {
+      return node.flatMap((value, index) => nonStringConstants(value, `${path}[${index}]`));
+    }
+    const record = node as Record<string, unknown>;
+    const here: string[] = [];
+    if (Array.isArray(record.enum)) {
+      record.enum.forEach((value, index) => {
+        if (typeof value !== 'string') here.push(`${path}.enum[${index}]`);
+      });
+    }
+    if ('const' in record && typeof record.const !== 'string') here.push(`${path}.const`);
+    return here.concat(
+      Object.entries(record).flatMap(([key, value]) =>
+        key === 'enum' || key === 'const' ? [] : nonStringConstants(value, `${path}.${key}`),
+      ),
+    );
+  };
+
+  it('emits no non-string enum or const, in any tool', async () => {
+    const tools = await listTools();
+
+    const offenders = tools.flatMap((tool) => nonStringConstants(tool.inputSchema, tool.name));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('still requires an explicit confirm on stop_all_apps', async () => {
+    const tools = await listTools();
+    const schema = tools.find((tool) => tool.name === 'stop_all_apps')?.inputSchema as {
+      required?: string[];
+      properties?: Record<string, { type?: string; description?: string }>;
+    };
+
+    // The schema no longer pins the value, so `required` plus the description
+    // is the whole of what it still says: the model must send the parameter,
+    // and it is told which value does anything. The refusal moved to the
+    // handler, which is where it always actually lived.
+    expect(schema.required).toEqual(['confirm']);
+    expect(schema.properties?.confirm.type).toBe('boolean');
+    expect(schema.properties?.confirm.description).toMatch(/true/);
+  });
+});
+
+describe('stop_all_apps confirm gate', () => {
+  const callStopAll = async (args: Record<string, unknown>) => {
+    const srv = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+    const stopAllApps = jest.spyOn(srv['client'], 'stopAllApps').mockResolvedValue({} as never);
+    const listApplications = jest
+      .spyOn(srv['client'], 'listApplications')
+      .mockResolvedValue([] as never);
+    const client = new Client({ name: 'test', version: '0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([srv.connect(serverTransport), client.connect(clientTransport)]);
+    const result = (await client.callTool({ name: 'stop_all_apps', arguments: args })) as {
+      content: Array<{ text: string }>;
+    };
+    await client.close();
+    return { text: result.content.map((c) => c.text).join('\n'), stopAllApps, listApplications };
+  };
+
+  // With the literal gone from the schema, `false` now reaches the handler
+  // instead of being rejected by the parser, and this check is the only thing
+  // between it and an estate-wide stop. Both spies stay untouched: the refusal
+  // happens before anything is looked up, let alone stopped.
+  it('refuses confirm=false without calling Coolify at all', async () => {
+    const { text, stopAllApps, listApplications } = await callStopAll({ confirm: false });
+
+    expect(text).toBe('Error: confirm=true required');
+    expect(stopAllApps).not.toHaveBeenCalled();
+    expect(listApplications).not.toHaveBeenCalled();
+  });
+
+  // Everything that is not a boolean still never reaches the handler — the
+  // string "true" included, which is the shape a model reaching for the old
+  // literal is most likely to produce.
+  it.each([
+    ['omitted', {}],
+    ['the string "true"', { confirm: 'true' }],
+    ['the number 1', { confirm: 1 }],
+  ] as Array<[string, Record<string, unknown>]>)('rejects confirm %s', async (_label, args) => {
+    const { text, stopAllApps } = await callStopAll(args);
+
+    expect(text).toMatch(/expected boolean/);
+    expect(stopAllApps).not.toHaveBeenCalled();
+  });
+
+  it('runs on an explicit true', async () => {
+    const { stopAllApps } = await callStopAll({ confirm: true });
+
+    expect(stopAllApps).toHaveBeenCalled();
+  });
+});
+
 describe('tags tool (#298)', () => {
   let server: CoolifyMcpServer;
 

--- a/src/lib/elicit.ts
+++ b/src/lib/elicit.ts
@@ -1,7 +1,7 @@
 /**
  * Human-in-the-loop confirmation for destructive tools (#261).
  *
- * The problem this solves: `stop_all_apps` is gated on a `confirm: z.literal(true)`
+ * The problem this solves: `stop_all_apps` is gated on a `confirm: true`
  * parameter, and the model fills that parameter in. That is the model confirming
  * with itself before taking every application on the estate down. Elicitation
  * moves the question to the human, rendered by the client, outside the model's

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -2793,9 +2793,30 @@ export class CoolifyMcpServer extends McpServer {
     this.defineTool(
       'stop_all_apps',
       'EMERGENCY: Stop all running apps',
-      { confirm: z.literal(true) },
+      // Not `z.literal(true)`, and this is the one schema in the server where
+      // that choice is not cosmetic. Zod emits a literal as `const: true`;
+      // @ai-sdk/google rewrites `const` into `enum: [const]` when it converts
+      // the tool list for `generateContent`, and Google's `enum` is
+      // string-only — so the request comes back `400 Invalid value at
+      // 'tools[0].function_declarations[N].parameters.properties[0].value.enum[0]'
+      // (TYPE_STRING), true`. The whole request is rejected, not this tool, so
+      // one parameter here decides whether the other 43 tools work at all on
+      // Gemini. Anthropic and the OpenAI-compatible providers accept it, which
+      // is why it survived this long.
+      //
+      // Nothing is loosened. A literal only ever required the model to type
+      // `true`, and a model willing to stop the estate types it either way;
+      // the guard below is where the refusal actually lives, and it stops
+      // being dead code behind the parser. It compares against `true` by
+      // identity rather than testing truthiness, so widening this schema later
+      // cannot quietly turn the string `"false"` into consent.
+      {
+        confirm: z
+          .boolean()
+          .describe('Must be true, and only when the user has asked to stop everything.'),
+      },
       async ({ confirm }, extra) => {
-        if (!confirm)
+        if (confirm !== true)
           return { content: [{ type: 'text' as const, text: 'Error: confirm=true required' }] };
         // `confirm` above is filled in by the model, which is why #261 exists.
         // On an elicitation-capable client the real gate is below, in front of


### PR DESCRIPTION
## Summary

`stop_all_apps` declares `confirm: z.literal(true)`. zod emits that as `const: true`, and `@ai-sdk/google` rewrites `const` into `enum: [const]` when it converts the tool list for `generateContent`. Google only accepts string enum values, so every request that includes this server's tools fails:

```
400 Invalid value at 'tools[0].function_declarations[42].parameters.properties[0].value.enum[0]' (TYPE_STRING), true
```

Google rejects the whole request, not just the one declaration, so all 44 tools go down with it, and nothing in the error points at a schema. Anthropic and the OpenAI-compatible providers accept the same list unchanged, which is why this only bites Gemini users. Reproduced with opencode 1.17.19 + gemini-2.5-flash on published v2.18.0, and independently with curl against the live API.

## Changes

- `confirm` is now `z.boolean()` with the requirement in its description, and the handler's existing check (now `confirm !== true`) is the gate.
- Nothing is loosened. The literal never stopped a model from sending `true` (with the fixed schema Gemini still emits `confirm: true` unprompted), and the elicitation prompt from #261 is untouched. Non-booleans (`"true"`, `1`, omitted) are still refused by the parser; `false` is refused before any Coolify call is made.
- Added a test that walks every tool's `inputSchema` over a real `tools/list` round trip and fails on any non-string `enum` or `const`, so the next literal gets caught in CI instead of by a provider.
- Updated the `elicit.ts` docstring that quoted the old declaration.

## Test plan

- [x] Tests added/updated — 610 pass (+7; the new ones fail on `main`)
- [x] Manually tested locally
  - The same 44-tool payload captured out of `@ai-sdk/google`: 400 before, 200 after against live `gemini-2.5-flash`
  - `confirm: false` / omitted / `"true"` / `1` / `null` all refuse over stdio JSON-RPC; with a request-logging server on the other end, `confirm: false` produces zero HTTP requests
  - `confirm: true` against a mock hits exactly `GET /applications` then `POST /applications/{uuid}/stop`, running apps only
  - Read-only tools verified against a live Coolify 4.1.2
  - opencode + `gemini-2.5-flash`: 400 on published v2.18.0, clean `get_version` on this branch

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed (CHANGELOG; tool count unchanged so no README edit)
