### PR TITLE
feat: verify exact application environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Exact application-environment verification without enumeration.** The new read-only `verify_app_environment` tool requires an application UUID, project UUID and expected environment name, reads only those exact application and environment endpoints, and returns a minimal identity proof. UUID, project, environment name and numeric environment identity drift all fail closed; embedded environment resources and configuration never enter the tool response.
+
 ## [2.19.3] - 2026-08-06
 
 A security release, and the one that ends the leak class instead of patching another instance of it. Update from any earlier version.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Coolify that provides 44 token-optimized tools for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, teams, cloud tokens, documentation search, smart diagnostics, and batch operations. v2.0.0 reduced token usage by 85% (from ~43,000 to ~6,600 tokens) by consolidating related operations into single tools with action parameters.
+MCP (Model Context Protocol) server for Coolify that provides 45 token-optimized tools for AI assistants to manage infrastructure through natural language. Tools cover servers, projects, environments, applications, databases, services, deployments, private keys, teams, cloud tokens, documentation search, smart diagnostics, and batch operations. v2.0.0 reduced token usage by 85% (from ~43,000 to ~6,600 tokens) by consolidating related operations into single tools with action parameters.
 
 ## Commands
 
@@ -181,6 +181,6 @@ When making changes to the codebase, ensure documentation is updated:
    - New example prompts needed
    - Response size improvements made (update comparison table)
 
-3. **This file (CLAUDE.md)** - Update tool count if changed (currently 44 tools)
+3. **This file (CLAUDE.md)** - Update tool count if changed (currently 45 tools)
 
 Always work on a feature branch and include documentation updates in the same PR as code changes.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.StuMason%2Fcoolify-blue)](https://registry.modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Manage [Coolify](https://coolify.io/) from Claude, Cursor, or any MCP client: 44 consolidated tools for deploying, debugging, and operating your self-hosted PaaS in plain English.
+Manage [Coolify](https://coolify.io/) from Claude, Cursor, or any MCP client: 45 consolidated tools for deploying, debugging, and operating your self-hosted PaaS in plain English.
 
 📖 **[coolify-mcp.stumason.dev](https://coolify-mcp.stumason.dev)**: what it does, how to install it, and why it is safe to point at production.
 
@@ -57,7 +57,7 @@ Behind Cloudflare Access or an auth proxy? Add `--header "Key: Value"` args (rep
 | **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`                                                                                     |
 | **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                                                           |
 | **Environments**     | `environments` (list, get, create, delete via action param)                                                                                                               |
-| **Applications**     | `list_applications`, `get_application`, `application` (CRUD + delete_preview)                                                                                             |
+| **Applications**     | `list_applications`, `get_application`, `verify_app_environment`, `application` (CRUD + delete_preview)                                                                   |
 | **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, delete), `database_backups` (CRUD schedules, executions incl. delete)                                       |
 | **Services**         | `list_services`, `get_service`, `service` (create, update, delete, list_containers; per-container `update_application` + `start/stop/restart_application`, Coolify v4.2+) |
 | **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                                                              |

--- a/evals/src/contract/__toolsnaps__/_roster.json
+++ b/evals/src/contract/__toolsnaps__/_roster.json
@@ -42,5 +42,6 @@
   "system",
   "tags",
   "teams",
-  "validate_server"
+  "validate_server",
+  "verify_app_environment"
 ]

--- a/evals/src/contract/__toolsnaps__/verify_app_environment.json
+++ b/evals/src/contract/__toolsnaps__/verify_app_environment.json
@@ -1,0 +1,30 @@
+{
+  "name": "verify_app_environment",
+  "description": "Verify one exact application belongs to one exact project environment without list calls",
+  "annotations": {
+    "readOnlyHint": true
+  },
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "application_uuid": {
+        "type": "string",
+        "minLength": 1
+      },
+      "project_uuid": {
+        "type": "string",
+        "minLength": 1
+      },
+      "expected_environment": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required": [
+      "application_uuid",
+      "project_uuid",
+      "expected_environment"
+    ],
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "coolify-mcp",
   "display_name": "Coolify MCP",
   "version": "2.19.3",
-  "description": "44 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
+  "description": "45 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
   "author": {
     "name": "Stuart Mason",
     "url": "https://stumason.dev"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.StuMason/coolify",
-  "description": "44 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
+  "description": "45 optimized tools for managing Coolify infrastructure, diagnostics, and docs search",
   "repository": {
     "url": "https://github.com/StuMason/coolify-mcp",
     "source": "github"

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -1628,6 +1628,126 @@ describe('CoolifyClient', () => {
       expect(result).toEqual(mockApplication);
     });
 
+    describe('verifyApplicationEnvironment', () => {
+      const exactApplication = {
+        ...mockApplication,
+        uuid: 'app-exact-uuid',
+        environment_id: 17,
+        project_uuid: 'project-exact-uuid',
+      };
+      const exactEnvironment = {
+        id: 17,
+        uuid: 'environment-exact-uuid',
+        name: 'staging',
+        project_uuid: 'project-exact-uuid',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        applications: [{ uuid: 'must-not-leak' }],
+      };
+
+      it('uses only exact endpoints and returns a minimal identity proof', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(exactApplication))
+          .mockResolvedValueOnce(mockResponse(exactEnvironment));
+
+        const result = await client.verifyApplicationEnvironment(
+          'app-exact-uuid',
+          'project-exact-uuid',
+          'staging',
+        );
+
+        expect(result).toEqual({
+          identity: '17',
+          name: 'staging',
+        });
+        expect(JSON.stringify(result)).not.toContain('must-not-leak');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          'http://localhost:3000/api/v1/applications/app-exact-uuid',
+          expect.any(Object),
+        );
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          'http://localhost:3000/api/v1/projects/project-exact-uuid/staging',
+          expect.any(Object),
+        );
+      });
+
+      it('rejects unsafe or empty anchors before any provider call', async () => {
+        for (const args of [
+          ['', 'project-exact-uuid', 'staging'],
+          ['app-exact-uuid', '../project', 'staging'],
+          ['app-exact-uuid', 'project-exact-uuid', 'staging?full=true'],
+        ] as const) {
+          await expect(
+            client.verifyApplicationEnvironment(args[0], args[1], args[2]),
+          ).rejects.toThrow(/^Exact .+ is invalid$/);
+        }
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('accepts an application response without project_uuid when the environment identity binds it', async () => {
+        const withoutProject = { ...exactApplication, project_uuid: undefined };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(withoutProject))
+          .mockResolvedValueOnce(mockResponse(exactEnvironment));
+
+        await expect(
+          client.verifyApplicationEnvironment('app-exact-uuid', 'project-exact-uuid', 'staging'),
+        ).resolves.toEqual({ identity: '17', name: 'staging' });
+      });
+
+      it('fails before the environment read when application identity or project drifts', async () => {
+        mockFetch.mockResolvedValueOnce(
+          mockResponse({ ...exactApplication, uuid: 'different-app-uuid' }),
+        );
+        await expect(
+          client.verifyApplicationEnvironment('app-exact-uuid', 'project-exact-uuid', 'staging'),
+        ).rejects.toThrow('Exact application UUID could not be verified');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        mockFetch.mockClear();
+        mockFetch.mockResolvedValueOnce(
+          mockResponse({ ...exactApplication, project_uuid: 'different-project-uuid' }),
+        );
+        await expect(
+          client.verifyApplicationEnvironment('app-exact-uuid', 'project-exact-uuid', 'staging'),
+        ).rejects.toThrow('Exact application project UUID does not match');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('rejects missing or drifting environment identity, name, and project', async () => {
+        mockFetch.mockResolvedValueOnce(
+          mockResponse({ ...exactApplication, environment_id: undefined }),
+        );
+        await expect(
+          client.verifyApplicationEnvironment('app-exact-uuid', 'project-exact-uuid', 'staging'),
+        ).rejects.toThrow('Exact application environment identity is unavailable');
+
+        for (const [environment, message] of [
+          [
+            { ...exactEnvironment, id: 18 },
+            'Exact application environment identity does not match',
+          ],
+          [{ ...exactEnvironment, name: 'production' }, 'Exact environment name does not match'],
+          [
+            { ...exactEnvironment, project_uuid: 'different-project-uuid' },
+            'Exact environment project UUID does not match',
+          ],
+        ] as const) {
+          mockFetch.mockClear();
+          mockFetch
+            .mockResolvedValueOnce(mockResponse(exactApplication))
+            .mockResolvedValueOnce(mockResponse(environment));
+          await expect(
+            client.verifyApplicationEnvironment('app-exact-uuid', 'project-exact-uuid', 'staging'),
+          ).rejects.toThrow(message);
+          expect(mockFetch).toHaveBeenCalledTimes(2);
+        }
+      });
+    });
+
     it('should create application from public repo', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'new-app-uuid' }));
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -83,6 +83,7 @@ describe('CoolifyMcpServer v2', () => {
       // Application operations
       expect(typeof client.listApplications).toBe('function');
       expect(typeof client.getApplication).toBe('function');
+      expect(typeof client.verifyApplicationEnvironment).toBe('function');
       expect(typeof client.createApplicationPublic).toBe('function');
       expect(typeof client.createApplicationPrivateGH).toBe('function');
       expect(typeof client.createApplicationPrivateKey).toBe('function');
@@ -1764,6 +1765,42 @@ describe('truncateLogs', () => {
   });
 });
 
+describe('verify_app_environment', () => {
+  it('passes exact anchors to the client and returns only the proof projection', async () => {
+    const server = new CoolifyMcpServer({
+      baseUrl: 'http://localhost:3000',
+      accessToken: 'test-token',
+    });
+    const proof = {
+      identity: '17',
+      name: 'staging',
+    };
+    const spy = jest
+      .spyOn(server['client'], 'verifyApplicationEnvironment')
+      .mockResolvedValue(proof);
+    const registered = (
+      server as unknown as {
+        _registeredTools: Record<
+          string,
+          { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+        >;
+      }
+    )._registeredTools;
+
+    const result = (await registered['verify_app_environment'].handler(
+      {
+        application_uuid: 'app-exact-uuid',
+        project_uuid: 'project-exact-uuid',
+        expected_environment: 'staging',
+      },
+      {},
+    )) as { content: Array<{ text: string }> };
+
+    expect(spy).toHaveBeenCalledWith('app-exact-uuid', 'project-exact-uuid', 'staging');
+    expect(JSON.parse(result.content[0].text)).toEqual(proof);
+  });
+});
+
 // =============================================================================
 // Action Generators Tests
 // =============================================================================
@@ -1830,6 +1867,7 @@ describe('tool annotations (#260)', () => {
         'server_domains',
         'server_resources',
         'teams',
+        'verify_app_environment',
       ].sort(),
     );
   });
@@ -1954,7 +1992,7 @@ describe('tool annotations (#260)', () => {
  *
  * Google's `generateContent` requires every `enum` entry to be a string and
  * rejects the entire request when one is not — not the offending tool, the
- * request, so all 44 go with it. `@ai-sdk/google` rewrites a JSON Schema
+ * request, so all 45 go with it. `@ai-sdk/google` rewrites a JSON Schema
  * `const` into `enum: [const]` on the way out, and zod emits `z.literal(true)`
  * as `const: true`, which is how a single confirmation parameter on
  * `stop_all_apps` made every Gemini model unusable while Anthropic and the

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -25,6 +25,7 @@ import type {
   CreateEnvironmentRequest,
   // Application types
   Application,
+  ApplicationEnvironmentVerification,
   CreateApplicationPublicRequest,
   CreateApplicationPrivateGHRequest,
   CreateApplicationPrivateKeyRequest,
@@ -1114,6 +1115,63 @@ export class CoolifyClient {
 
   async getApplication(uuid: string, options?: { reveal?: boolean }): Promise<Application> {
     return this.request<Application>(`/applications/${uuid}`, {}, { reveal: options?.reveal });
+  }
+
+  /**
+   * Verify that one exact application is bound to one exact project environment.
+   *
+   * This intentionally uses only the application detail endpoint and the exact
+   * project/environment endpoint. It never falls back to listing applications,
+   * projects, environments, or resources. The numeric `environment_id` is the
+   * only environment identity Coolify reliably includes on application rows, so
+   * the returned identity is its canonical string representation.
+   */
+  async verifyApplicationEnvironment(
+    applicationUuid: string,
+    projectUuid: string,
+    expectedEnvironment: string,
+  ): Promise<ApplicationEnvironmentVerification> {
+    for (const [label, value] of [
+      ['application UUID', applicationUuid],
+      ['project UUID', projectUuid],
+      ['environment name', expectedEnvironment],
+    ]) {
+      if (!value || value.trim() !== value || /[\0\r\n/?#%\\]/u.test(value)) {
+        throw new Error(`Exact ${label} is invalid`);
+      }
+    }
+
+    const application = await this.getApplication(applicationUuid);
+    if (!application || application.uuid !== applicationUuid) {
+      throw new Error('Exact application UUID could not be verified');
+    }
+    const environmentIdentity = application.environment_id;
+    if (
+      typeof environmentIdentity !== 'number' ||
+      !Number.isSafeInteger(environmentIdentity) ||
+      environmentIdentity < 1
+    ) {
+      throw new Error('Exact application environment identity is unavailable');
+    }
+    if (application.project_uuid && application.project_uuid !== projectUuid) {
+      throw new Error('Exact application project UUID does not match');
+    }
+
+    const environment = await this.getProjectEnvironment(projectUuid, expectedEnvironment);
+    if (!environment || environment.name !== expectedEnvironment) {
+      throw new Error('Exact environment name does not match');
+    }
+    if (!Number.isSafeInteger(environment.id) || environment.id !== environmentIdentity) {
+      throw new Error('Exact application environment identity does not match');
+    }
+    if (environment.project_uuid && environment.project_uuid !== projectUuid) {
+      throw new Error('Exact environment project UUID does not match');
+    }
+
+    return {
+      identity: String(environment.id),
+      name: environment.name,
+    };
   }
 
   async createApplicationPublic(data: CreateApplicationPublicRequest): Promise<UuidResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -471,6 +471,7 @@ export const TOOL_ANNOTATIONS = {
   list_deployments: READ_ONLY,
   get_server: READ_ONLY,
   get_application: READ_ONLY,
+  verify_app_environment: READ_ONLY,
   get_database: READ_ONLY,
   get_service: READ_ONLY,
   server_resources: READ_ONLY,
@@ -976,7 +977,7 @@ export class CoolifyMcpServer extends McpServer {
     );
 
     // =========================================================================
-    // Applications (4 tools)
+    // Applications (5 tools)
     // =========================================================================
     this.defineTool(
       'list_applications',
@@ -999,6 +1000,24 @@ export class CoolifyMcpServer extends McpServer {
         wrapWithActions(
           () => this.client.getApplication(uuid, { reveal }),
           (app) => getApplicationActions(app.uuid, app.status),
+        ),
+    );
+
+    this.defineTool(
+      'verify_app_environment',
+      'Verify one exact application belongs to one exact project environment without list calls',
+      {
+        application_uuid: z.string().min(1),
+        project_uuid: z.string().min(1),
+        expected_environment: z.string().min(1),
+      },
+      async ({ application_uuid, project_uuid, expected_environment }) =>
+        wrap(() =>
+          this.client.verifyApplicationEnvironment(
+            application_uuid,
+            project_uuid,
+            expected_environment,
+          ),
         ),
     );
 

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -264,6 +264,16 @@ export interface Application {
   updated_at: string;
 }
 
+/**
+ * Minimal proof that one exact application belongs to one exact environment.
+ * Deliberately excludes embedded resources and configuration so callers do not
+ * need a project or environment enumeration to bind the two identities.
+ */
+export interface ApplicationEnvironmentVerification {
+  identity: string;
+  name: string;
+}
+
 export interface CreateApplicationPublicRequest {
   project_uuid: string;
   server_uuid: string;


### PR DESCRIPTION
Adds a read-only verify_app_environment tool for callers that already hold exact application, project, and environment anchors.\n\nThe implementation uses only GET /applications/{application_uuid} and GET /projects/{project_uuid}/{expected_environment}; it does not enumerate applications, projects, environments, or resources. Application UUID, project UUID when returned, environment name, and numeric environment identity are checked fail-closed. The response is limited to identity and name.\n\nAlso updates the tool annotation, contract snapshot and roster, tool-count manifests, README, CLAUDE guidance, and changelog.\n\nValidation:\n- npm run build\n- npm test -- --runInBand (661/661)\n- npm run lint (0 errors; 52 existing warnings)\n- npm run format:check\n- npm run check:chunk-drift (14/14)\n- npm --prefix evals run snapshots (4/4)\n- npm --prefix evals run typecheck\n- npm --prefix evals run lint\n- npm --prefix evals run format:check\n- git diff --check\n\nNo provider-backed integration test was run because this change is intentionally provider-free and read-only.