### PR TITLE
ci: run claude-review once per PR, not on every push

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,10 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # Once per PR, not on every push: re-reviewing each fix commit produced
+    # an author↔reviewer loop (PR #375: four rounds on five files). Ask for
+    # another pass with an @claude comment when you actually want one.
+    types: [opened, reopened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
Drops `synchronize` from the review workflow's triggers. Re-reviewing every fix commit produced an author↔reviewer loop — four rounds on a five-file PR (#375). Reviews now fire on `opened`/`reopened` only; an `@claude` comment (already wired in `claude.yml`) requests another pass when someone actually wants one.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a