### PR TITLE
fix(deployments): honor app list pagination

### DIFF
--- a/evals/src/contract/__toolsnaps__/deployment.json
+++ b/evals/src/contract/__toolsnaps__/deployment.json
@@ -22,7 +22,14 @@
         "type": "number"
       },
       "page": {
-        "type": "number"
+        "type": "integer",
+        "exclusiveMinimum": 0,
+        "maximum": 9007199254740991
+      },
+      "per_page": {
+        "type": "integer",
+        "exclusiveMinimum": 0,
+        "maximum": 9007199254740991
       },
       "max_chars": {
         "type": "number"

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -3546,6 +3546,17 @@ describe('CoolifyClient', () => {
       );
     });
 
+    it('should paginate application deployments with Coolify skip and take parameters', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ count: 25, deployments: [] }));
+
+      await client.listApplicationDeployments('app-uuid', { page: 2, perPage: 10 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/deployments/applications/app-uuid?skip=10&take=10',
+        expect.any(Object),
+      );
+    });
+
     it('should attach logs to the essential projection when includeLogs is true (never the raw object)', async () => {
       const withLogs = {
         ...mockDeployment,

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1268,6 +1268,27 @@ describe('CoolifyMcpServer v2', () => {
       expect(spy).toHaveBeenCalledWith('app-uuid', { includeLogs: false });
       expect(result.content[0].text).not.toContain('BEGIN UNTRUSTED LOG OUTPUT');
     });
+
+    it('passes list pagination to the Coolify client', async () => {
+      const server = new CoolifyMcpServer({ baseUrl: 'http://localhost:3000', accessToken: 't' });
+      const spy = jest.spyOn(server['client'], 'listApplicationDeployments').mockResolvedValue({
+        count: 25,
+        deployments: [],
+      });
+
+      await callDeploymentTool(server, {
+        action: 'list_for_app',
+        uuid: 'app-uuid',
+        page: 2,
+        per_page: 10,
+      });
+
+      expect(spy).toHaveBeenCalledWith('app-uuid', {
+        includeLogs: undefined,
+        page: 2,
+        perPage: 10,
+      });
+    });
   });
 
   describe('scheduled_tasks tool handler', () => {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1766,10 +1766,16 @@ export class CoolifyClient {
    */
   async listApplicationDeployments(
     appUuid: string,
-    options?: { includeLogs?: boolean },
+    options?: { includeLogs?: boolean; page?: number; perPage?: number },
   ): Promise<{ count: number; deployments: DeploymentEssential[] }> {
+    const page = Math.max(1, options?.page ?? 1);
+    const perPage = Math.max(1, options?.perPage ?? 10);
+    const query =
+      options?.page !== undefined || options?.perPage !== undefined
+        ? `?skip=${(page - 1) * perPage}&take=${perPage}`
+        : '';
     const envelope = await this.request<{ count: number; deployments: Deployment[] }>(
-      `/deployments/applications/${appUuid}`,
+      `/deployments/applications/${appUuid}${query}`,
     );
     const deployments = Array.isArray(envelope?.deployments) ? envelope.deployments : [];
     return {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -2056,11 +2056,12 @@ export class CoolifyMcpServer extends McpServer {
         action: z.enum(['get', 'cancel', 'list_for_app']),
         uuid: z.string(),
         lines: z.number().optional(), // Include logs truncated to last N entries (omit for no logs)
-        page: z.number().optional(), // Log page (1=most recent, 2=older, etc.)
+        page: z.number().int().positive().optional(), // Log page for get; deployment page for list_for_app
+        per_page: z.number().int().positive().optional(), // list_for_app page size (default 10)
         max_chars: z.number().optional(), // Limit log output to last N chars (default: 50000)
         include_logs: z.boolean().optional(), // list_for_app only: include raw build logs (default false; upstream returns ~30KB per deployment)
       },
-      async ({ action, uuid, lines, page, max_chars, include_logs }) => {
+      async ({ action, uuid, lines, page, per_page, max_chars, include_logs }) => {
         switch (action) {
           case 'get':
             // If lines param specified, include logs and truncate
@@ -2126,6 +2127,8 @@ export class CoolifyMcpServer extends McpServer {
             return wrap(async () => {
               const result = await this.client.listApplicationDeployments(uuid, {
                 includeLogs: include_logs,
+                ...(page !== undefined && { page }),
+                ...(per_page !== undefined && { perPage: per_page }),
               });
               // include_logs pulls raw build output onto each row — same
               // attacker-influenceable surface as the other log paths (FINDINGS #4).


### PR DESCRIPTION
## Problem

`deployment` accepts `page` for `list_for_app`, but the handler drops it. Coolify therefore receives no `skip`/`take` query and every requested page returns the newest 10 deployments. This makes historical incident correlation silently incomplete.

## Fix

- add `per_page` for `list_for_app`
- map `page` and `per_page` to Coolify's documented `skip` and `take` parameters
- preserve the existing unpaginated request when neither option is supplied
- add client and MCP handler regressions

## Verification

- red: focused tests showed page 2 still called the unpaginated endpoint and handler dropped both values
- green: 556 focused tests passed
- `npx tsc --noEmit` passed
- ESLint: 0 errors; existing warnings only
