### PR TITLE
fix(v3): 401 auth-gate tests, loopback-scheme redirect hole, SSRF guard (#340)

### DIFF
--- a/src/__tests__/http-interop.test.ts
+++ b/src/__tests__/http-interop.test.ts
@@ -221,4 +221,27 @@ describe('HTTP mode interop with the reference MCP client', () => {
       }),
     ).rejects.toThrow();
   }, 30_000);
+
+  it('answers an unauthenticated POST /mcp with a transport-level 401 on the wire (#340)', async (): Promise<void> => {
+    const response = await fetch(resourceUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(response.status).toBe(401);
+    const challenge = response.headers.get('www-authenticate') ?? '';
+    expect(challenge).toMatch(/^Bearer /);
+    expect(challenge).toContain(
+      `resource_metadata="${publicUrl}/.well-known/oauth-protected-resource"`,
+    );
+    expect(await response.text()).not.toContain('"jsonrpc"');
+
+    // ...and the metadata it points at answers, with the resource the client typed.
+    const prm = await fetch(`${publicUrl}/.well-known/oauth-protected-resource`);
+    expect(prm.status).toBe(200);
+    expect(((await prm.json()) as { resource: string }).resource).toBe(resourceUrl);
+  });
 });

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -107,9 +107,28 @@ describe('OAuthProvider', () => {
     it('allows loopback redirect URIs over http', () => {
       const provider = makeProvider();
       const result = provider.registerClient({
-        redirect_uris: ['http://localhost:33418/callback', 'http://127.0.0.1:33418/callback'],
+        redirect_uris: [
+          'http://localhost:33418/callback',
+          'http://127.0.0.1:33418/callback',
+          'http://[::1]:33418/callback',
+        ],
       });
       expect(result.client_id).toBeDefined();
+    });
+
+    it('rejects non-http schemes even on a loopback host, and fragments (#340)', () => {
+      const provider = makeProvider();
+      for (const uri of [
+        'javascript://localhost/alert(1)',
+        'file://localhost/etc/passwd',
+        'data://127.0.0.1/text',
+        'custom://[::1]/cb',
+      ]) {
+        expect(() => provider.registerClient({ redirect_uris: [uri] })).toThrow('https');
+      }
+      expect(() =>
+        provider.registerClient({ redirect_uris: ['https://ok.example.com/cb#frag'] }),
+      ).toThrow('fragment');
     });
   });
 
@@ -467,6 +486,59 @@ describe('HTTP app routes', () => {
     expect(response.status).toBe(201);
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.client_id).toMatch(/^mcp_client_/);
+  });
+
+  it('answers an unauthenticated POST /mcp with 401 + WWW-Authenticate before the SDK sees the body (#340)', async () => {
+    const app = makeApp();
+    // The audit line is written only past the bearer gate, so capturing stdout
+    // shows whether the JSON-RPC body ever reached the handler.
+    const written: string[] = [];
+    const auditSpy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      written.push(args.map(String).join(' '));
+    });
+    try {
+      const toolsCall = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'get_mcp_version', arguments: {} },
+      });
+      const headers = {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      };
+
+      const missing = await app.fetch(
+        new Request(RESOURCE, { method: 'POST', headers, body: toolsCall }),
+      );
+      expect(missing.status).toBe(401);
+      const challenge = missing.headers.get('www-authenticate') ?? '';
+      expect(challenge).toMatch(/^Bearer /);
+      expect(challenge).toContain(
+        `resource_metadata="${ISSUER}/.well-known/oauth-protected-resource"`,
+      );
+      // Not the 200-with-isError anti-pattern: no JSON-RPC envelope comes back.
+      expect(await missing.text()).not.toContain('"jsonrpc"');
+
+      const bogus = await app.fetch(
+        new Request(RESOURCE, {
+          method: 'POST',
+          headers: { ...headers, authorization: 'Bearer mcp_at_not_a_real_token' },
+          body: toolsCall,
+        }),
+      );
+      expect(bogus.status).toBe(401);
+      expect(bogus.headers.get('www-authenticate')).toContain('error="invalid_token"');
+
+      expect(written.some((line) => line.includes('"audit"'))).toBe(false);
+
+      // The challenge points at metadata whose resource is exactly the URL the
+      // client used, so discovery can start from the 401 alone.
+      const prm = await app.fetch(new Request(`${ISSUER}/.well-known/oauth-protected-resource`));
+      expect(((await prm.json()) as { resource: string }).resource).toBe(RESOURCE);
+    } finally {
+      auditSpy.mockRestore();
+    }
   });
 
   it('renders the authorize form with state carried as hidden fields, escaped', async () => {

--- a/src/__tests__/ssrf.test.ts
+++ b/src/__tests__/ssrf.test.ts
@@ -1,0 +1,131 @@
+import { jest } from '@jest/globals';
+import { createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+import {
+  type ResolvedAddress,
+  UnsafeUrlError,
+  assertPublicUrl,
+  fetchPublicJson,
+  isForbiddenAddress,
+  pinnedLookup,
+  resolvePublicAddresses,
+} from '../lib/ssrf.js';
+
+describe('SSRF guard for AS outbound fetches (#340)', () => {
+  it('knows the private, loopback, link-local, metadata and reserved ranges', () => {
+    for (const ip of [
+      '127.0.0.1',
+      '10.1.2.3',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '169.254.169.254',
+      '100.64.0.1',
+      '0.0.0.0',
+      '224.0.0.1',
+      '255.255.255.255',
+      '::1',
+      '::',
+      'fe80::1',
+      'fd00::1',
+      'fc00::1',
+      'ff02::1',
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+      '64:ff9b::a00:1',
+    ]) {
+      expect(isForbiddenAddress(ip)).toBe(true);
+    }
+    for (const ip of ['93.184.216.34', '1.1.1.1', '172.32.0.1', '2606:4700:4700::1111']) {
+      expect(isForbiddenAddress(ip)).toBe(false);
+    }
+    expect(isForbiddenAddress('not-an-ip')).toBe(true);
+  });
+
+  it('accepts only clean public https URLs', () => {
+    expect(assertPublicUrl('https://client.example.com/.well-known/cimd.json').hostname).toBe(
+      'client.example.com',
+    );
+    for (const raw of [
+      'http://client.example.com/x',
+      'javascript:alert(1)',
+      'data:application/json,{}',
+      'file:///etc/passwd',
+      'https://user:pw@client.example.com/x',
+      'https://localhost/x',
+      'https://api.localhost/x',
+      'https://127.0.0.1/x',
+      'https://169.254.169.254/latest/meta-data',
+      'https://[::1]/x',
+      'https://[::ffff:10.0.0.1]/x',
+      'not a url',
+    ]) {
+      expect(() => assertPublicUrl(raw)).toThrow(UnsafeUrlError);
+    }
+    expect(
+      assertPublicUrl('http://client.example.com/x', { allowInsecureHttp: true }).protocol,
+    ).toBe('http:');
+  });
+
+  it('rejects a hostname when any resolved address is private', async () => {
+    const mixed = async (): Promise<ResolvedAddress[]> => [
+      { address: '93.184.216.34', family: 4 as const },
+      { address: '10.0.0.5', family: 4 as const },
+    ];
+    await expect(resolvePublicAddresses('rebind.example', mixed)).rejects.toThrow(/private/);
+    await expect(
+      resolvePublicAddresses('nxdomain.example', async (): Promise<ResolvedAddress[]> => []),
+    ).rejects.toThrow(UnsafeUrlError);
+    const clean = async (): Promise<ResolvedAddress[]> => [
+      { address: '93.184.216.34', family: 4 as const },
+    ];
+    await expect(resolvePublicAddresses('ok.example', clean)).resolves.toHaveLength(1);
+  });
+
+  it('pins the socket to the vetted addresses instead of resolving again', () => {
+    const vetted = [
+      { address: '93.184.216.34', family: 4 as const },
+      { address: '2606:4700:4700::1111', family: 6 as const },
+    ];
+    const lookup = pinnedLookup(vetted);
+    const single = jest.fn();
+    lookup('rebind.example', {}, single);
+    expect(single).toHaveBeenCalledWith(null, '93.184.216.34', 4);
+    const all = jest.fn();
+    lookup('rebind.example', { all: true }, all);
+    expect(all).toHaveBeenCalledWith(null, vetted);
+  });
+
+  it('fetchPublicJson refuses before opening a socket when the target is private', async () => {
+    let hits = 0;
+    const server = createServer((_req, res) => {
+      hits += 1;
+      res.end('{}');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const toLocal = async (): Promise<ResolvedAddress[]> => [
+      { address: '127.0.0.1', family: 4 as const },
+    ];
+    try {
+      await expect(
+        fetchPublicJson(`http://cimd.example:${port}/doc.json`, {
+          allowInsecureHttp: true,
+          resolver: toLocal,
+        }),
+      ).rejects.toThrow(/private/);
+      await expect(
+        fetchPublicJson(`http://127.0.0.1:${port}/doc.json`, { allowInsecureHttp: true }),
+      ).rejects.toThrow(UnsafeUrlError);
+      await expect(
+        fetchPublicJson('https://cimd.example/doc.json', { resolver: toLocal }),
+      ).rejects.toThrow(/private/);
+      await expect(
+        fetchPublicJson(`http://cimd.example:${port}/doc.json`, { resolver: toLocal }),
+      ).rejects.toThrow(/scheme/);
+      expect(hits).toBe(0);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -186,11 +186,21 @@ export class OAuthProvider {
       } catch {
         throw new OAuthErrorResponse('invalid_redirect_uri', `not a valid URL: ${uri}`);
       }
-      const isLoopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
-      if (parsed.protocol !== 'https:' && !isLoopback) {
+      const host = parsed.hostname.replace(/^\[|\]$/g, '');
+      const isLoopback = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+      // Loopback relaxes the TLS requirement, never the scheme: a javascript:,
+      // data: or file: URI with a loopback "host" is still a redirect into
+      // something that is not a browser callback (#340).
+      if (!(parsed.protocol === 'https:' || (parsed.protocol === 'http:' && isLoopback))) {
         throw new OAuthErrorResponse(
           'invalid_redirect_uri',
-          'redirect_uris must be https (loopback excepted)',
+          'redirect_uris must be https (http loopback excepted)',
+        );
+      }
+      if (parsed.hash) {
+        throw new OAuthErrorResponse(
+          'invalid_redirect_uri',
+          'redirect_uris must not carry a fragment',
         );
       }
     }

--- a/src/lib/ssrf.ts
+++ b/src/lib/ssrf.ts
@@ -1,0 +1,219 @@
+/**
+ * Outbound-fetch guard for the authorization server (#340).
+ *
+ * Anything the AS fetches because a client told it to (today nothing; the
+ * Client ID Metadata Document behind a CIMD client_id when that lands) is a
+ * server-side request forgery surface: a hostile client_id can point at the
+ * Docker network, the cloud metadata service, or this very container. The
+ * guard is three checks that all have to pass:
+ *
+ *   1. the URL itself: https only, no credentials, no literal private address;
+ *   2. every address the hostname resolves to is public;
+ *   3. the socket is pinned to the addresses that passed check 2, so a DNS
+ *      answer that changes between resolve and connect (rebinding) cannot
+ *      steer the connection somewhere private.
+ *
+ * The Coolify base URL is deliberately NOT routed through here. It is operator
+ * configuration, and on a Coolify deployment it is an internal address by
+ * design.
+ */
+
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { BlockList, isIP, type LookupFunction } from 'node:net';
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsafeUrlError';
+  }
+}
+
+export interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+/** Resolves a hostname to every address it answers with. Injectable for tests. */
+export type Resolver = (hostname: string) => Promise<ResolvedAddress[]>;
+
+const forbidden = new BlockList();
+// IPv4: "this" network, RFC 1918, CGNAT, loopback, link-local (incl. the cloud
+// metadata service at 169.254.169.254), IETF protocol assignments, benchmarking,
+// multicast, reserved and broadcast.
+forbidden.addSubnet('0.0.0.0', 8, 'ipv4');
+forbidden.addSubnet('10.0.0.0', 8, 'ipv4');
+forbidden.addSubnet('100.64.0.0', 10, 'ipv4');
+forbidden.addSubnet('127.0.0.0', 8, 'ipv4');
+forbidden.addSubnet('169.254.0.0', 16, 'ipv4');
+forbidden.addSubnet('172.16.0.0', 12, 'ipv4');
+forbidden.addSubnet('192.0.0.0', 24, 'ipv4');
+forbidden.addSubnet('192.168.0.0', 16, 'ipv4');
+forbidden.addSubnet('198.18.0.0', 15, 'ipv4');
+forbidden.addSubnet('224.0.0.0', 4, 'ipv4');
+forbidden.addSubnet('240.0.0.0', 4, 'ipv4');
+// IPv6: unspecified, loopback, NAT64 (hides an unchecked IPv4 behind it),
+// unique-local, link-local, multicast. IPv4-mapped addresses are checked by
+// BlockList against the IPv4 rules above.
+forbidden.addSubnet('::', 128, 'ipv6');
+forbidden.addSubnet('::1', 128, 'ipv6');
+forbidden.addSubnet('64:ff9b::', 96, 'ipv6');
+forbidden.addSubnet('fc00::', 7, 'ipv6');
+forbidden.addSubnet('fe80::', 10, 'ipv6');
+forbidden.addSubnet('ff00::', 8, 'ipv6');
+
+/** True for anything that is not a public unicast address (unparseable counts). */
+export function isForbiddenAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 0) return true;
+  return forbidden.check(address, family === 6 ? 'ipv6' : 'ipv4');
+}
+
+function bareHost(url: URL): string {
+  return url.hostname.replace(/^\[|\]$/g, '');
+}
+
+/**
+ * Check 1: the URL as written. Throws UnsafeUrlError on anything that is not a
+ * credential-free https URL to a non-local hostname or public literal address.
+ */
+export function assertPublicUrl(raw: string, options?: { allowInsecureHttp?: boolean }): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new UnsafeUrlError(`not a URL: ${raw}`);
+  }
+  const allowed = options?.allowInsecureHttp ? ['https:', 'http:'] : ['https:'];
+  if (!allowed.includes(url.protocol)) {
+    throw new UnsafeUrlError(`${url.protocol} is not an allowed scheme for an outbound fetch`);
+  }
+  if (url.username || url.password) {
+    throw new UnsafeUrlError('outbound URLs must not carry credentials');
+  }
+  const host = bareHost(url);
+  if (host === '' || host === 'localhost' || host.endsWith('.localhost')) {
+    throw new UnsafeUrlError(`${host || '(empty)'} is not a public host`);
+  }
+  if (isIP(host) !== 0 && isForbiddenAddress(host)) {
+    throw new UnsafeUrlError(`${host} is not a public address`);
+  }
+  return url;
+}
+
+const systemResolver: Resolver = async (hostname) =>
+  (await dnsLookup(hostname, { all: true, verbatim: true })).map((entry) => ({
+    address: entry.address,
+    family: entry.family === 6 ? 6 : 4,
+  }));
+
+/** Check 2: every address the name resolves to is public; returns them. */
+export async function resolvePublicAddresses(
+  hostname: string,
+  resolver: Resolver = systemResolver,
+): Promise<ResolvedAddress[]> {
+  const addresses = await resolver(hostname);
+  if (addresses.length === 0) {
+    throw new UnsafeUrlError(`${hostname} did not resolve`);
+  }
+  for (const entry of addresses) {
+    if (isForbiddenAddress(entry.address)) {
+      throw new UnsafeUrlError(`${hostname} resolves to a private address (${entry.address})`);
+    }
+  }
+  return addresses;
+}
+
+/**
+ * Check 3: a Node `lookup` that answers from the vetted list and never
+ * consults DNS again, so the connection cannot be rebound after the check.
+ */
+export function pinnedLookup(addresses: ResolvedAddress[]): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (typeof options === 'object' && options !== null && options.all) {
+      callback(
+        null,
+        addresses.map((entry) => ({ address: entry.address, family: entry.family })),
+      );
+      return;
+    }
+    callback(null, addresses[0].address, addresses[0].family);
+  };
+}
+
+export interface FetchPublicJsonOptions {
+  /** Hard deadline for the whole exchange. Claude allows 10 s for discovery. */
+  timeoutMs?: number;
+  /** Response size cap; a metadata document is a few hundred bytes. */
+  maxBytes?: number;
+  /** Development only (mirrors MCP_ALLOW_INSECURE_HTTP). */
+  allowInsecureHttp?: boolean;
+  resolver?: Resolver;
+}
+
+/**
+ * GET a JSON document from a public URL with all three checks applied.
+ * Redirects are not followed: a 3xx is a failure, because following one would
+ * re-open every question the checks just answered.
+ */
+export async function fetchPublicJson(
+  raw: string,
+  options: FetchPublicJsonOptions = {},
+): Promise<unknown> {
+  const { timeoutMs = 10_000, maxBytes = 64 * 1024 } = options;
+  const url = assertPublicUrl(raw, { allowInsecureHttp: options.allowInsecureHttp });
+  const host = bareHost(url);
+  const literal = isIP(host);
+  const addresses =
+    literal !== 0
+      ? [{ address: host, family: literal === 6 ? (6 as const) : (4 as const) }]
+      : await resolvePublicAddresses(host, options.resolver);
+
+  const request = url.protocol === 'https:' ? httpsRequest : httpRequest;
+  return new Promise((resolve, reject) => {
+    const req = request(
+      url,
+      {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+        lookup: pinnedLookup(addresses),
+        timeout: timeoutMs,
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(
+            new UnsafeUrlError(
+              `${url.host} answered ${res.statusCode}; redirects are not followed`,
+            ),
+          );
+          return;
+        }
+        const chunks: Buffer[] = [];
+        let size = 0;
+        res.on('data', (chunk: Buffer) => {
+          size += chunk.length;
+          if (size > maxBytes) {
+            req.destroy(new UnsafeUrlError(`${url.host} response exceeds ${maxBytes} bytes`));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch {
+            reject(new UnsafeUrlError(`${url.host} did not return JSON`));
+          }
+        });
+        res.on('error', reject);
+      },
+    );
+    req.on('timeout', () =>
+      req.destroy(new UnsafeUrlError(`${url.host} gave no response within ${timeoutMs}ms`)),
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}


### PR DESCRIPTION
Two of the #340 tasks, plus a hole found on the way.

## 401 shape, pinned

The bearer gate already ran before the SDK handler; nothing proved it. Now two tests do: one in-process (`oauth.test.ts`) and one over a real socket (`http-interop.test.ts`). An unauthenticated `POST /mcp` must answer `401` with `WWW-Authenticate: Bearer ... resource_metadata="<issuer>/.well-known/oauth-protected-resource"`, carry no JSON-RPC envelope (the 200-with-`isError` anti-pattern), and the audit line, which is written only past the gate, must not fire. A bogus bearer gets `error="invalid_token"`. The metadata the challenge points at answers with the exact resource URL, so discovery can start from the 401 alone.

## Redirect URI: loopback relaxed the scheme, not just TLS

`javascript://localhost/alert(1)` and `file://localhost/etc/passwd` parse with hostname `localhost`, so the loopback exemption accepted them as redirect URIs. Allowed now: `https:`, or `http:` on `localhost` / `127.0.0.1` / `[::1]`. Fragments are rejected (RFC 6749 §3.1.2).

## `src/lib/ssrf.ts`

Guard for anything the AS fetches because a client asked it to. Today that is nothing; the Client ID Metadata Document fetch (#340 item 1, 3.1) is the consumer, and it must go through `fetchPublicJson`. Three checks, all required:

1. the URL as written: https only, no credentials, no local hostname, no literal private address;
2. every address the name resolves to is public (`net.BlockList`: RFC 1918, loopback, link-local incl. `169.254.169.254`, CGNAT, `0/8`, benchmarking, multicast/reserved; `::1`, ULA, link-local, multicast, NAT64, IPv4-mapped);
3. the socket is pinned to the vetted addresses via a custom `lookup`, so a DNS answer that changes between check and connect cannot rebind it.

Redirects are not followed; 10 s deadline and 64 KB cap by default. The Coolify base URL is deliberately exempt: it is operator configuration and on a Coolify deployment it is an internal address by design.

Not covered by a test: the happy path of the pinned connection itself (a public TLS endpoint is needed; only the rejection paths and the lookup pin are exercised). Zero new dependencies.

## Verification

- `npm test` 719/719 (17 new)
- `http-interop.test.ts` 2/2 over TCP
- `npm --prefix evals run snapshots` 4/4
- `npm run lint` 0 errors, `npm audit --audit-level=high` clean
- Live: `mcp.stumason.dev` already answers the 401 shape on the deployed v3 HEAD; this PR pins it.