### PR TITLE
fix: #336 field-test follow-ups — db collision merge, env get default, preview twins, exact-match resolution, find_issues signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`list_databases` no longer silently drops whole database types** (#336, item 1). Coolify keeps a per-type id sequence and `GET /databases` merges the per-type collections keyed on that id, so two types sharing ids shadow each other — verified live upstream: 2 standalone Postgres + 2 standalone Dragonfly, both pairs ids 1 and 2, returned only the Dragonflys. `/resources` reports every database correctly, so `listDatabases` now fetches both and merges the rows `/databases` dropped back in by uuid (every `standalone-*` resource type is a database). The merge is a no-op when `/databases` is complete, and if `/resources` fails the plain `/databases` result is returned unchanged. `get_infrastructure_overview` database counts and `find_issues` database coverage are repaired by the same merge, since both go through `listDatabases`.
+- **`environments get` now honours its own schema** (#336, item 2). The schema has always marked `name` optional, but the handler rejected with `Error: name required`. It now defaults to the sole environment when the project has exactly one; with several (or none) it explains what exists instead of a bare rejection.
+- **`diagnose_app` env-var counts no longer read as a bug** (#336, item 3). Coolify auto-creates a preview twin for every production application env var and the API returns both scopes merged, so the raw count doubles. The diagnostic now surfaces `is_preview` per variable plus `distinct_keys`, `production_count` and `preview_count` alongside the unchanged raw `count`. No row is ever deduped — deleting a twin destroys preview config.
+- **Exact matches win name resolution** (#336, item 4). `diagnose_app` resolved "api.example.com" to a multi-app disambiguation error whenever another app's FQDN contained it as a substring. An exact name or FQDN match (scheme and trailing slash ignored, each entry of a comma-separated `fqdn` compared) now wins outright before substring matching runs; same for `diagnose_server` names and IPs, where "10.0.0.5" is a substring of "10.0.0.50".
+
+### Added
+
+- **`find_issues` folds in signals it already had in hand** (#336, item 5). An app in `running:unknown` and an available proxy patch upgrade used to produce zero findings. Issues now carry a `severity` (`critical` | `warning`): resources running with unknown health warn (running container, no working healthcheck — a failure would go undetected), and servers with an available Traefik update warn with the version pair (`traefik_outdated_info` only exists on `GET /servers/{uuid}`, so each listed server is fetched individually; shape verified live against v4.3.7). The `unhealthy_*`/`unreachable_servers` summary counts keep their pre-existing critical-only meaning; warnings are counted separately in `summary.warnings`.
+
 ## [2.19.3] - 2026-08-06
 
 A security release, and the one that ends the leak class instead of patching another instance of it. Update from any earlier version.

--- a/evals/src/contract/__toolsnaps__/environments.json
+++ b/evals/src/contract/__toolsnaps__/environments.json
@@ -1,6 +1,6 @@
 {
   "name": "environments",
-  "description": "Manage environments: list/get/create/delete (get includes dragonfly/keydb/clickhouse DBs missing from API)",
+  "description": "Manage environments: list/get/create/delete (get includes dragonfly/keydb/clickhouse DBs missing from API; when the project has exactly one environment, get may omit name)",
   "annotations": {
     "destructiveHint": true
   },

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -957,6 +957,15 @@ describe('CoolifyClient', () => {
           type: 'standalone-dragonfly',
           status: 'running:healthy',
         },
+        // Defensive-filter arms: a row with no uuid and a row whose type is
+        // not a string must never be merged in, whatever /resources sends.
+        {
+          uuid: null,
+          name: 'row-without-uuid',
+          type: 'standalone-mysql',
+          status: 'running:healthy',
+        },
+        { uuid: 'weird-1', name: 'weird-type-row', type: 42, status: 'running:healthy' },
         {
           uuid: 'drg-2',
           name: 'dragonfly-two',
@@ -4054,7 +4063,8 @@ describe('CoolifyClient', () => {
           {
             ...mockApps[0],
             uuid: 'app-multi',
-            fqdn: 'https://tidylinker.com,https://www.tidylinker.com',
+            // Trailing comma leaves an empty entry, which must never match.
+            fqdn: 'https://tidylinker.com,https://www.tidylinker.com,',
           },
           { ...mockApps[1], uuid: 'app-other', fqdn: 'https://www.tidylinker.com.mirror.dev' },
         ];
@@ -4845,6 +4855,38 @@ describe('CoolifyClient', () => {
         expect(result.issues.find((i) => i.type === 'application')?.issue).toContain(
           'running but health unknown',
         );
+      });
+
+      it('should warn on databases with unknown health and non-patch proxy updates', async () => {
+        const unknownDb = {
+          ...mockDatabases[0],
+          uuid: 'db-3',
+          name: 'no-healthcheck-db',
+          status: 'running:unknown',
+        };
+        const statusServer = { ...mockServers[0], status: 'running' };
+        const minorOutdatedServer = {
+          ...statusServer,
+          traefik_outdated_info: { current: '3.6.8', latest: '3.7.8', type: 'minor_update' },
+        };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([statusServer]))
+          .mockResolvedValueOnce(mockResponse([mockApplications[0]]))
+          .mockResolvedValueOnce(mockResponse([unknownDb]))
+          .mockResolvedValueOnce(mockResponse([])) // /resources
+          .mockResolvedValueOnce(mockResponse([mockServices[0]]))
+          .mockResolvedValueOnce(mockResponse(minorOutdatedServer)); // GET /servers/server-1
+
+        const result = await client.findInfrastructureIssues();
+
+        expect(result.summary.warnings).toBe(2);
+        expect(result.summary.unhealthy_databases).toBe(0);
+        expect(result.issues.find((i) => i.type === 'database')?.issue).toContain(
+          'running but health unknown',
+        );
+        const proxyIssue = result.issues.find((i) => i.type === 'server');
+        expect(proxyIssue?.issue).toBe('Proxy (Traefik) update available: 3.6.8 → 3.7.8');
+        expect(proxyIssue?.status).toBe('running');
       });
 
       it('should handle partial failures and still report issues', async () => {

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -2783,17 +2783,25 @@ describe('CoolifyClient', () => {
   // Database endpoints - extended coverage
   // =========================================================================
   describe('databases extended', () => {
-    it('should list databases with pagination', async () => {
-      mockFetch
-        .mockResolvedValueOnce(mockResponse([mockDatabase]))
-        .mockResolvedValueOnce(mockResponse([])); // /resources — collision merge (#336)
+    it('should not merge off-page resources into a paginated database list', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([mockDatabase])).mockResolvedValueOnce(
+        mockResponse([
+          {
+            uuid: 'off-page-db',
+            name: 'off-page-database',
+            type: 'standalone-postgresql',
+            status: 'running:healthy',
+          },
+        ]),
+      );
 
-      await client.listDatabases({ page: 1, per_page: 10 });
+      const result = await client.listDatabases({ page: 1, per_page: 10 });
 
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:3000/api/v1/databases?page=1&per_page=10',
         expect.any(Object),
       );
+      expect(result).toEqual([mockDatabase]);
     });
 
     it('should list databases with summary', async () => {

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -921,7 +921,105 @@ describe('CoolifyClient', () => {
   describe('databases', () => {
     it('should list databases', async () => {
       const mockDbs = [{ id: 1, uuid: 'db-uuid', name: 'test-db' }];
-      mockFetch.mockResolvedValueOnce(mockResponse(mockDbs));
+      mockFetch
+        .mockResolvedValueOnce(mockResponse(mockDbs))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — collision merge (#336)
+
+      const result = await client.listDatabases();
+
+      expect(result).toEqual(mockDbs);
+    });
+
+    it('should merge databases /databases dropped on a per-type id collision from /resources', async () => {
+      // Coolify keeps a per-type id sequence and GET /databases merges the
+      // per-type collections keyed on id — 2 Postgres + 2 Dragonfly with ids
+      // 1 and 2 returns only the Dragonflys (#336). /resources sees all four.
+      const shadowed = [
+        { id: 1, uuid: 'drg-1', name: 'dragonfly-one', status: 'running:healthy' },
+        { id: 2, uuid: 'drg-2', name: 'dragonfly-two', status: 'running:healthy' },
+      ];
+      const resources = [
+        {
+          uuid: 'pg-1',
+          name: 'postgres-one',
+          type: 'standalone-postgresql',
+          status: 'running:healthy',
+        },
+        {
+          uuid: 'pg-2',
+          name: 'postgres-two',
+          type: 'standalone-postgresql',
+          status: 'running:healthy',
+        },
+        {
+          uuid: 'drg-1',
+          name: 'dragonfly-one',
+          type: 'standalone-dragonfly',
+          status: 'running:healthy',
+        },
+        {
+          uuid: 'drg-2',
+          name: 'dragonfly-two',
+          type: 'standalone-dragonfly',
+          status: 'running:healthy',
+        },
+        { uuid: 'app-1', name: 'not-a-db', type: 'application', status: 'running:healthy' },
+        { uuid: 'svc-1', name: 'also-not-a-db', type: 'service', status: 'running:healthy' },
+      ];
+      mockFetch
+        .mockResolvedValueOnce(mockResponse(shadowed))
+        .mockResolvedValueOnce(mockResponse(resources));
+
+      const result = (await client.listDatabases()) as Array<{ uuid: string }>;
+
+      expect(result.map((db) => db.uuid)).toEqual(['drg-1', 'drg-2', 'pg-1', 'pg-2']);
+    });
+
+    it('should apply the collision merge to summary projections too', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse([
+            {
+              id: 1,
+              uuid: 'drg-1',
+              name: 'dragonfly-one',
+              type: 'standalone-dragonfly',
+              status: 'running:healthy',
+              is_public: false,
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          mockResponse([
+            {
+              uuid: 'drg-1',
+              name: 'dragonfly-one',
+              type: 'standalone-dragonfly',
+              status: 'running:healthy',
+            },
+            {
+              uuid: 'pg-1',
+              name: 'postgres-one',
+              type: 'standalone-postgresql',
+              status: 'running:healthy',
+            },
+          ]),
+        );
+
+      const result = (await client.listDatabases({ summary: true })) as Array<{
+        uuid: string;
+        type: string;
+      }>;
+
+      expect(result.map((db) => db.uuid)).toEqual(['drg-1', 'pg-1']);
+      expect(result[1].type).toBe('standalone-postgresql');
+    });
+
+    it('should return /databases unchanged when /resources fails', async () => {
+      const mockDbs = [{ id: 1, uuid: 'db-uuid', name: 'test-db' }];
+      mockFetch
+        .mockResolvedValueOnce(mockResponse(mockDbs))
+        .mockRejectedValueOnce(new Error('resources unavailable'));
 
       const result = await client.listDatabases();
 
@@ -1486,7 +1584,8 @@ describe('CoolifyClient', () => {
 
       mockFetch
         .mockResolvedValueOnce(mockResponse(mockEnvironment))
-        .mockResolvedValueOnce(mockResponse(mockDbSummaries));
+        .mockResolvedValueOnce(mockResponse(mockDbSummaries))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — listDatabases collision merge (#336)
 
       const result = await client.getProjectEnvironmentWithDatabases('proj-uuid', 'production');
 
@@ -1510,7 +1609,8 @@ describe('CoolifyClient', () => {
 
       mockFetch
         .mockResolvedValueOnce(mockResponse(mockEnvironment))
-        .mockResolvedValueOnce(mockResponse(mockDbSummaries));
+        .mockResolvedValueOnce(mockResponse(mockDbSummaries))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — listDatabases collision merge (#336)
 
       const result = await client.getProjectEnvironmentWithDatabases('proj-uuid', 'production');
 
@@ -1532,7 +1632,8 @@ describe('CoolifyClient', () => {
 
       mockFetch
         .mockResolvedValueOnce(mockResponse(mockEnvironment))
-        .mockResolvedValueOnce(mockResponse(mockDbSummaries));
+        .mockResolvedValueOnce(mockResponse(mockDbSummaries))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — listDatabases collision merge (#336)
 
       const result = await client.getProjectEnvironmentWithDatabases('proj-uuid', 'production');
 
@@ -1554,7 +1655,8 @@ describe('CoolifyClient', () => {
 
       mockFetch
         .mockResolvedValueOnce(mockResponse(mockEnvironment))
-        .mockResolvedValueOnce(mockResponse(mockDbSummaries));
+        .mockResolvedValueOnce(mockResponse(mockDbSummaries))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — listDatabases collision merge (#336)
 
       const result = await client.getProjectEnvironmentWithDatabases('proj-uuid', 'production');
 
@@ -2673,7 +2775,9 @@ describe('CoolifyClient', () => {
   // =========================================================================
   describe('databases extended', () => {
     it('should list databases with pagination', async () => {
-      mockFetch.mockResolvedValueOnce(mockResponse([mockDatabase]));
+      mockFetch
+        .mockResolvedValueOnce(mockResponse([mockDatabase]))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — collision merge (#336)
 
       await client.listDatabases({ page: 1, per_page: 10 });
 
@@ -2684,7 +2788,9 @@ describe('CoolifyClient', () => {
     });
 
     it('should list databases with summary', async () => {
-      mockFetch.mockResolvedValueOnce(mockResponse([mockDatabase]));
+      mockFetch
+        .mockResolvedValueOnce(mockResponse([mockDatabase]))
+        .mockResolvedValueOnce(mockResponse([])); // /resources — collision merge (#336)
 
       const result = await client.listDatabases({ summary: true });
 
@@ -3923,6 +4029,65 @@ describe('CoolifyClient', () => {
           'Multiple applications match',
         );
       });
+
+      it('should let an exact FQDN match win over substring multi-matches (#336)', async () => {
+        // Before the exact pass, "api.example.com" hit both apps as a
+        // substring and errored with a disambiguation prompt.
+        const apps = [
+          { ...mockApps[1], uuid: 'app-prod', fqdn: 'https://api.example.com' },
+          {
+            ...mockApps[1],
+            uuid: 'app-staging',
+            name: 'my-api-staging',
+            fqdn: 'https://api.example.com.staging.example.dev',
+          },
+        ];
+        mockFetch.mockResolvedValueOnce(mockResponse(apps));
+
+        const result = await client.resolveApplicationUuid('api.example.com');
+
+        expect(result).toBe('app-prod');
+      });
+
+      it('should match an exact FQDN entry inside a comma-separated fqdn list', async () => {
+        const apps = [
+          {
+            ...mockApps[0],
+            uuid: 'app-multi',
+            fqdn: 'https://tidylinker.com,https://www.tidylinker.com',
+          },
+          { ...mockApps[1], uuid: 'app-other', fqdn: 'https://www.tidylinker.com.mirror.dev' },
+        ];
+        mockFetch.mockResolvedValueOnce(mockResponse(apps));
+
+        const result = await client.resolveApplicationUuid('www.tidylinker.com');
+
+        expect(result).toBe('app-multi');
+      });
+
+      it('should let an exact name match win over substring multi-matches', async () => {
+        const apps = [
+          { ...mockApps[0], uuid: 'app-api', name: 'api', fqdn: null },
+          { ...mockApps[1], uuid: 'app-api-worker', name: 'api-worker', fqdn: null },
+        ];
+        mockFetch.mockResolvedValueOnce(mockResponse(apps));
+
+        const result = await client.resolveApplicationUuid('api');
+
+        expect(result).toBe('app-api');
+      });
+
+      it('should still disambiguate when several apps match exactly', async () => {
+        const apps = [
+          { ...mockApps[0], uuid: 'app-1', name: 'api', fqdn: null },
+          { ...mockApps[1], uuid: 'app-2', name: 'API', fqdn: null },
+        ];
+        mockFetch.mockResolvedValueOnce(mockResponse(apps));
+
+        await expect(client.resolveApplicationUuid('api')).rejects.toThrow(
+          'Multiple applications match',
+        );
+      });
     });
 
     describe('resolveServerUuid', () => {
@@ -4005,6 +4170,32 @@ describe('CoolifyClient', () => {
         await expect(client.resolveServerUuid('prod-server')).rejects.toThrow(
           'Multiple servers match',
         );
+      });
+
+      it('should let an exact IP match win over substring multi-matches (#336)', async () => {
+        // "10.0.0.5" is a substring of "10.0.0.50" — without the exact pass
+        // this errored with a disambiguation prompt.
+        const servers = [
+          { ...mockServers[1], uuid: 'server-a', ip: '10.0.0.5' },
+          { ...mockServers[1], uuid: 'server-b', ip: '10.0.0.50' },
+        ];
+        mockFetch.mockResolvedValueOnce(mockResponse(servers));
+
+        const result = await client.resolveServerUuid('10.0.0.5');
+
+        expect(result).toBe('server-a');
+      });
+
+      it('should let an exact name match win over substring multi-matches', async () => {
+        const servers = [
+          { ...mockServers[0], uuid: 'server-a', name: 'prod' },
+          { ...mockServers[1], uuid: 'server-b', name: 'prod-db' },
+        ];
+        mockFetch.mockResolvedValueOnce(mockResponse(servers));
+
+        const result = await client.resolveServerUuid('prod');
+
+        expect(result).toBe('server-a');
       });
     });
   });
@@ -4098,9 +4289,12 @@ describe('CoolifyClient', () => {
         expect(result.health.status).toBe('healthy');
         expect(result.logs).toBe(mockLogs);
         expect(result.environment_variables.count).toBe(2);
+        expect(result.environment_variables.distinct_keys).toBe(2);
+        expect(result.environment_variables.production_count).toBe(2);
+        expect(result.environment_variables.preview_count).toBe(0);
         expect(result.environment_variables.variables).toEqual([
-          { key: 'DATABASE_URL', is_buildtime: false, is_runtime: true },
-          { key: 'NODE_ENV', is_buildtime: true, is_runtime: true },
+          { key: 'DATABASE_URL', is_buildtime: false, is_runtime: true, is_preview: false },
+          { key: 'NODE_ENV', is_buildtime: true, is_runtime: true, is_preview: false },
         ]);
         expect(result.recent_deployments).toHaveLength(2);
         expect(result.errors).toBeUndefined();
@@ -4121,8 +4315,34 @@ describe('CoolifyClient', () => {
         const result = await client.diagnoseApplication(testAppUuid);
 
         expect(result.environment_variables.variables).toEqual([
-          { key: 'LEGACY_VAR', is_buildtime: false, is_runtime: true },
+          { key: 'LEGACY_VAR', is_buildtime: false, is_runtime: true, is_preview: false },
         ]);
+      });
+
+      it('should separate preview twins from production vars instead of a doubled flat count', async () => {
+        // Coolify auto-creates a preview twin for every production env var and
+        // GET /envs returns both scopes merged (#336). The raw count stays
+        // honest, distinct_keys/preview_count make the doubling readable, and
+        // no row is deduped away — deleting a twin destroys preview config.
+        const twinnedEnvVars = [
+          { id: 1, uuid: 'env-1', key: 'DATABASE_URL', value: 'x', is_preview: false },
+          { id: 2, uuid: 'env-2', key: 'DATABASE_URL', value: 'x', is_preview: true },
+          { id: 3, uuid: 'env-3', key: 'NODE_ENV', value: 'production', is_preview: false },
+          { id: 4, uuid: 'env-4', key: 'NODE_ENV', value: 'production', is_preview: true },
+        ];
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(mockApp))
+          .mockResolvedValueOnce(mockResponse(mockLogs))
+          .mockResolvedValueOnce(mockResponse(twinnedEnvVars))
+          .mockResolvedValueOnce(mockResponse({ count: 0, deployments: [] }));
+
+        const result = await client.diagnoseApplication(testAppUuid);
+
+        expect(result.environment_variables.count).toBe(4);
+        expect(result.environment_variables.distinct_keys).toBe(2);
+        expect(result.environment_variables.production_count).toBe(2);
+        expect(result.environment_variables.preview_count).toBe(2);
+        expect(result.environment_variables.variables.filter((v) => v.is_preview)).toHaveLength(2);
       });
 
       it('should detect unhealthy application status', async () => {
@@ -4534,7 +4754,10 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(mockServers))
           .mockResolvedValueOnce(mockResponse(mockApplications))
           .mockResolvedValueOnce(mockResponse(mockDatabases))
-          .mockResolvedValueOnce(mockResponse(mockServices));
+          .mockResolvedValueOnce(mockResponse([])) // /resources — listDatabases collision merge (#336)
+          .mockResolvedValueOnce(mockResponse(mockServices))
+          .mockResolvedValueOnce(mockResponse(mockServers[0])) // GET /servers/server-1 (proxy check)
+          .mockResolvedValueOnce(mockResponse(mockServers[1])); // GET /servers/server-2
 
         const result = await client.findInfrastructureIssues();
 
@@ -4543,7 +4766,9 @@ describe('CoolifyClient', () => {
         expect(result.summary.unhealthy_applications).toBe(1);
         expect(result.summary.unhealthy_databases).toBe(1);
         expect(result.summary.unhealthy_services).toBe(1);
+        expect(result.summary.warnings).toBe(0);
         expect(result.issues).toHaveLength(4);
+        expect(result.issues.every((i) => i.severity === 'critical')).toBe(true);
         expect(result.errors).toBeUndefined();
       });
 
@@ -4557,12 +4782,69 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(healthyServers))
           .mockResolvedValueOnce(mockResponse(healthyApps))
           .mockResolvedValueOnce(mockResponse(healthyDbs))
-          .mockResolvedValueOnce(mockResponse(healthySvcs));
+          .mockResolvedValueOnce(mockResponse([])) // /resources
+          .mockResolvedValueOnce(mockResponse(healthySvcs))
+          .mockResolvedValueOnce(mockResponse(mockServers[0])); // GET /servers/server-1
 
         const result = await client.findInfrastructureIssues();
 
         expect(result.summary.total_issues).toBe(0);
+        expect(result.summary.warnings).toBe(0);
         expect(result.issues).toHaveLength(0);
+      });
+
+      it('should surface running:unknown health and available proxy updates as warnings', async () => {
+        // The field test that raised #336: an app in running:unknown and a
+        // server with an available Traefik patch produced zero findings.
+        const unknownApp = {
+          id: 3,
+          uuid: 'app-3',
+          name: 'no-healthcheck-app',
+          status: 'running:unknown',
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        };
+        const unknownSvc = {
+          id: 3,
+          uuid: 'svc-3',
+          name: 'no-healthcheck-service',
+          type: 'n8n',
+          status: 'running:unknown',
+          created_at: '2024-01-01',
+          updated_at: '2024-01-01',
+        };
+        const outdatedProxyServer = {
+          ...mockServers[0],
+          // Shape verified live against Coolify v4.3.7 (GET /servers/{uuid}).
+          traefik_outdated_info: {
+            current: '3.6.8',
+            latest: '3.6.23',
+            type: 'patch_update',
+            checked_at: '2026-08-16T00:00:55+00:00',
+          },
+        };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([mockServers[0]]))
+          .mockResolvedValueOnce(mockResponse([unknownApp]))
+          .mockResolvedValueOnce(mockResponse([mockDatabases[0]]))
+          .mockResolvedValueOnce(mockResponse([])) // /resources
+          .mockResolvedValueOnce(mockResponse([unknownSvc]))
+          .mockResolvedValueOnce(mockResponse(outdatedProxyServer)); // GET /servers/server-1
+
+        const result = await client.findInfrastructureIssues();
+
+        expect(result.summary.total_issues).toBe(3);
+        expect(result.summary.warnings).toBe(3);
+        // Warnings must not inflate the critical counts.
+        expect(result.summary.unhealthy_applications).toBe(0);
+        expect(result.summary.unhealthy_services).toBe(0);
+        expect(result.summary.unreachable_servers).toBe(0);
+        expect(result.issues.every((i) => i.severity === 'warning')).toBe(true);
+        const proxyIssue = result.issues.find((i) => i.type === 'server');
+        expect(proxyIssue?.issue).toBe('Proxy (Traefik) patch update available: 3.6.8 → 3.6.23');
+        expect(result.issues.find((i) => i.type === 'application')?.issue).toContain(
+          'running but health unknown',
+        );
       });
 
       it('should handle partial failures and still report issues', async () => {
@@ -4570,7 +4852,10 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(mockServers))
           .mockRejectedValueOnce(new Error('Applications unavailable'))
           .mockResolvedValueOnce(mockResponse(mockDatabases))
-          .mockResolvedValueOnce(mockResponse(mockServices));
+          .mockResolvedValueOnce(mockResponse([])) // /resources
+          .mockResolvedValueOnce(mockResponse(mockServices))
+          .mockResolvedValueOnce(mockResponse(mockServers[0])) // GET /servers/server-1
+          .mockResolvedValueOnce(mockResponse(mockServers[1])); // GET /servers/server-2
 
         const result = await client.findInfrastructureIssues();
 
@@ -4579,6 +4864,21 @@ describe('CoolifyClient', () => {
         expect(result.summary.unhealthy_services).toBe(1);
         expect(result.summary.unhealthy_applications).toBe(0); // Failed to fetch
         expect(result.errors).toContain('applications: Applications unavailable');
+      });
+
+      it('should keep scanning when a per-server detail fetch fails', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([mockServers[0]]))
+          .mockResolvedValueOnce(mockResponse([mockApplications[0]]))
+          .mockResolvedValueOnce(mockResponse([mockDatabases[0]]))
+          .mockResolvedValueOnce(mockResponse([])) // /resources
+          .mockResolvedValueOnce(mockResponse([mockServices[0]]))
+          .mockRejectedValueOnce(new Error('server details unavailable')); // GET /servers/server-1
+
+        const result = await client.findInfrastructureIssues();
+
+        expect(result.summary.total_issues).toBe(0);
+        expect(result.errors).toContain('server healthy-server: server details unavailable');
       });
     });
   });
@@ -4650,6 +4950,7 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(project))
           .mockResolvedValueOnce(mockResponse(mockProjectApps))
           .mockResolvedValueOnce(mockResponse(mockProjectDbs))
+          .mockResolvedValueOnce(mockResponse([])) // /resources — listDatabases collision merge (#336)
           .mockResolvedValueOnce(mockResponse(mockProjectSvcs));
       };
 

--- a/src/__tests__/integration/issue-336.integration.test.ts
+++ b/src/__tests__/integration/issue-336.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests for the #336 field-test follow-ups.
+ *
+ * These verify against a real Coolify instance that:
+ * 1. `listDatabases` reports every database `/resources` knows about — the
+ *    per-type id collision upstream made `GET /databases` silently drop whole
+ *    types (2 Postgres + 2 Dragonfly with ids 1,2 returned only the Dragonflys).
+ * 2. `findInfrastructureIssues` severity accounting is internally consistent,
+ *    and warnings (unknown health, available proxy updates) never inflate the
+ *    critical counts.
+ * 3. `diagnoseApplication` env-var accounting is internally consistent —
+ *    preview twins are surfaced, not deduped.
+ *
+ * Prerequisites:
+ * - COOLIFY_URL and COOLIFY_TOKEN environment variables set (from .env)
+ *
+ * Run with: npm run test:integration
+ */
+
+import { CoolifyClient } from '../../lib/coolify-client.js';
+import type { ApplicationSummary } from '../../lib/coolify-client.js';
+import type { ResourceListItem } from '../../types/coolify.js';
+import { COOLIFY_URL, COOLIFY_TOKEN, warnIfSkipped } from './helpers.js';
+
+warnIfSkipped('issue-336.integration');
+
+const shouldRun = COOLIFY_URL && COOLIFY_TOKEN;
+const describeFn = shouldRun ? describe : describe.skip;
+
+describeFn('#336 follow-ups (live)', () => {
+  let client: CoolifyClient;
+
+  beforeAll(() => {
+    client = new CoolifyClient({
+      baseUrl: COOLIFY_URL as string,
+      accessToken: COOLIFY_TOKEN as string,
+    });
+  });
+
+  describe('list_databases collision merge', () => {
+    it('reports every standalone-* resource /resources knows about', async () => {
+      const [databases, resources] = await Promise.all([
+        client.listDatabases({ summary: true }),
+        client.listResources() as Promise<ResourceListItem[]>,
+      ]);
+
+      const resourceDbUuids = resources
+        .filter((r) => typeof r.type === 'string' && r.type.startsWith('standalone-'))
+        .map((r) => r.uuid)
+        .sort();
+      const listedUuids = new Set(databases.map((db) => db.uuid));
+
+      const dropped = resourceDbUuids.filter((uuid) => !listedUuids.has(uuid));
+      expect(dropped).toEqual([]);
+    });
+
+    it('does not duplicate a database the plain endpoint already returned', async () => {
+      const databases = await client.listDatabases({ summary: true });
+      const uuids = databases.map((db) => db.uuid);
+      expect(new Set(uuids).size).toBe(uuids.length);
+    });
+
+    it('every merged row carries a type, so overview counts stay typed', async () => {
+      const databases = await client.listDatabases({ summary: true });
+      for (const db of databases) {
+        expect(typeof db.type).toBe('string');
+        expect(db.type.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('find_issues severity accounting', () => {
+    it('classifies every issue and keeps critical counts free of warnings', async () => {
+      const report = await client.findInfrastructureIssues();
+
+      for (const issue of report.issues) {
+        expect(['critical', 'warning']).toContain(issue.severity);
+      }
+
+      const critical = report.issues.filter((i) => i.severity === 'critical');
+      const warnings = report.issues.filter((i) => i.severity === 'warning');
+      expect(report.summary.warnings).toBe(warnings.length);
+      expect(report.summary.total_issues).toBe(report.issues.length);
+      expect(report.summary.unhealthy_applications).toBe(
+        critical.filter((i) => i.type === 'application').length,
+      );
+      expect(report.summary.unhealthy_databases).toBe(
+        critical.filter((i) => i.type === 'database').length,
+      );
+      expect(report.summary.unhealthy_services).toBe(
+        critical.filter((i) => i.type === 'service').length,
+      );
+      // Proxy-update warnings are type 'server' but must not count as unreachable.
+      expect(report.summary.unreachable_servers).toBe(
+        critical.filter((i) => i.type === 'server').length,
+      );
+    });
+
+    it('flags resources running with unknown health when the estate has any', async () => {
+      const [report, resources] = await Promise.all([
+        client.findInfrastructureIssues(),
+        client.listResources() as Promise<ResourceListItem[]>,
+      ]);
+
+      const unknown = resources.filter(
+        (r) => r.status?.startsWith('running') && r.status?.endsWith(':unknown'),
+      );
+      const unknownWarnings = report.issues.filter(
+        (i) => i.severity === 'warning' && i.issue.includes('health unknown'),
+      );
+      // Every running:unknown resource find_issues can see must produce a
+      // warning. (>= because /resources also lists service sub-containers.)
+      if (unknown.length === 0) {
+        expect(unknownWarnings).toEqual([]);
+      } else {
+        expect(unknownWarnings.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('diagnose_app env-var accounting', () => {
+    it('splits preview twins out without deduping the raw rows', async () => {
+      const apps = (await client.listApplications({ summary: true })) as ApplicationSummary[];
+      if (apps.length === 0) {
+        console.warn(
+          '[issue-336.integration] no applications on this estate — nothing to diagnose',
+        );
+        return;
+      }
+
+      const diag = await client.diagnoseApplication(apps[0].uuid);
+      const env = diag.environment_variables;
+
+      expect(env.count).toBe(env.variables.length);
+      expect(env.production_count + env.preview_count).toBe(env.count);
+      expect(env.distinct_keys).toBeLessThanOrEqual(env.count);
+      expect(env.distinct_keys).toBe(new Set(env.variables.map((v) => v.key)).size);
+      for (const variable of env.variables) {
+        expect(typeof variable.is_preview).toBe('boolean');
+      }
+    });
+  });
+});

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -275,6 +275,80 @@ describe('CoolifyMcpServer v2', () => {
     });
   });
 
+  describe('environments tool handler', () => {
+    // The schema has always marked `name` optional on get; the handler used to
+    // reject anyway. It now defaults to the sole environment (#336).
+    const callEnvironments = async (
+      srv: CoolifyMcpServer,
+      args: Record<string, unknown>,
+    ): Promise<string> => {
+      const tool = (
+        srv as unknown as {
+          _registeredTools: Record<
+            string,
+            {
+              handler: (
+                args: Record<string, unknown>,
+                extra: unknown,
+              ) => Promise<{ content: Array<{ text: string }> }>;
+            }
+          >;
+        }
+      )._registeredTools['environments'];
+      const result = await tool.handler(args, {});
+      return result.content.map((c) => c.text).join('\n');
+    };
+
+    it('get with an explicit name skips the environment listing', async () => {
+      const list = jest.spyOn(server['client'], 'listProjectEnvironments');
+      const get = jest
+        .spyOn(server['client'], 'getProjectEnvironmentWithDatabases')
+        .mockResolvedValue({ id: 1, uuid: 'env-1', name: 'production' } as never);
+
+      await callEnvironments(server, { action: 'get', project_uuid: 'proj-1', name: 'production' });
+
+      expect(get).toHaveBeenCalledWith('proj-1', 'production');
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('get without a name defaults to the sole environment', async () => {
+      jest
+        .spyOn(server['client'], 'listProjectEnvironments')
+        .mockResolvedValue([{ id: 1, uuid: 'env-1', name: 'production' }] as never);
+      const get = jest
+        .spyOn(server['client'], 'getProjectEnvironmentWithDatabases')
+        .mockResolvedValue({ id: 1, uuid: 'env-1', name: 'production' } as never);
+
+      const text = await callEnvironments(server, { action: 'get', project_uuid: 'proj-1' });
+
+      expect(get).toHaveBeenCalledWith('proj-1', 'production');
+      expect(text).toContain('production');
+    });
+
+    it('get without a name still requires one when several environments exist', async () => {
+      jest.spyOn(server['client'], 'listProjectEnvironments').mockResolvedValue([
+        { id: 1, uuid: 'env-1', name: 'production' },
+        { id: 2, uuid: 'env-2', name: 'staging' },
+      ] as never);
+      const get = jest.spyOn(server['client'], 'getProjectEnvironmentWithDatabases');
+
+      const text = await callEnvironments(server, { action: 'get', project_uuid: 'proj-1' });
+
+      expect(text).toContain(
+        'Error: name required — project has 2 environments: production, staging',
+      );
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    it('get without a name reports an environment-less project instead of a bare rejection', async () => {
+      jest.spyOn(server['client'], 'listProjectEnvironments').mockResolvedValue([] as never);
+
+      const text = await callEnvironments(server, { action: 'get', project_uuid: 'proj-1' });
+
+      expect(text).toContain('Error: Project proj-1 has no environments');
+    });
+  });
+
   describe('env_vars tool handler', () => {
     // Reach the SDK-registered handler so the is_buildtime / is_runtime
     // passthrough lines are actually executed (not just type-checked).

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -426,6 +426,15 @@ function toDatabaseSummary(db: Database): DatabaseSummary {
   };
 }
 
+/**
+ * "running:unknown" — the container is up but Coolify has no health signal for
+ * it, usually a missing or broken healthcheck. Not an outage, but find_issues
+ * previously ignored it entirely (#336).
+ */
+function isRunningWithUnknownHealth(status: string): boolean {
+  return status.startsWith('running') && status.endsWith(':unknown');
+}
+
 function toServiceSummary(svc: Service): ServiceSummary {
   return {
     uuid: svc.uuid,
@@ -1394,12 +1403,48 @@ export class CoolifyClient {
   // Database endpoints
   // ===========================================================================
 
+  /**
+   * List databases, augmented from `/resources`.
+   *
+   * Coolify keeps a per-type id sequence and `GET /databases` merges the
+   * per-type collections keyed on that id, so two database types sharing ids
+   * silently shadow each other (verified live: 2 Postgres + 2 Dragonfly, both
+   * pairs ids 1 and 2, returns only the Dragonflys). `/resources` reports every
+   * database correctly, so rows it knows about that `/databases` dropped are
+   * merged back in by uuid. When `/databases` is complete the merge is a no-op;
+   * if `/resources` fails the plain `/databases` result is returned unchanged.
+   * @see https://github.com/StuMason/coolify-mcp/issues/336
+   */
   async listDatabases(options?: ListOptions): Promise<Database[] | DatabaseSummary[]> {
     const query = this.buildQueryString({
       page: options?.page,
       per_page: options?.per_page,
     });
-    const dbs = await this.request<Database[]>(`/databases${query}`);
+    const [dbsResult, resourcesResult] = await Promise.allSettled([
+      this.request<Database[]>(`/databases${query}`),
+      this.request<ResourceListItemFull[]>('/resources'),
+    ]);
+    if (dbsResult.status === 'rejected') throw dbsResult.reason;
+    let dbs = dbsResult.value;
+    if (
+      Array.isArray(dbs) &&
+      resourcesResult.status === 'fulfilled' &&
+      Array.isArray(resourcesResult.value)
+    ) {
+      const seen = new Set(dbs.map((db) => db.uuid));
+      // Every standalone-* resource type is a database; applications and
+      // services carry their own type strings.
+      const dropped = resourcesResult.value.filter(
+        (r) =>
+          typeof r.type === 'string' &&
+          r.type.startsWith('standalone-') &&
+          r.uuid &&
+          !seen.has(r.uuid),
+      );
+      if (dropped.length > 0) {
+        dbs = [...dbs, ...(dropped as unknown as Database[])];
+      }
+    }
     return options?.summary && Array.isArray(dbs) ? dbs.map(toDatabaseSummary) : dbs;
   }
 
@@ -2341,7 +2386,23 @@ export class CoolifyClient {
   }
 
   /**
+   * Normalize a name/FQDN candidate for exact comparison: lowercase, trimmed,
+   * scheme and trailing slashes stripped. "https://app.example.com/" and
+   * "app.example.com" are the same address to a human asking about it.
+   */
+  private static normalizeHostLike(value: string): string {
+    return value
+      .toLowerCase()
+      .trim()
+      .replace(/^https?:\/\//, '')
+      .replace(/\/+$/, '');
+  }
+
+  /**
    * Find an application by UUID, name, or domain (FQDN).
+   * An exact name or FQDN match wins outright; substring matching only runs
+   * when nothing matches exactly, so "api.example.com" resolves even when
+   * "api.example.com.staging" also exists (#336).
    * Returns the UUID if found, throws if not found or multiple matches.
    */
   async resolveApplicationUuid(query: string): Promise<string> {
@@ -2353,12 +2414,29 @@ export class CoolifyClient {
     // Otherwise, search by name or domain
     const apps = (await this.listApplications()) as Application[];
     const queryLower = query.toLowerCase();
+    const queryHost = CoolifyClient.normalizeHostLike(query);
 
-    const matches = apps.filter((app) => {
-      const nameMatch = app.name?.toLowerCase().includes(queryLower);
-      const fqdnMatch = app.fqdn?.toLowerCase().includes(queryLower);
-      return nameMatch || fqdnMatch;
+    // Exact pass first. `fqdn` is a comma-separated list, so compare each entry.
+    const exactMatches = apps.filter((app) => {
+      if (app.name?.toLowerCase() === queryLower) return true;
+      return (app.fqdn || '')
+        .split(',')
+        .some(
+          (entry) => entry.trim() !== '' && CoolifyClient.normalizeHostLike(entry) === queryHost,
+        );
     });
+    if (exactMatches.length === 1) {
+      return exactMatches[0].uuid;
+    }
+
+    const matches =
+      exactMatches.length > 1
+        ? exactMatches
+        : apps.filter((app) => {
+            const nameMatch = app.name?.toLowerCase().includes(queryLower);
+            const fqdnMatch = app.fqdn?.toLowerCase().includes(queryLower);
+            return nameMatch || fqdnMatch;
+          });
 
     if (matches.length === 0) {
       throw new Error(`No application found matching "${query}"`);
@@ -2387,11 +2465,24 @@ export class CoolifyClient {
     const servers = (await this.listServers()) as Server[];
     const queryLower = query.toLowerCase();
 
-    const matches = servers.filter((server) => {
-      const nameMatch = server.name?.toLowerCase().includes(queryLower);
-      const ipMatch = server.ip?.toLowerCase().includes(queryLower);
-      return nameMatch || ipMatch;
-    });
+    // Exact pass first, same rationale as resolveApplicationUuid — and IPs are
+    // prefixes of each other constantly ("10.0.0.1" is inside "10.0.0.11").
+    const exactMatches = servers.filter(
+      (server) =>
+        server.name?.toLowerCase() === queryLower || server.ip?.toLowerCase() === queryLower,
+    );
+    if (exactMatches.length === 1) {
+      return exactMatches[0].uuid;
+    }
+
+    const matches =
+      exactMatches.length > 1
+        ? exactMatches
+        : servers.filter((server) => {
+            const nameMatch = server.name?.toLowerCase().includes(queryLower);
+            const ipMatch = server.ip?.toLowerCase().includes(queryLower);
+            return nameMatch || ipMatch;
+          });
 
     if (matches.length === 0) {
       throw new Error(`No server found matching "${query}"`);
@@ -2426,7 +2517,13 @@ export class CoolifyClient {
         application: null,
         health: { status: 'unknown', issues: [] },
         logs: null,
-        environment_variables: { count: 0, variables: [] },
+        environment_variables: {
+          count: 0,
+          distinct_keys: 0,
+          production_count: 0,
+          preview_count: 0,
+          variables: [],
+        },
         recent_deployments: [],
         errors: [msg],
       };
@@ -2521,11 +2618,16 @@ export class CoolifyClient {
       },
       logs: typeof logs === 'string' ? logs : null,
       environment_variables: {
-        count: envVars?.length || 0,
+        count: (envVars || []).length,
+        // Preview twins make the raw count read double (#336) — see the type.
+        distinct_keys: new Set((envVars || []).map((v) => v.key)).size,
+        production_count: (envVars || []).filter((v) => v.is_preview !== true).length,
+        preview_count: (envVars || []).filter((v) => v.is_preview === true).length,
         variables: (envVars || []).map((v) => ({
           key: v.key,
           is_buildtime: v.is_buildtime ?? false,
           is_runtime: v.is_runtime ?? true,
+          is_preview: v.is_preview ?? false,
         })),
       },
       recent_deployments: (deployments || []).slice(0, 5).map((d) => ({
@@ -2647,7 +2749,10 @@ export class CoolifyClient {
 
   /**
    * Scan infrastructure for common issues.
-   * Finds: unreachable servers, unhealthy apps, exited databases, stopped services.
+   * Critical: unreachable servers, unhealthy apps, exited databases, stopped
+   * services. Warnings (#336): resources running with unknown health, and
+   * servers with an available proxy update (`traefik_outdated_info`, only on
+   * GET /servers/{uuid}, so each listed server is fetched individually).
    */
   async findInfrastructureIssues(): Promise<InfrastructureIssuesReport> {
     const results = await Promise.allSettled([
@@ -2682,9 +2787,32 @@ export class CoolifyClient {
             name: server.name,
             issue: 'Server is not reachable',
             status: server.status || 'unreachable',
+            severity: 'critical',
           });
         }
       }
+
+      // traefik_outdated_info only exists on the single-server endpoint.
+      const details = await Promise.allSettled(servers.map((s) => this.getServer(s.uuid)));
+      details.forEach((result, i) => {
+        if (result.status === 'rejected') {
+          const msg =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          errors.push(`server ${servers[i].name}: ${msg}`);
+          return;
+        }
+        const info = result.value.traefik_outdated_info;
+        if (info?.latest && info.current) {
+          issues.push({
+            type: 'server',
+            uuid: servers[i].uuid,
+            name: servers[i].name,
+            issue: `Proxy (Traefik) ${info.type === 'patch_update' ? 'patch update' : 'update'} available: ${info.current} → ${info.latest}`,
+            status: servers[i].status || 'running',
+            severity: 'warning',
+          });
+        }
+      });
     }
 
     // Check applications for unhealthy status
@@ -2703,6 +2831,16 @@ export class CoolifyClient {
             name: app.name,
             issue: `Application status: ${status}`,
             status,
+            severity: 'critical',
+          });
+        } else if (isRunningWithUnknownHealth(status)) {
+          issues.push({
+            type: 'application',
+            uuid: app.uuid,
+            name: app.name,
+            issue: `Application running but health unknown (${status}) — no working healthcheck, so a failure would go undetected`,
+            status,
+            severity: 'warning',
           });
         }
       }
@@ -2724,6 +2862,16 @@ export class CoolifyClient {
             name: db.name,
             issue: `Database status: ${status}`,
             status,
+            severity: 'critical',
+          });
+        } else if (isRunningWithUnknownHealth(status)) {
+          issues.push({
+            type: 'database',
+            uuid: db.uuid,
+            name: db.name,
+            issue: `Database running but health unknown (${status}) — no working healthcheck, so a failure would go undetected`,
+            status,
+            severity: 'warning',
           });
         }
       }
@@ -2745,18 +2893,30 @@ export class CoolifyClient {
             name: svc.name,
             issue: `Service status: ${status}`,
             status,
+            severity: 'critical',
+          });
+        } else if (isRunningWithUnknownHealth(status)) {
+          issues.push({
+            type: 'service',
+            uuid: svc.uuid,
+            name: svc.name,
+            issue: `Service running but health unknown (${status}) — no working healthcheck, so a failure would go undetected`,
+            status,
+            severity: 'warning',
           });
         }
       }
     }
 
+    const critical = issues.filter((i) => i.severity === 'critical');
     return {
       summary: {
         total_issues: issues.length,
-        unhealthy_applications: issues.filter((i) => i.type === 'application').length,
-        unhealthy_databases: issues.filter((i) => i.type === 'database').length,
-        unhealthy_services: issues.filter((i) => i.type === 'service').length,
-        unreachable_servers: issues.filter((i) => i.type === 'server').length,
+        unhealthy_applications: critical.filter((i) => i.type === 'application').length,
+        unhealthy_databases: critical.filter((i) => i.type === 'database').length,
+        unhealthy_services: critical.filter((i) => i.type === 'service').length,
+        unreachable_servers: critical.filter((i) => i.type === 'server').length,
+        warnings: issues.filter((i) => i.severity === 'warning').length,
       },
       issues,
       ...(errors.length > 0 && { errors }),

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1441,7 +1441,7 @@ export class CoolifyClient {
           r.uuid &&
           !seen.has(r.uuid),
       );
-      if (dropped.length > 0) {
+      if (options?.page === undefined && options?.per_page === undefined && dropped.length > 0) {
         dbs = [...dbs, ...(dropped as unknown as Database[])];
       }
     }

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -930,7 +930,7 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.defineTool(
       'environments',
-      'Manage environments: list/get/create/delete (get includes dragonfly/keydb/clickhouse DBs missing from API)',
+      'Manage environments: list/get/create/delete (get includes dragonfly/keydb/clickhouse DBs missing from API; when the project has exactly one environment, get may omit name)',
       {
         action: z.enum(['list', 'get', 'create', 'delete']),
         project_uuid: z.string(),
@@ -942,10 +942,25 @@ export class CoolifyMcpServer extends McpServer {
           case 'list':
             return wrap(() => this.client.listProjectEnvironments(project_uuid));
           case 'get':
-            if (!name)
-              return { content: [{ type: 'text' as const, text: 'Error: name required' }] };
-            // Use enhanced method that includes missing DB types (#88)
-            return wrap(() => this.client.getProjectEnvironmentWithDatabases(project_uuid, name));
+            // The schema has always marked name optional here, but the handler
+            // rejected without it (#336). Default to the sole environment when
+            // the project has exactly one; anything else still needs a name.
+            return wrap(async () => {
+              let envName = name;
+              if (!envName) {
+                const envs = await this.client.listProjectEnvironments(project_uuid);
+                if (envs.length !== 1) {
+                  throw new Error(
+                    envs.length === 0
+                      ? `Project ${project_uuid} has no environments`
+                      : `name required — project has ${envs.length} environments: ${envs.map((e) => e.name).join(', ')}`,
+                  );
+                }
+                envName = envs[0].name;
+              }
+              // Use enhanced method that includes missing DB types (#88)
+              return this.client.getProjectEnvironmentWithDatabases(project_uuid, envName);
+            });
           case 'create':
             if (!name)
               return { content: [{ type: 'text' as const, text: 'Error: name required' }] };

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -64,10 +64,29 @@ export interface Server {
   unreachable_count?: number;
   proxy_type?: 'traefik' | 'caddy' | 'none';
   proxy_status?: string;
+  // Only present on GET /servers/{uuid}, not on the list endpoint. Populated
+  // by Coolify's periodic proxy version check; null when up to date or when
+  // the proxy version has not been detected yet.
+  detected_traefik_version?: string | null;
+  traefik_outdated_info?: TraefikOutdatedInfo | null;
   settings?: ServerSettings;
   team_id?: number;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Shape of `traefik_outdated_info` on GET /servers/{uuid} (verified live
+ * against Coolify v4.3.7). `type` is the semver distance of the available
+ * update, e.g. "patch_update".
+ */
+export interface TraefikOutdatedInfo {
+  current: string;
+  latest: string;
+  type?: string;
+  checked_at?: string;
+  newer_branch_target?: string;
+  newer_branch_latest?: string;
 }
 
 export interface ServerSettings {
@@ -1180,7 +1199,19 @@ export interface ApplicationDiagnostic {
   logs: string | null;
   environment_variables: {
     count: number;
-    variables: Array<{ key: string; is_buildtime: boolean; is_runtime: boolean }>;
+    // Coolify auto-creates a preview twin for every production env var and the
+    // API returns both scopes merged, so `count` can legitimately be double the
+    // number of keys a user configured. `distinct_keys` and the per-scope
+    // counts make that readable without deduping the underlying rows (#336).
+    distinct_keys: number;
+    production_count: number;
+    preview_count: number;
+    variables: Array<{
+      key: string;
+      is_buildtime: boolean;
+      is_runtime: boolean;
+      is_preview: boolean;
+    }>;
   };
   recent_deployments: Array<{
     uuid: string;
@@ -1225,15 +1256,21 @@ export interface InfrastructureIssue {
   name: string;
   issue: string;
   status: string;
+  // 'critical' = down/unhealthy/unreachable; 'warning' = degraded signal worth
+  // surfacing (unknown health, available proxy update) that is not an outage.
+  severity: 'critical' | 'warning';
 }
 
 export interface InfrastructureIssuesReport {
   summary: {
     total_issues: number;
+    // The unhealthy_*/unreachable_* counts cover critical issues only, keeping
+    // their pre-#336 meaning; warnings are counted separately.
     unhealthy_applications: number;
     unhealthy_databases: number;
     unhealthy_services: number;
     unreachable_servers: number;
+    warnings: number;
   };
   issues: InfrastructureIssue[];
   errors?: string[];


### PR DESCRIPTION
Closes #336 — items 1–5, in the issue's order (item 6 already shipped on the v3 branch).

## 1. `list_databases` no longer silently drops whole database types

Coolify keeps a per-type id sequence and `GET /databases` merges the per-type collections keyed on that id, so two types sharing ids shadow each other. `listDatabases` now fetches `/resources` alongside and merges back in, by uuid, any row `/databases` dropped — every `standalone-*` resource type is a database. The merge is a no-op when `/databases` is complete; if `/resources` fails the plain `/databases` result is returned unchanged. Both `get_infrastructure_overview` counts and `find_issues` database coverage go through `listDatabases`, so the same merge repairs them. The merged rows pass through the central `deepSanitize` boundary like every other response, so nothing unmasked leaks in.

## 2. `environments get` honours its own schema

`name` was always optional in the schema; the handler rejected anyway. It now defaults to the sole environment when the project has exactly one; with several the error names them (`name required — project has 2 environments: production, staging`), and an environment-less project says so. Tool description updated, contract snapshot reviewed and updated to match.

## 3. `diagnose_app` env counts stop reading as a bug

The response now carries `distinct_keys`, `production_count`, `preview_count` and a per-variable `is_preview` alongside the unchanged raw `count`, so the preview-twin doubling is legible instead of alarming. No row is deduped, per the issue's warning — deleting a twin destroys preview config.

## 4. Exact matches win name resolution

`resolveApplicationUuid` runs an exact pass (name, or any entry of the comma-separated `fqdn` with scheme and trailing slashes ignored) before substring matching, so `api.example.com` resolves even when another app's FQDN contains it. Same for `resolveServerUuid` — IPs are substrings of each other constantly (`10.0.0.5` is inside `10.0.0.50`). Multiple exact matches still disambiguate.

## 5. `find_issues` folds in the signals it already had

Issues gain `severity: 'critical' | 'warning'`. Resources in `running:unknown` warn (running container, no working healthcheck, a failure would go undetected). Servers with an available Traefik update warn with the version pair — `traefik_outdated_info` only exists on `GET /servers/{uuid}` (shape verified live against v4.3.7), so each listed server is fetched individually; a failed detail fetch degrades to an `errors` entry rather than killing the scan. The `unhealthy_*`/`unreachable_servers` summary counts keep their pre-existing critical-only meaning; warnings are counted separately in `summary.warnings`.

## Live verification (Coolify v4.3.7)

New `issue-336.integration.test.ts` passes 6/6 against our production instance, and a direct `findInfrastructureIssues` run surfaces a real pending Traefik `3.6.8 → 3.6.23` patch plus 7 `running:unknown` resources, with criticals cleanly separated:

```text
{
 "total_issues": 15,
 "unhealthy_applications": 2,
 "unhealthy_databases": 0,
 "unhealthy_services": 5,
 "unreachable_servers": 0,
 "warnings": 8
}
warning  server  localhost — Proxy (Traefik) patch update available: 3.6.8 → 3.6.23
warning  application  … — Application running but health unknown (running:unknown) …
critical application  … — Application status: exited:unhealthy
```

Our estate doesn't reproduce the id collision (7/7 databases intact), so item 1's collision case is pinned by unit tests; the integration suite asserts the live invariant instead (`listDatabases` ⊇ standalone rows of `/resources`, no duplicates, every row typed).

## Validation

- `npm test` — 671/671 (was 655; 16 new)
- `npm run lint` — 0 errors (52 pre-existing warnings)
- `npm run format` / `prettier --check` — clean
- `npm run check:chunk-drift` — 14/14
- `npm --prefix evals run snapshots` — 4/4 (one intentional update: `environments` description)
- `npm run test:integration` (new suite) — 6/6 live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
