### PR TITLE
fix: mask credentials on detail endpoints and private key material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ No runtime changes. Safe to skip; nothing to upgrade for.
 
   The GitHub-app blast radius filters by `source_type` as well as `source_id`, because the numeric id can collide with a GitLab source. Verified live: `source_type` is the Laravel class name (`App\Models\GithubApp`), null for public-repo applications.
 
-- **`private_keys update` with new key material is guarded like the delete** (#315 review). Overwriting key material deletes the old key: Coolify never returns key material, so the previous value is exactly as gone either way, and a model "fixing" a key by overwriting it takes the same servers offline. Renames and description edits pass without a prompt.
+- **`private_keys update` with new key material is guarded like the delete** (#315 review). Overwriting key material deletes the old key: Coolify does not give key material back (true upstream from v4.2, and enforced by this client on every version since 2.19.2 — see #327), so the previous value is exactly as gone either way, and a model "fixing" a key by overwriting it takes the same servers offline. Renames and description edits pass without a prompt.
 
 - **Test suite and type checking for the docs site's contact endpoint** (#319). The site had no test runner while `/api/contact` feeds unauthenticated form fields into SES subject and reply-to headers. 33 vitest cases now drive the real handler (header injection, origin checks, rate-limiter branches including the global ceiling, failure honesty), and `astro check` enforces the strict tsconfig in CI. Site-only; nothing in the npm package changes.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,12 @@ Secrets are masked at the API boundary. A client granted "list" access never see
 
 - **`env_vars`**: variable values return as `***`
 - **`system list_resources` (full mode)**: webhook HMAC secrets, basic-auth and database passwords, `internal/external_db_url` connection strings, compose bodies, Traefik labels, nested env vars
+- **`get_database` / `get_service`**: the same credential fields are masked on the detail endpoints, and any embedded server row is projected down to uuid/name/ip so its sentinel token and log-drain config never leave the client
+- **`get_server`**: sentinel and log-drain credentials are always masked, with no reveal
+- **`private_keys`**: key material is never returned, with no reveal; name, fingerprint and public key identify a key
 - **`deployment get`**: the raw upstream payload (server settings, log-drain tokens, webhook secrets) never leaves the client; responses are projected
+
+Log output (`logs`, `application_logs`, deployment logs) is wrapped in a tamper-evident untrusted-data boundary so a poisoned log line reads as data, not instructions.
 
 Destructive operations also ask a human first; see [Ask before it hurts](#ask-before-it-hurts) above.
 

--- a/evals/src/contract/__toolsnaps__/get_database.json
+++ b/evals/src/contract/__toolsnaps__/get_database.json
@@ -1,6 +1,6 @@
 {
   "name": "get_database",
-  "description": "Database details",
+  "description": "Database details. Credentials (passwords, connection URLs) are masked by default; pass reveal: true when you explicitly need them, e.g. to wire an app to the database.",
   "annotations": {
     "readOnlyHint": true
   },
@@ -9,6 +9,9 @@
     "properties": {
       "uuid": {
         "type": "string"
+      },
+      "reveal": {
+        "type": "boolean"
       }
     },
     "required": [

--- a/evals/src/contract/__toolsnaps__/get_server.json
+++ b/evals/src/contract/__toolsnaps__/get_server.json
@@ -1,6 +1,6 @@
 {
   "name": "get_server",
-  "description": "Server details",
+  "description": "Server details. Sentinel and log-drain credentials are always masked.",
   "annotations": {
     "readOnlyHint": true
   },

--- a/evals/src/contract/__toolsnaps__/get_service.json
+++ b/evals/src/contract/__toolsnaps__/get_service.json
@@ -1,6 +1,6 @@
 {
   "name": "get_service",
-  "description": "Service details",
+  "description": "Service details. Credentials (compose bodies with resolved passwords, webhook secrets) are masked by default; pass reveal: true when you explicitly need them.",
   "annotations": {
     "readOnlyHint": true
   },
@@ -9,6 +9,9 @@
     "properties": {
       "uuid": {
         "type": "string"
+      },
+      "reveal": {
+        "type": "boolean"
       }
     },
     "required": [

--- a/evals/src/contract/__toolsnaps__/private_keys.json
+++ b/evals/src/contract/__toolsnaps__/private_keys.json
@@ -1,6 +1,6 @@
 {
   "name": "private_keys",
-  "description": "Manage SSH keys: list/get/create/update/delete",
+  "description": "Manage SSH keys: list/get/create/update/delete. Key material is never returned; identify keys by name, fingerprint and public key.",
   "annotations": {
     "destructiveHint": true
   },

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -275,6 +275,213 @@ describe('CoolifyClient', () => {
     });
   });
 
+  describe('credential masking on detail endpoints (#327/#328)', () => {
+    // A pre-4.2 server row as Coolify actually serializes it: sentinel token
+    // and log-drain credentials in the clear on the settings blob.
+    const leakyServer = {
+      id: 9,
+      uuid: 'srv-1',
+      name: 'prod-1',
+      ip: '10.0.0.5',
+      user: 'root',
+      port: 22,
+      status: 'running',
+      is_reachable: true,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      settings: {
+        id: 1,
+        server_id: 9,
+        is_sentinel_enabled: true,
+        sentinel_token: 'sentinel-secret',
+        logdrain_axiom_api_key: 'axiom-secret',
+        logdrain_axiom_dataset_name: 'coolify-logs',
+        logdrain_custom_config: '[OUTPUT] http passwd hunter2',
+        logdrain_newrelic_license_key: 'newrelic-secret',
+      },
+    };
+
+    const projectedServer = {
+      uuid: 'srv-1',
+      name: 'prod-1',
+      ip: '10.0.0.5',
+      status: 'running',
+      is_reachable: true,
+    };
+
+    const leakyDatabase = {
+      ...mockDatabase,
+      postgres_user: 'postgres',
+      postgres_password: 'db-secret',
+      internal_db_url: 'postgres://postgres:db-secret@db:5432/app',
+      external_db_url: 'postgres://postgres:db-secret@1.2.3.4:5432/app',
+      server: leakyServer,
+      destination: { id: 3, network: 'coolify', server: leakyServer },
+    };
+
+    it('getServer masks sentinel and log-drain credentials but keeps non-secret settings', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyServer));
+
+      const result = (await client.getServer('srv-1')) as unknown as Record<string, any>;
+
+      expect(result.settings.sentinel_token).toBe('***');
+      expect(result.settings.logdrain_axiom_api_key).toBe('***');
+      expect(result.settings.logdrain_custom_config).toBe('***');
+      expect(result.settings.logdrain_newrelic_license_key).toBe('***');
+      expect(result.settings.logdrain_axiom_dataset_name).toBe('coolify-logs');
+      expect(result.settings.is_sentinel_enabled).toBe(true);
+      expect(result.ip).toBe('10.0.0.5');
+      expect(JSON.stringify(result)).not.toContain('sentinel-secret');
+    });
+
+    it('listServers full (non-summary) masks the same server secrets', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([leakyServer]));
+
+      const [result] = (await client.listServers()) as unknown as Array<Record<string, any>>;
+
+      expect(result.settings.sentinel_token).toBe('***');
+      expect(JSON.stringify(result)).not.toContain('axiom-secret');
+    });
+
+    it('updateServer response masks server secrets', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyServer));
+
+      const result = (await client.updateServer('srv-1', { name: 'prod-1' })) as unknown as Record<
+        string,
+        any
+      >;
+
+      expect(result.settings.sentinel_token).toBe('***');
+    });
+
+    it('getDatabase masks passwords and connection URLs and projects embedded servers', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyDatabase));
+
+      const result = (await client.getDatabase('db-uuid')) as unknown as Record<string, any>;
+
+      expect(result.postgres_password).toBe('***');
+      expect(result.internal_db_url).toBe('***');
+      expect(result.external_db_url).toBe('***');
+      expect(result.postgres_user).toBe('postgres');
+      expect(result.server).toEqual(projectedServer);
+      expect(result.destination.server).toEqual(projectedServer);
+      expect(result.destination.network).toBe('coolify');
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('db-secret');
+      expect(serialized).not.toContain('sentinel-secret');
+      expect(serialized).not.toContain('hunter2');
+    });
+
+    it('getDatabase reveal: true returns the database credentials but still projects servers', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyDatabase));
+
+      const result = (await client.getDatabase('db-uuid', { reveal: true })) as unknown as Record<
+        string,
+        any
+      >;
+
+      expect(result.postgres_password).toBe('db-secret');
+      expect(result.internal_db_url).toContain('db-secret');
+      expect(result.server).toEqual(projectedServer);
+      expect(JSON.stringify(result)).not.toContain('sentinel-secret');
+    });
+
+    it('updateDatabase response is masked', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyDatabase));
+
+      const result = (await client.updateDatabase('db-uuid', {
+        name: 'test-db',
+      })) as unknown as Record<string, any>;
+
+      expect(result.postgres_password).toBe('***');
+      expect(result.server).toEqual(projectedServer);
+    });
+
+    it('getService masks compose bodies and projects embedded servers', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ...mockService,
+          docker_compose_raw: 'services:\n  app:\n    environment:\n      PASSWORD: hunter2',
+          docker_compose: 'services:\n  app:\n    environment:\n      PASSWORD: hunter2',
+          server: leakyServer,
+          destination: { id: 3, network: 'coolify', server: leakyServer },
+        }),
+      );
+
+      const result = (await client.getService('test-uuid')) as unknown as Record<string, any>;
+
+      expect(result.docker_compose_raw).toBe('***');
+      expect(result.docker_compose).toBe('***');
+      expect(result.server).toEqual(projectedServer);
+      expect(result.destination.server).toEqual(projectedServer);
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('hunter2');
+      expect(serialized).not.toContain('sentinel-secret');
+    });
+
+    it('getService reveal: true returns compose bodies but still projects servers', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ...mockService,
+          docker_compose_raw: 'services: {}',
+          server: leakyServer,
+        }),
+      );
+
+      const result = (await client.getService('test-uuid', { reveal: true })) as unknown as Record<
+        string,
+        any
+      >;
+
+      expect(result.docker_compose_raw).toBe('services: {}');
+      expect(result.server).toEqual(projectedServer);
+      expect(JSON.stringify(result)).not.toContain('axiom-secret');
+    });
+
+    it('masks private key material on list, get and update; metadata survives (#327)', async () => {
+      const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc123\n-----END OPENSSH PRIVATE KEY-----';
+      const key = {
+        id: 1,
+        uuid: 'key-uuid',
+        name: 'deploy-key',
+        fingerprint: 'SHA256:abcdef',
+        public_key: 'ssh-ed25519 AAAA... deploy',
+        private_key: pem,
+      };
+
+      mockFetch.mockResolvedValueOnce(mockResponse([key]));
+      const [listed] = (await client.listPrivateKeys()) as unknown as Array<Record<string, any>>;
+      expect(listed.private_key).toBe('***');
+      expect(listed.fingerprint).toBe('SHA256:abcdef');
+      expect(listed.public_key).toBe('ssh-ed25519 AAAA... deploy');
+
+      mockFetch.mockResolvedValueOnce(mockResponse(key));
+      const got = (await client.getPrivateKey('key-uuid')) as unknown as Record<string, any>;
+      expect(got.private_key).toBe('***');
+
+      mockFetch.mockResolvedValueOnce(mockResponse(key));
+      const updated = (await client.updatePrivateKey('key-uuid', {
+        name: 'deploy-key',
+      })) as unknown as Record<string, any>;
+      expect(updated.private_key).toBe('***');
+      expect(JSON.stringify([listed, got, updated])).not.toContain('BEGIN OPENSSH');
+    });
+
+    it('masks a PEM echoed back by createPrivateKey', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ uuid: 'key-uuid', private_key: '-----BEGIN RSA PRIVATE KEY-----' }),
+      );
+
+      const created = (await client.createPrivateKey({
+        private_key: '-----BEGIN RSA PRIVATE KEY-----',
+        name: 'k',
+      })) as unknown as Record<string, any>;
+
+      expect(created.uuid).toBe('key-uuid');
+      expect(created.private_key).toBe('***');
+    });
+  });
+
   describe('getServerResources', () => {
     it('should get server resources', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockServerResources));

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -480,6 +480,51 @@ describe('CoolifyClient', () => {
       expect(created.uuid).toBe('key-uuid');
       expect(created.private_key).toBe('***');
     });
+
+    it('passes malformed upstream payloads through untouched instead of crashing', async () => {
+      // A misbehaving instance (or an HTML error page parsed as null) must not
+      // turn a masking pass into a TypeError.
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.updateServer('srv-1', { name: 'x' })).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.updatePrivateKey('key-uuid', { name: 'x' })).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.createPrivateKey({ private_key: 'k', name: 'k' })).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.listPrivateKeys()).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.listServers()).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.getDatabase('db-uuid')).toBeNull();
+    });
+
+    it('leaves non-object server and destination fields alone when projecting', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ ...mockDatabase, server: 'srv-by-name', destination: { id: 3 } }),
+      );
+
+      const result = (await client.getDatabase('db-uuid')) as unknown as Record<string, any>;
+
+      expect(result.server).toBe('srv-by-name');
+      expect(result.destination).toEqual({ id: 3 });
+
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ ...mockDatabase, server: null, destination: { id: 3, server: null } }),
+      );
+      const withNulls = (await client.getDatabase('db-uuid')) as unknown as Record<string, any>;
+      expect(withNulls.server).toBeNull();
+      expect(withNulls.destination.server).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse({ ...leakyServer, settings: null }));
+      const bareServer = (await client.getServer('srv-1')) as unknown as Record<string, any>;
+      expect(bareServer.settings).toBeNull();
+      expect(bareServer.ip).toBe('10.0.0.5');
+    });
   });
 
   describe('getServerResources', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -638,6 +638,106 @@ function maskResourceItemFull(item: ResourceListItemFull): ResourceListItemFull 
 }
 
 /**
+ * Secrets serialized on a server row by pre-4.2 Coolify — on the `settings`
+ * blob in 4.1.2, checked on the top level too in case another version
+ * flattens them. `sentinel_token` authenticates the Sentinel agent to the
+ * Coolify instance; the log-drain fields are destination credentials (Axiom
+ * API key, New Relic license key) plus the custom fluent-bit config block,
+ * which carries whatever credentials were pasted into it. None of them are
+ * needed to answer "what is this server and how is it doing", so they are
+ * masked unconditionally with no reveal (#328).
+ */
+const SENSITIVE_SERVER_FIELDS = [
+  'sentinel_token',
+  'logdrain_axiom_api_key',
+  'logdrain_custom_config',
+  'logdrain_newrelic_license_key',
+] as const;
+
+function maskFields(
+  record: Record<string, unknown>,
+  fields: readonly string[],
+): Record<string, unknown> {
+  const masked = { ...record };
+  for (const field of fields) {
+    if (masked[field] != null) {
+      masked[field] = MASKED_VALUE;
+    }
+  }
+  return masked;
+}
+
+/**
+ * Mask {@link SENSITIVE_SERVER_FIELDS} on a full {@link Server} row, top
+ * level and `settings` blob both. Null/undefined values are preserved, like
+ * every other masker here.
+ */
+function maskServerSecrets(server: Server): Server {
+  const masked = maskFields(server as unknown as Record<string, unknown>, SENSITIVE_SERVER_FIELDS);
+  if (masked.settings !== null && typeof masked.settings === 'object') {
+    masked.settings = maskFields(
+      masked.settings as Record<string, unknown>,
+      SENSITIVE_SERVER_FIELDS,
+    );
+  }
+  return masked as unknown as Server;
+}
+
+/**
+ * Replace any embedded full server row with its {@link ServerSummary}
+ * projection. Pre-4.2 `/databases/{uuid}` and `/services/{uuid}` inline the
+ * complete server — settings blob, sentinel token, log-drain config — none of
+ * which belongs in "database details" (#328). The relation appears at the top
+ * level and under `destination`, so both are walked; the projection is also a
+ * large token-count win on these payloads.
+ */
+function projectNestedServers(item: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...item };
+  if (out.server !== null && typeof out.server === 'object') {
+    out.server = toServerSummary(out.server as Server);
+  }
+  if (out.destination !== null && typeof out.destination === 'object') {
+    const destination = { ...(out.destination as Record<string, unknown>) };
+    if (destination.server !== null && typeof destination.server === 'object') {
+      destination.server = toServerSummary(destination.server as Server);
+    }
+    out.destination = destination;
+  }
+  return out;
+}
+
+/**
+ * Sanitize a database/service detail payload (#328): embedded server rows are
+ * projected down to summaries always, and unless `reveal` is set the same
+ * credential fields the `/resources` pipeline masks (database passwords,
+ * connection URLs, compose bodies, webhook secrets, labels, nested env-var
+ * values) are masked here too — pre-4.2 instances serialize all of them
+ * decrypted. `reveal: true` returns the resource's own credentials for the
+ * legitimate "wire an app to this database" case; it never brings the full
+ * server row back.
+ */
+function sanitizeResourceDetail<T extends object>(item: T, reveal?: boolean): T {
+  if (item === null || typeof item !== 'object' || Array.isArray(item)) return item;
+  let out = projectNestedServers(item as Record<string, unknown>);
+  if (reveal !== true) {
+    out = maskResourceItemFull(out as ResourceListItemFull);
+  }
+  return out as T;
+}
+
+/**
+ * Mask the PEM on a {@link PrivateKey} row (#327). Pre-4.2 Coolify returns
+ * complete private key material on `/security/keys` list and get; name,
+ * fingerprint and public-key fields serve every legitimate read, so the PEM
+ * is masked unconditionally — there is deliberately no `reveal` for key
+ * material.
+ */
+function maskPrivateKey(key: PrivateKey): PrivateKey {
+  if (key === null || typeof key !== 'object' || key.private_key == null) return key;
+  return { ...key, private_key: MASKED_VALUE };
+}
+
+/**
  * HTTP client for the Coolify API
  */
 export class CoolifyClient {
@@ -889,11 +989,12 @@ export class CoolifyClient {
       per_page: options?.per_page,
     });
     const servers = await this.request<Server[]>(`/servers${query}`);
-    return options?.summary && Array.isArray(servers) ? servers.map(toServerSummary) : servers;
+    if (options?.summary && Array.isArray(servers)) return servers.map(toServerSummary);
+    return Array.isArray(servers) ? servers.map(maskServerSecrets) : servers;
   }
 
   async getServer(uuid: string): Promise<Server> {
-    return this.request<Server>(`/servers/${uuid}`);
+    return maskServerSecrets(await this.request<Server>(`/servers/${uuid}`));
   }
 
   async createServer(data: CreateServerRequest): Promise<UuidResponse> {
@@ -904,10 +1005,11 @@ export class CoolifyClient {
   }
 
   async updateServer(uuid: string, data: UpdateServerRequest): Promise<Server> {
-    return this.request<Server>(`/servers/${uuid}`, {
+    const server = await this.request<Server>(`/servers/${uuid}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
     });
+    return server !== null && typeof server === 'object' ? maskServerSecrets(server) : server;
   }
 
   async deleteServer(uuid: string): Promise<MessageResponse> {
@@ -1350,15 +1452,17 @@ export class CoolifyClient {
     return options?.summary && Array.isArray(dbs) ? dbs.map(toDatabaseSummary) : dbs;
   }
 
-  async getDatabase(uuid: string): Promise<Database> {
-    return this.request<Database>(`/databases/${uuid}`);
+  async getDatabase(uuid: string, options?: { reveal?: boolean }): Promise<Database> {
+    const db = await this.request<Database>(`/databases/${uuid}`);
+    return sanitizeResourceDetail(db, options?.reveal);
   }
 
   async updateDatabase(uuid: string, data: UpdateDatabaseRequest): Promise<Database> {
-    return this.request<Database>(`/databases/${uuid}`, {
+    const db = await this.request<Database>(`/databases/${uuid}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
     });
+    return sanitizeResourceDetail(db);
   }
 
   async deleteDatabase(uuid: string, options?: DeleteOptions): Promise<MessageResponse> {
@@ -1461,8 +1565,9 @@ export class CoolifyClient {
     return options?.summary && Array.isArray(services) ? services.map(toServiceSummary) : services;
   }
 
-  async getService(uuid: string): Promise<Service> {
-    return this.request<Service>(`/services/${uuid}`);
+  async getService(uuid: string, options?: { reveal?: boolean }): Promise<Service> {
+    const service = await this.request<Service>(`/services/${uuid}`);
+    return sanitizeResourceDetail(service, options?.reveal);
   }
 
   async createService(data: CreateServiceRequest): Promise<ServiceCreateResponse> {
@@ -1481,10 +1586,11 @@ export class CoolifyClient {
     if (payload.docker_compose_raw) {
       payload.docker_compose_raw = toBase64(payload.docker_compose_raw);
     }
-    return this.request<Service>(`/services/${uuid}`, {
+    const service = await this.request<Service>(`/services/${uuid}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
     });
+    return sanitizeResourceDetail(service);
   }
 
   async updateServiceApplication(
@@ -1713,25 +1819,31 @@ export class CoolifyClient {
   // ===========================================================================
 
   async listPrivateKeys(): Promise<PrivateKey[]> {
-    return this.request<PrivateKey[]>('/security/keys');
+    const keys = await this.request<PrivateKey[]>('/security/keys');
+    return Array.isArray(keys) ? keys.map(maskPrivateKey) : keys;
   }
 
   async getPrivateKey(uuid: string): Promise<PrivateKey> {
-    return this.request<PrivateKey>(`/security/keys/${uuid}`);
+    return maskPrivateKey(await this.request<PrivateKey>(`/security/keys/${uuid}`));
   }
 
   async createPrivateKey(data: CreatePrivateKeyRequest): Promise<UuidResponse> {
-    return this.request<UuidResponse>('/security/keys', {
+    const created = await this.request<UuidResponse>('/security/keys', {
       method: 'POST',
       body: JSON.stringify(data),
     });
+    // Typed as uuid-only, but don't trust upstream not to echo the PEM back.
+    return created !== null && typeof created === 'object'
+      ? (maskPrivateKey(created as PrivateKey) as UuidResponse)
+      : created;
   }
 
   async updatePrivateKey(uuid: string, data: UpdatePrivateKeyRequest): Promise<PrivateKey> {
-    return this.request<PrivateKey>(`/security/keys/${uuid}`, {
+    const key = await this.request<PrivateKey>(`/security/keys/${uuid}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
     });
+    return key !== null && typeof key === 'object' ? maskPrivateKey(key) : key;
   }
 
   async deletePrivateKey(uuid: string): Promise<MessageResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -822,8 +822,11 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.listServers({ page, per_page, summary: true })),
     );
 
-    this.defineTool('get_server', 'Server details', { uuid: z.string() }, async ({ uuid }) =>
-      wrap(() => this.client.getServer(uuid)),
+    this.defineTool(
+      'get_server',
+      'Server details. Sentinel and log-drain credentials are always masked.',
+      { uuid: z.string() },
+      async ({ uuid }) => wrap(() => this.client.getServer(uuid)),
     );
 
     this.defineTool(
@@ -1421,8 +1424,11 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.listDatabases({ page, per_page, summary: true })),
     );
 
-    this.defineTool('get_database', 'Database details', { uuid: z.string() }, async ({ uuid }) =>
-      wrap(() => this.client.getDatabase(uuid)),
+    this.defineTool(
+      'get_database',
+      'Database details. Credentials (passwords, connection URLs) are masked by default; pass reveal: true when you explicitly need them, e.g. to wire an app to the database.',
+      { uuid: z.string(), reveal: z.boolean().optional() },
+      async ({ uuid, reveal }) => wrap(() => this.client.getDatabase(uuid, { reveal })),
     );
 
     this.defineTool(
@@ -1525,8 +1531,11 @@ export class CoolifyMcpServer extends McpServer {
         wrap(() => this.client.listServices({ page, per_page, summary: true })),
     );
 
-    this.defineTool('get_service', 'Service details', { uuid: z.string() }, async ({ uuid }) =>
-      wrap(() => this.client.getService(uuid)),
+    this.defineTool(
+      'get_service',
+      'Service details. Credentials (compose bodies with resolved passwords, webhook secrets) are masked by default; pass reveal: true when you explicitly need them.',
+      { uuid: z.string(), reveal: z.boolean().optional() },
+      async ({ uuid, reveal }) => wrap(() => this.client.getService(uuid, { reveal })),
     );
 
     this.defineTool(
@@ -2118,7 +2127,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.defineTool(
       'private_keys',
-      'Manage SSH keys: list/get/create/update/delete',
+      'Manage SSH keys: list/get/create/update/delete. Key material is never returned; identify keys by name, fingerprint and public key.',
       {
         action: z.enum(['list', 'get', 'create', 'update', 'delete']),
         uuid: z.string().optional(),
@@ -2149,8 +2158,9 @@ export class CoolifyMcpServer extends McpServer {
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
             // Renames and descriptions pass freely, but replacing the key
             // material is guarded like the delete, because it IS the delete of
-            // the old key: Coolify never returns key material, so the
-            // overwritten value is exactly as gone as a deleted one, and a
+            // the old key: key material is never readable back through this
+            // client (masked since #327, and stripped upstream from v4.2), so
+            // the overwritten value is exactly as gone as a deleted one, and a
             // model "fixing" a key by overwriting it takes the same servers
             // offline.
             if (private_key === undefined) {
@@ -2173,9 +2183,10 @@ export class CoolifyMcpServer extends McpServer {
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
-            // #315: guarded because the loss is irrecoverable — Coolify never
-            // returns key material after v4.2 hides secrets, and often not
-            // before, so a deleted key cannot be re-read and re-added. The
+            // #315: guarded because the loss is irrecoverable — key material
+            // is never readable back through this client (masked since #327,
+            // stripped upstream from v4.2), so a deleted key cannot be
+            // re-read and re-added. The
             // routine deletes (storages, scheduled tasks, env vars) stay
             // unguarded on purpose; a prompt on every delete is how prompts
             // stop being read.


### PR DESCRIPTION
Closes #327, closes #328.

## What leaks today (pre-4.2 instances, every published version)

- `get_database`: the database password in its own field, plus `internal_db_url` / `external_db_url` with the password embedded
- `get_database` / `get_service`: the full nested `server` row, carrying `sentinel_token` and the complete log-drain configuration (including any credentials pasted into a custom fluent-bit block)
- `get_server`: the same settings blob, first-hand
- `private_keys` list/get: the complete PEM for every key — every deploy key and the host SSH key in one call

## The fix, at the client boundary like every existing masker

- **`get_database` / `get_service`** mask the same credential fields the `/resources` pipeline already masks (the #209 audit list), with `reveal: true` opt-in matching `env_vars` for the legitimate "wire an app to this database" case. Embedded server rows are projected down to the existing `ServerSummary` shape **unconditionally** — `reveal` never brings the server settings back. Also a large token-count win. Update responses get the same treatment.
- **`get_server` / `list_servers` / `updateServer`** mask `sentinel_token`, `logdrain_axiom_api_key`, `logdrain_custom_config` and `logdrain_newrelic_license_key`, no reveal. Non-secret settings (dataset names, flags) pass through.
- **`private_keys`** never returns PEM material on any action. This is deliberately stronger than #327's proposed `reveal` opt-in: name, fingerprint and public key serve every legitimate read, and the injection evals already treat key disclosure as a breach — so the server simply doesn't offer it.

Also corrects the 2.18.0 changelog claim #327 flagged ("Coolify never returns key material" was only true from v4.2) and the matching guard comments.

## Verification

- 10 new unit tests: masking, reveal behaviour, server projection at both nesting sites, PEM masking across list/get/create/update, plus `JSON.stringify` never-contains-secret assertions
- 645 total, all green; contract snapshots regenerated for the 4 changed tool surfaces (`get_database`, `get_service`, `get_server`, `private_keys`)
- README "Secure by default" section updated to state the new posture