### PR TITLE
chore(deps): override smol-toml to ^1.8.0 to clear the audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6463,9 +6463,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scope": "@masonator",
   "version": "3.1.0",
   "mcpName": "io.github.StuMason/coolify",
-  "description": "MCP server for Coolify — 45 optimized tools for infrastructure management, diagnostics, and documentation search",
+  "description": "MCP server for Coolify \u2014 45 optimized tools for infrastructure management, diagnostics, and documentation search",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -110,7 +110,8 @@
     "brace-expansion": "^5.0.6",
     "picomatch": "^4.0.4",
     "js-yaml": "^4.3.1",
-    "markdown-it": "^14.2.0"
+    "markdown-it": "^14.2.0",
+    "smol-toml": "^1.8.0"
   },
   "lint-staged": {
     "*.{ts,js,json,md,yaml,yml}": "prettier --write",


### PR DESCRIPTION
GHSA-7w5x-hrqm-74c2 (high, denial of service via malformed TOML documents) affects `smol-toml <=1.7.0`.

`markdownlint-cli2@0.23.2` — the current release — depends on **exactly** `1.7.0`, so no lockfile refresh reaches the fix, and `npm audit fix --force` would downgrade the linter to `0.21.0`: a breaking change to a dev tool to clear a dev-only advisory.

An `overrides` entry pins `1.8.0` instead. Same major, security patch only. markdownlint runs in both the pre-commit hook and CI, so a real incompatibility would surface immediately rather than silently.

## Why on its own

This is currently failing `build (20.x)`, `build (22.x)` and `build (24.x)` on **every** open PR (#387, #388, #389, #391, #392). It has nothing to do with any of them, so it lands separately rather than being smuggled into a feature branch. Merging this first and rebasing the others turns five red PRs green.

## Verification

```
npm audit --audit-level=high   # found 0 vulnerabilities
npm ls smol-toml               # smol-toml@1.8.0 overridden
npx markdownlint-cli2          # 0 issues in 0 files
npm test                       # 823 passing, 14 suites
npm run build                  # clean
```

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a