### PR TITLE
fix: mask get_application credentials and project the server row

### DIFF
--- a/evals/src/contract/__toolsnaps__/get_application.json
+++ b/evals/src/contract/__toolsnaps__/get_application.json
@@ -1,6 +1,6 @@
 {
   "name": "get_application",
-  "description": "App details",
+  "description": "App details. Credentials (webhook secrets, basic-auth password, compose bodies, labels) are masked by default; pass reveal: true when you explicitly need them.",
   "annotations": {
     "readOnlyHint": true
   },
@@ -9,6 +9,9 @@
     "properties": {
       "uuid": {
         "type": "string"
+      },
+      "reveal": {
+        "type": "boolean"
       }
     },
     "required": [

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -275,6 +275,84 @@ describe('CoolifyClient', () => {
     });
   });
 
+  describe('get_application credential masking (#332)', () => {
+    const leakyApplication = {
+      ...mockApplication,
+      manual_webhook_secret_github: 'gh-hmac-secret',
+      manual_webhook_secret_gitlab: 'gl-hmac-secret',
+      http_basic_auth_password: 'basic-secret',
+      custom_labels: 'dHJhZWZpay5odHBhc3N3ZA==',
+      destination: {
+        id: 0,
+        network: 'coolify',
+        server: {
+          id: 0,
+          uuid: 'srv-0',
+          name: 'localhost',
+          ip: 'host.docker.internal',
+          status: 'running',
+          settings: {
+            sentinel_token: 'sentinel-secret',
+            logdrain_custom_config: 'Header Authorization Bearer drain-secret',
+          },
+        },
+      },
+    };
+
+    it('masks webhook secrets and projects the embedded server by default', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyApplication));
+
+      const result = (await client.getApplication('app-uuid')) as unknown as Record<string, any>;
+
+      expect(result.manual_webhook_secret_github).toBe('***');
+      expect(result.manual_webhook_secret_gitlab).toBe('***');
+      expect(result.http_basic_auth_password).toBe('***');
+      expect(result.custom_labels).toBe('***');
+      expect(result.destination.server).toEqual({
+        uuid: 'srv-0',
+        name: 'localhost',
+        ip: 'host.docker.internal',
+        status: 'running',
+      });
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('hmac-secret');
+      expect(serialized).not.toContain('sentinel-secret');
+      expect(serialized).not.toContain('drain-secret');
+    });
+
+    it('reveal: true returns the app credentials but still projects the server', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyApplication));
+
+      const result = (await client.getApplication('app-uuid', {
+        reveal: true,
+      })) as unknown as Record<string, any>;
+
+      expect(result.manual_webhook_secret_github).toBe('gh-hmac-secret');
+      expect(result.custom_labels).toBe('dHJhZWZpay5odHBhc3N3ZA==');
+      expect(JSON.stringify(result)).not.toContain('sentinel-secret');
+    });
+
+    it('updateApplication response is masked', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(leakyApplication));
+
+      const result = (await client.updateApplication('app-uuid', {
+        name: 'test-app',
+      })) as unknown as Record<string, any>;
+
+      expect(result.manual_webhook_secret_github).toBe('***');
+      expect(JSON.stringify(result)).not.toContain('drain-secret');
+    });
+
+    it('listApplications full (non-summary) is masked too', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([leakyApplication]));
+
+      const [result] = (await client.listApplications()) as unknown as Array<Record<string, any>>;
+
+      expect(result.manual_webhook_secret_github).toBe('***');
+      expect(JSON.stringify(result)).not.toContain('sentinel-secret');
+    });
+  });
+
   describe('credential masking on detail endpoints (#327/#328)', () => {
     // A pre-4.2 server row as Coolify actually serializes it: sentinel token
     // and log-drain credentials in the clear on the settings blob.

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -351,6 +351,17 @@ describe('CoolifyClient', () => {
       expect(result.manual_webhook_secret_github).toBe('***');
       expect(JSON.stringify(result)).not.toContain('sentinel-secret');
     });
+
+    it('passes malformed upstream payloads through untouched instead of crashing', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.getApplication('app-uuid')).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.updateApplication('app-uuid', { name: 'x' })).toBeNull();
+
+      mockFetch.mockResolvedValueOnce(mockResponse(null));
+      expect(await client.listApplications()).toBeNull();
+    });
   });
 
   describe('credential masking on detail endpoints (#327/#328)', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1159,11 +1159,13 @@ export class CoolifyClient {
       per_page: options?.per_page,
     });
     const apps = await this.request<Application[]>(`/applications${query}`);
-    return options?.summary && Array.isArray(apps) ? apps.map(toApplicationSummary) : apps;
+    if (options?.summary && Array.isArray(apps)) return apps.map(toApplicationSummary);
+    return Array.isArray(apps) ? apps.map((app) => sanitizeResourceDetail(app)) : apps;
   }
 
-  async getApplication(uuid: string): Promise<Application> {
-    return this.request<Application>(`/applications/${uuid}`);
+  async getApplication(uuid: string, options?: { reveal?: boolean }): Promise<Application> {
+    const app = await this.request<Application>(`/applications/${uuid}`);
+    return sanitizeResourceDetail(app, options?.reveal);
   }
 
   async createApplicationPublic(data: CreateApplicationPublicRequest): Promise<UuidResponse> {
@@ -1233,10 +1235,11 @@ export class CoolifyClient {
     if (mapped.docker_compose_raw) {
       (payload as Record<string, unknown>).docker_compose_raw = toBase64(mapped.docker_compose_raw);
     }
-    return this.request<Application>(`/applications/${uuid}`, {
+    const app = await this.request<Application>(`/applications/${uuid}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
     });
+    return sanitizeResourceDetail(app);
   }
 
   async deleteApplication(uuid: string, options?: DeleteOptions): Promise<MessageResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -991,11 +991,15 @@ export class CoolifyMcpServer extends McpServer {
         ),
     );
 
-    this.defineTool('get_application', 'App details', { uuid: z.string() }, async ({ uuid }) =>
-      wrapWithActions(
-        () => this.client.getApplication(uuid),
-        (app) => getApplicationActions(app.uuid, app.status),
-      ),
+    this.defineTool(
+      'get_application',
+      'App details. Credentials (webhook secrets, basic-auth password, compose bodies, labels) are masked by default; pass reveal: true when you explicitly need them.',
+      { uuid: z.string(), reveal: z.boolean().optional() },
+      async ({ uuid, reveal }) =>
+        wrapWithActions(
+          () => this.client.getApplication(uuid, { reveal }),
+          (app) => getApplicationActions(app.uuid, app.status),
+        ),
     );
 
     this.defineTool(


### PR DESCRIPTION
Closes #332. Same treatment as #331: mask the #209 sensitive-field list on `get_application` / `updateApplication` / non-summary `listApplications` with `reveal: true` opt-in on get, and project embedded `destination.server` rows to the summary shape unconditionally. Four new tests with never-contains-secret assertions; `get_application` contract snapshot regenerated. Found live: reading an app's config through the MCP returned the deploy-webhook HMAC keys and the server's log-drain credentials in the clear.