### PR TITLE
fix: clear npm audit high (fast-uri) blocking CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **Lockfile bumped past four npm advisories to unblock CI** (#363). `npm audit fix` for `fast-uri` (high: SSRF and host-confusion, GHSA-5jgf/f65p/fph4/jqff), `qs` and `@humanfs/node` (moderate), all in the dev/CI install tree this repo controls. This unblocks the `npm audit --audit-level=high` CI gate; it does not change what consumers install — a downstream `@masonator/coolify-mcp` install resolves `fast-uri@3` through `@modelcontextprotocol/sdk` → `ajv`, and this package's `overrides` only apply at its own root. The `body-parser` low (GHSA-v422) is left in place: this server only ever constructs a `StdioServerTransport`, so the SDK's express code paths never load.
+
 ## [2.19.4] - 2026-08-22
 
 The field-test follow-ups from #336, contributed by the field-tester. The headline is an upstream bug: `GET /databases` can drop whole database types, and `list_databases` now repairs that from `/resources`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,7 +1638,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
       "version": "2.6.0",
@@ -1659,7 +1662,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.6.0",
@@ -1680,7 +1686,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
       "version": "2.6.0",
@@ -1701,7 +1710,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.6.0",
@@ -1722,7 +1734,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
       "version": "2.6.0",
@@ -1743,7 +1758,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.6.0",
@@ -2381,6 +2399,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
@@ -2395,6 +2416,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
@@ -2409,6 +2433,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
@@ -2423,6 +2450,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
@@ -2437,6 +2467,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
@@ -2451,6 +2484,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
@@ -2465,6 +2501,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
@@ -2479,6 +2518,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
@@ -2493,6 +2535,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
@@ -2507,6 +2552,9 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-openharmony-arm64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -719,25 +719,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1613,9 +1627,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1637,9 +1648,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1661,9 +1669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1685,9 +1690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,9 +1711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1733,9 +1732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,9 +2377,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,9 +2391,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,9 +2405,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,9 +2419,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2449,9 +2433,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,9 +2447,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,9 +2461,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,9 +2475,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,9 +2489,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2534,9 +2503,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3580,9 +3546,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4021,9 +3987,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -7070,12 +7036,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7511,14 +7478,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7530,13 +7497,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
The security-audit step is failing every PR (see #362's build 22.x) on 4 advisories that landed since 2.19.4 shipped: **fast-uri high** (SSRF / host confusion), qs + humanfs moderates, body-parser low.

This is `npm audit fix` plus review follow-ups — lockfile and CHANGELOG only, no code:

- **Scope, precisely:** this unblocks the `npm audit --audit-level=high` CI gate. It does not change what consumers install — downstream resolves `fast-uri@3` via `@modelcontextprotocol/sdk` → `ajv`, and our `overrides` only apply at this repo's root.
- **body-parser low left in place deliberately:** this server only constructs `StdioServerTransport`; the SDK's express paths never load.
- **Cooldown check done:** `@humanfs/types@0.15.0` and `es-define-property@1.0.1` are 2024 publishes, `qs@6.16.0` is 9 days old, `fast-uri@4.1.4` (5 days) is the advisory fix itself.
- **libc metadata restored:** the npm-10 rewrite dropped 16 `libc` fields; restored verbatim from main (no versions changed), `npm ci` under npm 11 validates clean.

Verified locally: audit gate exits 0, build + full test suite (674) green.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a