### PR TITLE
chore(deps): bump js-yaml override to ^4.3.1 (audit fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5115,9 +5115,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "flatted": "^3.4.2",
     "brace-expansion": "^5.0.6",
     "picomatch": "^4.0.4",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0"
   },
   "lint-staged": {


### PR DESCRIPTION
CI's \`npm audit --audit-level=high\` gate went red on main after js-yaml advisory GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, quadratic CPU in \`!!omap\` resolution) landed. js-yaml is a transitive dev dependency (markdownlint-cli2, ts-jest) pinned by our \`overrides\` at \`^4.2.0\`. This bumps the override to \`^4.3.1\`, the patched release.

Same failure currently blocks #346 (Dependabot) and #345; both go green after a rebase on this.

Verification:
- \`npm audit --audit-level=high\` exits 0 (one low-severity body-parser advisory remains, below the gate)
- \`npm test\` 655/655
- \`npm run lint\` 0 errors