### PR TITLE
fix(deps): bump js-yaml to 4.3.2 (GHSA-2883-xcg3-v3hh)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4616,9 +4616,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
New high advisory in js-yaml (maxTotalMergeKeys CPU exhaustion, [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh)) is failing the `npm audit --audit-level=high` gate on every open PR (#375, #377, #378). Same pattern as #348 and #363.

`npm audit fix` under npm 11 — lockfile only, three lines, `npm audit` clean after. Once merged, the open PRs need `update-branch` to go green.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a