### PR TITLE
fix: return exact environment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`env_vars` exact-key reveal now returns a value or a capability error** (Tchori-Labs/infra#137). Application lists request the full env-var representation when `key` and `reveal: true` are supplied, then filter to that exact key. Reveal without a key is rejected before the API call, and APIs/tokens that omit both `value` and `real_value` return a clear sensitive-read capability error instead of claiming success. Coolify exposes only the collection env endpoint; there is no supported per-variable GET or reveal query flag.
+
 ## [2.19.4] - 2026-08-22
 
 The field-test follow-ups from #336, contributed by the field-tester. The headline is an upstream bug: `GET /databases` can drop whole database types, and `list_databases` now repairs that from `/resources`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Set `COOLIFY_MCP_ELICITATION=off` to turn the confirmations off entirely. It exi
 
 Secrets are masked at the API boundary. A client granted "list" access never sees plaintext credentials unless you explicitly opt in with `reveal: true`:
 
-- **`env_vars`**: variable values return as `***`
+- **`env_vars`**: variable values return as `***`. `reveal: true` is accepted only with an exact `key`; the tool then returns only that matching row. Coolify exposes env vars through a collection endpoint, not a per-variable GET or a `reveal` query flag, so the token must have `read:sensitive` access (and the required owner/admin role on newer versions). If the API omits both value fields, the tool returns a capability error instead of claiming the value was revealed.
 - **`system list_resources` (full mode)**: webhook HMAC secrets, basic-auth and database passwords, `internal/external_db_url` connection strings, compose bodies, Traefik labels, nested env vars
 - **`get_database` / `get_service`**: the same credential fields are masked on the detail endpoints, and any embedded server row is projected down to uuid/name/ip so its sentinel token and log-drain config never leave the client
 - **`get_server`**: sentinel and log-drain credentials are always masked, with no reveal
@@ -134,7 +134,7 @@ Destructive operations also ask a human first; see [Ask before it hurts](#ask-be
 
 Works against Coolify v4.0 through v4.2+. Two v4.2 changes are worth knowing about:
 
-- **Secrets are hidden by default.** From v4.2 Coolify strips sensitive fields from API responses unless the token has sensitive-read scope, so `reveal: true` can return a variable with no value at all. That is the server withholding it, not a bug here; issue a token with sensitive-read scope if you need plaintext back.
+- **Secrets are hidden by default.** From v4.2 Coolify strips sensitive fields from API responses unless the token has sensitive-read scope. For `env_vars`, the exact-key `reveal: true` path reports a capability error when the server withholds the value; issue a token with sensitive-read scope if you need plaintext back.
 - **Member-role tokens are read-only.** From v4.2 a token belonging to a Member-role user can view resources but cannot deploy, start, stop, create, update or delete. Those calls return 403. Promote the user or use a token from a role with write access.
 
 State-changing endpoints also moved from GET to POST in v4.2. The client handles this for you across both eras, so no action is needed.

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -611,13 +611,98 @@ describe('CoolifyMcpServer v2', () => {
       expect(vars[0].key).toBe('NODE_ENV');
     });
 
+    it('list with an application key + reveal requests full values and filters exactly', async () => {
+      const spy = jest.spyOn(server['client'], 'listApplicationEnvVars').mockResolvedValue([
+        {
+          uuid: 'env-1',
+          key: 'NODE_ENV',
+          value: 'plain-value',
+          real_value: 'plain-value',
+          is_buildtime: false,
+          is_runtime: true,
+          is_preview: false,
+        },
+        {
+          uuid: 'env-2',
+          key: 'UNSELECTED_VALUE',
+          value: 'do-not-return',
+          real_value: 'do-not-return',
+          is_buildtime: false,
+          is_runtime: true,
+          is_preview: false,
+        },
+      ] as never);
+
+      const result = (await callEnvVars(server, {
+        resource: 'application',
+        action: 'list',
+        uuid: 'app-uuid',
+        key: 'NODE_ENV',
+        reveal: true,
+      })) as { content: Array<{ text: string }> };
+
+      expect(spy).toHaveBeenCalledWith('app-uuid', { summary: false, reveal: true });
+      expect(result.content[0].text).not.toContain('do-not-return');
+      const vars = JSON.parse(result.content[0].text) as Array<{
+        key: string;
+        value: string;
+        real_value: string;
+      }>;
+      expect(vars).toHaveLength(1);
+      expect(vars[0]).toEqual(
+        expect.objectContaining({
+          key: 'NODE_ENV',
+          value: 'plain-value',
+          real_value: 'plain-value',
+        }),
+      );
+    });
+
+    it('reports when exact-key reveal is unavailable from the API', async () => {
+      const spy = jest.spyOn(server['client'], 'listApplicationEnvVars').mockResolvedValue([
+        {
+          uuid: 'env-1',
+          key: 'NODE_ENV',
+          value: undefined,
+          is_buildtime: false,
+          is_runtime: true,
+          is_preview: false,
+        },
+      ] as never);
+
+      const result = (await callEnvVars(server, {
+        resource: 'application',
+        action: 'list',
+        uuid: 'app-uuid',
+        key: 'NODE_ENV',
+        reveal: true,
+      })) as { content: Array<{ text: string }> };
+
+      expect(spy).toHaveBeenCalledWith('app-uuid', { summary: false, reveal: true });
+      expect(result.content[0].text).toContain('does not support sensitive env-var reads');
+    });
+
+    it('rejects reveal without an exact key before calling Coolify', async () => {
+      const spy = jest.spyOn(server['client'], 'listApplicationEnvVars');
+
+      const result = (await callEnvVars(server, {
+        resource: 'application',
+        action: 'list',
+        uuid: 'app-uuid',
+        reveal: true,
+      })) as { content: Array<{ text: string }> };
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('requires an exact key');
+    });
+
     it('list with key + reveal exposes only the requested value', async () => {
       const spy = jest.spyOn(server['client'], 'listServiceEnvVars').mockResolvedValue([
         { uuid: 'env-1', key: 'FLAG', value: 'true', is_buildtime: false, is_runtime: true },
         {
           uuid: 'env-2',
           key: 'DB_PASSWORD',
-          value: 'hunter2',
+          value: 'not-selected',
           is_buildtime: false,
           is_runtime: true,
         },
@@ -632,7 +717,7 @@ describe('CoolifyMcpServer v2', () => {
       })) as { content: Array<{ text: string }> };
 
       expect(spy).toHaveBeenCalledWith('svc-uuid', { reveal: true });
-      expect(result.content[0].text).not.toContain('hunter2');
+      expect(result.content[0].text).not.toContain('not-selected');
       const vars = JSON.parse(result.content[0].text) as Array<{ key: string; value: string }>;
       expect(vars).toEqual([expect.objectContaining({ key: 'FLAG', value: 'true' })]);
     });
@@ -652,15 +737,16 @@ describe('CoolifyMcpServer v2', () => {
       expect(JSON.parse(result.content[0].text)).toHaveLength(2);
     });
 
-    it('database list forwards reveal to listDatabaseEnvVars (#276)', async () => {
+    it('database list forwards exact-key reveal to listDatabaseEnvVars (#276)', async () => {
       const spy = jest
         .spyOn(server['client'], 'listDatabaseEnvVars')
-        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: 'hunter2' }] as never);
+        .mockResolvedValue([{ uuid: 'env-1', key: 'DB_PASSWORD', value: 'plain-value' }] as never);
 
       await callEnvVars(server, {
         resource: 'database',
         action: 'list',
         uuid: 'db-uuid',
+        key: 'DB_PASSWORD',
         reveal: true,
       });
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1866,15 +1866,42 @@ export class CoolifyMcpServer extends McpServer {
         // On `list`, an optional `key` narrows the response to that single
         // variable. This matters most with reveal=true: without it, asking
         // for one value dumps every secret on the resource to the MCP client.
-        const filterByKey = <T extends { key: string }>(vars: T[]): T[] =>
-          key ? vars.filter((v) => v.key === key) : vars;
+        if (action === 'list' && reveal === true && !key?.trim()) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: reveal=true requires an exact key; refusing to return every environment variable',
+              },
+            ],
+          };
+        }
+        const hasReturnedValue = (value: unknown): boolean =>
+          value !== undefined && value !== null && value !== '***';
+        const filterByKey = <T extends { key: string; value?: string; real_value?: string }>(
+          vars: T[],
+        ): T[] => {
+          const filtered = key ? vars.filter((v) => v.key === key) : vars;
+          if (
+            reveal === true &&
+            filtered.some((v) => !hasReturnedValue(v.value) && !hasReturnedValue(v.real_value))
+          ) {
+            throw new Error(
+              'Coolify did not return the requested environment variable value. The API or token does not support sensitive env-var reads; use a token with read:sensitive permission (and the required owner/admin role on newer Coolify versions).',
+            );
+          }
+          return filtered;
+        };
 
         if (resource === 'application') {
           switch (action) {
             case 'list':
               return wrap(async () =>
                 filterByKey(
-                  await this.client.listApplicationEnvVars(uuid, { summary: true, reveal }),
+                  await this.client.listApplicationEnvVars(uuid, {
+                    summary: !(reveal === true && Boolean(key?.trim())),
+                    reveal,
+                  }),
                 ),
               );
             case 'create':


### PR DESCRIPTION
## Summary

Fix `env_vars` exact-key + `reveal=true` so supported API responses return the requested value instead of an application summary. When Coolify withholds both value fields, the tool now reports a sensitive-read capability error.

Related: https://github.com/Tchori-Labs/infra/issues/137

## Changes

- Request the full application env-var representation for exact-key reveal, then filter to that key.
- Reject `reveal=true` without an exact key before calling Coolify.
- Report a clear capability error when the API/token omits `value` and `real_value`.
- Document the collection-only API limitation and `read:sensitive` requirement.
- Add regression coverage for returned values, filtering, unavailable values, and the no-key guard. Fixtures use non-secret placeholders.

## Test plan

- [x] `npm test -- --runInBand --coverage=false src/__tests__/mcp-server.test.ts -t "env_vars tool handler"`
- [x] `npx eslint --quiet src/lib/mcp-server.ts src/__tests__/mcp-server.test.ts`
- [x] `npx prettier --check src/lib/mcp-server.ts src/__tests__/mcp-server.test.ts README.md CHANGELOG.md`
- [ ] Full CI suite

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated