### PR TITLE
docs: answer the "why not Coolify's own MCP?" question in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README answers "why not Coolify's own MCP server?" directly, with a comparison against the built-in `/mcp` and the official CLI, and recommends the built-in outright for single-instance read-only use.
+
 ## [3.2.0] - 2026-09-10
 
 The client-surface release. The server now speaks all three MCP primitives instead of one: prompts you start as slash commands, resources your client can attach, and an `instructions` field that tells a model what this server is before it reads a single tool definition. `search_docs` works with no network at all. HTTP mode accepts Client ID Metadata Documents, which the spec now prefers over dynamic registration.

--- a/README.md
+++ b/README.md
@@ -95,17 +95,17 @@ At the time of writing Coolify documents its server as read-only, with write ope
 
 This server is for the jobs those two do not cover yet.
 
-|  | Coolify's built-in `/mcp` | Official CLI | This server |
-| --- | --- | --- | --- |
-| Where it runs | Inside your Coolify | Your shell | Your machine, or a container inside your Coolify |
-| Install | Nothing | One binary | `npx`, a one-click Claude Desktop extension, or a container |
-| Transport | Streamable HTTP | Not an MCP server | stdio and HTTP, so it also works in clients that only speak stdio |
-| Coolify instances | One | One context at a time | One or many, every tool taking an `instance` |
-| Writes | Documented as read-only today | Yes | Yes |
-| Before a destructive call | Not applicable | You typed it | Stops and asks you in your own client, naming the blast radius |
-| When something is broken | Not applicable | Shell exit codes | `doctor` names the cause and the one-line fix |
+|                           | Coolify's built-in `/mcp`     | Official CLI          | This server                                                       |
+| ------------------------- | ----------------------------- | --------------------- | ----------------------------------------------------------------- |
+| Where it runs             | Inside your Coolify           | Your shell            | Your machine, or a container inside your Coolify                  |
+| Install                   | Nothing                       | One binary            | `npx`, a one-click Claude Desktop extension, or a container       |
+| Transport                 | Streamable HTTP               | Not an MCP server     | stdio and HTTP, so it also works in clients that only speak stdio |
+| Coolify instances         | One                           | One context at a time | One or many, every tool taking an `instance`                      |
+| Writes                    | Documented as read-only today | Yes                   | Yes                                                               |
+| Before a destructive call | Not applicable                | You typed it          | Stops and asks you in your own client, naming the blast radius    |
+| When something is broken  | Not applicable                | Shell exit codes      | `doctor` names the cause and the one-line fix                     |
 
-A rough rule. One instance and read-only questions, with no setup: use Coolify's. Scripting and CI: use the CLI. Several instances, writes you want a human gate in front of, a client that only speaks stdio, or you want to be told *why* it is broken: this one.
+A rough rule. One instance and read-only questions, with no setup: use Coolify's. Scripting and CI: use the CLI. Several instances, writes you want a human gate in front of, a client that only speaks stdio, or you want to be told _why_ it is broken: this one.
 
 Other third-party Coolify MCP servers exist. Choose on transport, on how many instances you need to reach from one connection, and on what happens the moment before something is deleted.
 

--- a/README.md
+++ b/README.md
@@ -89,21 +89,21 @@ Works against Coolify v4.0 through v4.3. The v4.2 GET-to-POST change and the v4.
 
 ## Coolify's own MCP server, and when you want this one
 
-Coolify ships an MCP server of its own, built into the product. Enable it in **Settings → Advanced** (and per team), point your client at `https://your-coolify/mcp`, and there is nothing to install: it runs inside the instance, so your token never leaves the box. If you run one Coolify, with one team, and you mostly want to ask it questions, use that. It is the shortest path and it costs you nothing.
+Coolify ships an MCP server of its own, built into the product. Enable it in **Settings → Advanced** (and per team), point your client at `https://your-coolify/mcp`, and there is nothing to install: it runs inside the instance, so no third-party code ever holds your token. If you run one Coolify, with one team, and you mostly want to ask it questions, use that. It is the shortest path and it costs you nothing.
 
 At the time of writing Coolify documents its server as read-only, with write operations planned. It is moving quickly, so check [the Coolify docs](https://coolify.io/docs/integrations/mcp) for where it has got to. There is also an [official CLI](https://github.com/coollabsio/coolify-cli) if you would rather script than converse.
 
 This server is for the jobs those two do not cover yet.
 
-|                           | Coolify's built-in `/mcp`     | Official CLI          | This server                                                       |
-| ------------------------- | ----------------------------- | --------------------- | ----------------------------------------------------------------- |
-| Where it runs             | Inside your Coolify           | Your shell            | Your machine, or a container inside your Coolify                  |
-| Install                   | Nothing                       | One binary            | `npx`, a one-click Claude Desktop extension, or a container       |
-| Transport                 | Streamable HTTP               | Not an MCP server     | stdio and HTTP, so it also works in clients that only speak stdio |
-| Coolify instances         | One                           | One context at a time | One or many, every tool taking an `instance`                      |
-| Writes                    | Documented as read-only today | Yes                   | Yes                                                               |
-| Before a destructive call | Not applicable                | You typed it          | Stops and asks you in your own client, naming the blast radius    |
-| When something is broken  | Not applicable                | Shell exit codes      | `doctor` names the cause and the one-line fix                     |
+|                           | Coolify's built-in `/mcp`     | Official CLI          | This server                                                                                                                    |
+| ------------------------- | ----------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Where it runs             | Inside your Coolify           | Your shell            | Your machine, or a container inside your Coolify                                                                               |
+| Install                   | Nothing                       | One binary            | `npx`, a one-click Claude Desktop extension, or a container                                                                    |
+| Transport                 | Streamable HTTP               | Not an MCP server     | stdio and HTTP, so it also works in clients that only speak stdio                                                              |
+| Coolify instances         | One                           | One context at a time | One or many; in fleet mode every tool takes an `instance`                                                                      |
+| Writes                    | Documented as read-only today | Yes                   | Yes                                                                                                                            |
+| Before a destructive call | Not applicable                | You typed it          | Stops and asks you in your own client, naming the blast radius, on clients that support elicitation; fails closed in HTTP mode |
+| When something is broken  | Not applicable                | Shell exit codes      | `doctor` names the cause and the one-line fix                                                                                  |
 
 A rough rule. One instance and read-only questions, with no setup: use Coolify's. Scripting and CI: use the CLI. Several instances, writes you want a human gate in front of, a client that only speaks stdio, or you want to be told _why_ it is broken: this one.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,28 @@ Destructive operations stop and ask **you**, in your own client, before anything
 
 Works against Coolify v4.0 through v4.3. The v4.2 GET-to-POST change and the v4.2 secrets and Member-role restrictions are handled; see [compatibility](docs/tools.md#coolify-version-compatibility).
 
+## Coolify's own MCP server, and when you want this one
+
+Coolify ships an MCP server of its own, built into the product. Enable it in **Settings → Advanced** (and per team), point your client at `https://your-coolify/mcp`, and there is nothing to install: it runs inside the instance, so your token never leaves the box. If you run one Coolify, with one team, and you mostly want to ask it questions, use that. It is the shortest path and it costs you nothing.
+
+At the time of writing Coolify documents its server as read-only, with write operations planned. It is moving quickly, so check [the Coolify docs](https://coolify.io/docs/integrations/mcp) for where it has got to. There is also an [official CLI](https://github.com/coollabsio/coolify-cli) if you would rather script than converse.
+
+This server is for the jobs those two do not cover yet.
+
+|  | Coolify's built-in `/mcp` | Official CLI | This server |
+| --- | --- | --- | --- |
+| Where it runs | Inside your Coolify | Your shell | Your machine, or a container inside your Coolify |
+| Install | Nothing | One binary | `npx`, a one-click Claude Desktop extension, or a container |
+| Transport | Streamable HTTP | Not an MCP server | stdio and HTTP, so it also works in clients that only speak stdio |
+| Coolify instances | One | One context at a time | One or many, every tool taking an `instance` |
+| Writes | Documented as read-only today | Yes | Yes |
+| Before a destructive call | Not applicable | You typed it | Stops and asks you in your own client, naming the blast radius |
+| When something is broken | Not applicable | Shell exit codes | `doctor` names the cause and the one-line fix |
+
+A rough rule. One instance and read-only questions, with no setup: use Coolify's. Scripting and CI: use the CLI. Several instances, writes you want a human gate in front of, a client that only speaks stdio, or you want to be told *why* it is broken: this one.
+
+Other third-party Coolify MCP servers exist. Choose on transport, on how many instances you need to reach from one connection, and on what happens the moment before something is deleted.
+
 ## Example prompts
 
 ```text


### PR DESCRIPTION
Coolify has shipped its own MCP server inside the product since v4, and there is an official CLI at v1.8.0. The README has never mentioned either. That is the first question a visitor has now, and we were not answering it.

Worse, someone else is. A competing third-party server publishes a comparison table naming this project, and two of its four claims about us are already out of date.

**What the section does**

Sends people to Coolify's built-in server when it genuinely fits: one instance, one team, read-only questions, nothing to install, token never leaves the box. Being straight about that is worth more than a captured install.

Then a table on the axes where this server is actually different: stdio as well as HTTP, one or many instances, writes, a human gate before a destructive call, and `doctor`.

**Two judgement calls to sanity check**

1. Coolify's read-only status is written as "documented as read-only today" with a link out, not as a fact. Their surface is moving fast and this line will age.
2. Other third-party servers get one neutral sentence and no table row. Naming them hands them a backlink from the most-read page in the repo.

Placed after "Safe to point at production", so the reader hits it once they know what the thing does and are asking why not the free built-in one.

https://claude.ai/code/session_016XwRu1P3sSrqzXk1j87chR