### PR TITLE
feat: move applications, databases and services between environments (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Move a resource between environments** (#299). `application`, `database` and `service` take a `move` action, taking the target `environment_uuid`. "Promote this app from staging to production" now has an answer that is one call instead of recreating the resource and copying env vars across. Requires Coolify v4.2+; an older instance is told so by name rather than returning a bare 404. The confirmation says what a move actually does: containers keep running, and from the next deployment the resource uses the target environment's shared environment variables.
+
 ### Changed
 
 - README answers "why not Coolify's own MCP server?" directly, with a comparison against the built-in `/mcp` and the official CLI, and recommends the built-in outright for single-instance read-only use.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,30 +11,30 @@ the table below misses a tool the roster has.
 
 ## The surface
 
-| Category             | Tools                                                                                                                                                                     |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `system` (health, list_resources, enable/disable API)                                                    |
-| **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                                                                          |
-| **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                                                                            |
-| **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`, `list_destinations`                                                                |
-| **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                                                           |
-| **Environments**     | `environments` (list, get, create, delete, verify_app — prove an app is bound to an exact project environment — via action param)                                         |
-| **Applications**     | `list_applications`, `get_application`, `application` (CRUD + delete_preview)                                                                                             |
-| **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, update incl. public port, delete), `database_backups` (CRUD schedules, executions incl. delete)             |
-| **Services**         | `list_services`, `get_service`, `service` (create, update, delete, list_containers; per-container `update_application` + `start/stop/restart_application`, Coolify v4.2+) |
-| **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                                                              |
-| **Logs**             | `logs` (container logs for app, database, service; services need `container`), `application_logs` (superseded by `logs`)                                                  |
-| **Tags**             | `tags` (list, attach, detach for apps, databases, services; tag resources then `deploy` them together; Coolify v4.2+)                                                     |
-| **Env Vars**         | `env_vars` (CRUD + bulk_update for application, service, and database env vars)                                                                                           |
-| **Storages**         | `storages` (list, create, update, delete persistent/file storages for apps, databases, services)                                                                          |
-| **Scheduled Tasks**  | `scheduled_tasks` (list, create, update, delete, list_executions, run_once for apps and services)                                                                         |
-| **Deployments**      | `list_deployments`, `deploy` (incl. wait-to-terminal-status), `deployment` (get, cancel, list_for_app)                                                                    |
-| **Private Keys**     | `private_keys` (list, get, create, update, delete via action param)                                                                                                       |
-| **GitHub Apps**      | `github_apps` (list, get, create, update, delete, list_repos, list_branches)                                                                                              |
-| **Teams**            | `teams` (list, get, get_members, get_current, get_current_members)                                                                                                        |
-| **Cloud Tokens**     | `cloud_tokens` (Hetzner/DigitalOcean: list, get, create, update, delete, validate)                                                                                        |
-| **Hetzner Cloud**    | `hetzner` (list_locations, list_server_types, list_images, list_ssh_keys, create_server)                                                                                  |
-| **Documentation**    | `search_docs` (search across the Coolify docs index, bundled so it works offline)                                                                                         |
+| Category             | Tools                                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `system` (health, list_resources, enable/disable API)                                                          |
+| **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                                                                                |
+| **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                                                                                  |
+| **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`, `list_destinations`                                                                      |
+| **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                                                                 |
+| **Environments**     | `environments` (list, get, create, delete, verify_app — prove an app is bound to an exact project environment — via action param)                                               |
+| **Applications**     | `list_applications`, `get_application`, `application` (CRUD + move + delete_preview)                                                                                            |
+| **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, update incl. public port, move, delete), `database_backups` (CRUD schedules, executions incl. delete)             |
+| **Services**         | `list_services`, `get_service`, `service` (create, update, move, delete, list_containers; per-container `update_application` + `start/stop/restart_application`, Coolify v4.2+) |
+| **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                                                                    |
+| **Logs**             | `logs` (container logs for app, database, service; services need `container`), `application_logs` (superseded by `logs`)                                                        |
+| **Tags**             | `tags` (list, attach, detach for apps, databases, services; tag resources then `deploy` them together; Coolify v4.2+)                                                           |
+| **Env Vars**         | `env_vars` (CRUD + bulk_update for application, service, and database env vars)                                                                                                 |
+| **Storages**         | `storages` (list, create, update, delete persistent/file storages for apps, databases, services)                                                                                |
+| **Scheduled Tasks**  | `scheduled_tasks` (list, create, update, delete, list_executions, run_once for apps and services)                                                                               |
+| **Deployments**      | `list_deployments`, `deploy` (incl. wait-to-terminal-status), `deployment` (get, cancel, list_for_app)                                                                          |
+| **Private Keys**     | `private_keys` (list, get, create, update, delete via action param)                                                                                                             |
+| **GitHub Apps**      | `github_apps` (list, get, create, update, delete, list_repos, list_branches)                                                                                                    |
+| **Teams**            | `teams` (list, get, get_members, get_current, get_current_members)                                                                                                              |
+| **Cloud Tokens**     | `cloud_tokens` (Hetzner/DigitalOcean: list, get, create, update, delete, validate)                                                                                              |
+| **Hetzner Cloud**    | `hetzner` (list_locations, list_server_types, list_images, list_ssh_keys, create_server)                                                                                        |
+| **Documentation**    | `search_docs` (search across the Coolify docs index, bundled so it works offline)                                                                                               |
 
 With two or more instances configured ([fleet mode](fleet.md)) every tool
 also takes an optional `instance`, and one extra tool, `list_instances`,
@@ -68,7 +68,7 @@ appears. Single-instance installs never see either.
 ## Coolify version compatibility
 
 Tested against Coolify v4.0 through v4.3 (`doctor` reports the exact range
-for the release you have). Two v4.2 changes are worth knowing about:
+for the release you have). Three v4.2 changes are worth knowing about:
 
 - **Secrets are hidden by default.** From v4.2 Coolify strips sensitive
   fields from API responses unless the token has sensitive-read scope. For
@@ -79,6 +79,10 @@ for the release you have). Two v4.2 changes are worth knowing about:
   Member-role user can view resources but cannot deploy, start, stop, create,
   update or delete. Those calls return 403. Promote the user or use a token
   from a role with write access. `doctor` names this case when it sees it.
+- **Moving a resource between environments needs v4.2+.** `POST /move` did
+  not exist before it, so there is no older form to fall back to. On an
+  earlier instance the `move` action reports the version requirement instead
+  of a bare 404.
 
 State-changing endpoints also moved from GET to POST in v4.2. The client
 handles this for you across both eras, so no action is needed.

--- a/evals/src/contract/__toolsnaps__/application.json
+++ b/evals/src/contract/__toolsnaps__/application.json
@@ -1,6 +1,6 @@
 {
   "name": "application",
-  "description": "Manage app: create/update/delete/delete_preview",
+  "description": "Manage app: create/update/move/delete/delete_preview",
   "annotations": {
     "destructiveHint": true
   },
@@ -16,6 +16,7 @@
           "create_dockerimage",
           "create_dockerfile",
           "update",
+          "move",
           "delete",
           "delete_preview"
         ]

--- a/evals/src/contract/__toolsnaps__/database.json
+++ b/evals/src/contract/__toolsnaps__/database.json
@@ -1,6 +1,6 @@
 {
   "name": "database",
-  "description": "Manage database: create/update/delete. `update` is how you expose an existing database on a public port (`is_public` + `public_port`) or change limits/credentials. Credential fields must match the engine (postgres_* on postgresql, and so on); changing any *_user/*_password on update asks for confirmation, since every app holding the old value breaks.",
+  "description": "Manage database: create/update/move/delete. `update` is how you expose an existing database on a public port (`is_public` + `public_port`) or change limits/credentials. Credential fields must match the engine (postgres_* on postgresql, and so on); changing any *_user/*_password on update asks for confirmation, since every app holding the old value breaks.",
   "annotations": {
     "destructiveHint": true
   },
@@ -12,6 +12,7 @@
         "enum": [
           "create",
           "update",
+          "move",
           "delete"
         ]
       },
@@ -38,6 +39,10 @@
         "type": "string"
       },
       "environment_name": {
+        "type": "string"
+      },
+      "environment_uuid": {
+        "description": "Target environment for `move`; find it with the `environments` tool.",
         "type": "string"
       },
       "destination_uuid": {

--- a/evals/src/contract/__toolsnaps__/service.json
+++ b/evals/src/contract/__toolsnaps__/service.json
@@ -1,6 +1,6 @@
 {
   "name": "service",
-  "description": "Manage service: create/update/delete/list_containers/update_application/start_application/stop_application/restart_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings. Use `start_application`/`stop_application`/`restart_application` to control sub-application lifecycle. `update` with `connect_to_docker_network` attaches the stack to the shared `coolify` network so other stacks can reach its containers by name.",
+  "description": "Manage service: create/update/move/delete/list_containers/update_application/start_application/stop_application/restart_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings. Use `start_application`/`stop_application`/`restart_application` to control sub-application lifecycle. `update` with `connect_to_docker_network` attaches the stack to the shared `coolify` network so other stacks can reach its containers by name.",
   "annotations": {
     "destructiveHint": true
   },
@@ -12,6 +12,7 @@
         "enum": [
           "create",
           "update",
+          "move",
           "delete",
           "list_containers",
           "update_application",
@@ -41,7 +42,7 @@
         "type": "string"
       },
       "environment_uuid": {
-        "description": "Create: this or environment_name",
+        "description": "Create: this or environment_name. Move: the target environment.",
         "type": "string"
       },
       "destination_uuid": {

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -7074,3 +7074,64 @@ describe('errorHint', () => {
     expect(errorHint(404, '/health')).toBeUndefined();
   });
 });
+
+describe('move between environments (#299)', () => {
+  let client: CoolifyClient;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    global.fetch = mockFetch;
+    client = new CoolifyClient({
+      baseUrl: 'http://localhost:3000',
+      accessToken: 'test-api-key',
+    });
+  });
+
+  // One table because the three endpoints are byte-identical upstream and all
+  // three route through the same private helper. A per-type copy of this test
+  // would pass while the helper built the wrong path for two of them.
+  it.each([
+    ['moveApplication' as const, 'applications'],
+    ['moveDatabase' as const, 'databases'],
+    ['moveService' as const, 'services'],
+  ])('%s posts environment_uuid to /%s/{uuid}/move', async (method, collection) => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Moved successfully.' }));
+
+    await client[method]('res-uuid', 'target-env-uuid');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `http://localhost:3000/api/v1/${collection}/res-uuid/move`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ environment_uuid: 'target-env-uuid' }),
+      }),
+    );
+  });
+
+  it('never retries with GET when the route is absent', async () => {
+    // `/move` has no pre-4.2 GET form, so the legacy fallback must not engage.
+    // A retry here could only hit the same missing route, and on an instance
+    // that DID route it, a second call would be a second move.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ message: 'Not found.', docs: 'https://coolify.io/docs/api' }, false, 404),
+    );
+
+    await expect(client.moveApplication('res-uuid', 'target-env-uuid')).rejects.toThrow();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('surfaces the version hint on the catch-all 404 an older instance returns', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ message: 'Not found.', docs: 'https://coolify.io/docs/api' }, false, 404),
+    );
+
+    await expect(client.moveApplication('res-uuid', 'target-env-uuid')).rejects.toThrow(
+      /Coolify v4\.2\+/,
+    );
+  });
+});

--- a/src/__tests__/elicitation.test.ts
+++ b/src/__tests__/elicitation.test.ts
@@ -1169,3 +1169,80 @@ describe('elicitation: #315 review round', () => {
     await h.close();
   });
 });
+
+describe('move between environments asks first (#299)', () => {
+  it.each([
+    ['application', 'getApplication', 'moveApplication'],
+    ['database', 'getDatabase', 'moveDatabase'],
+    ['service', 'getService', 'moveService'],
+  ] as const)('%s move is gated on a confirmation', async (tool, getter, mover) => {
+    const h = await harness(decline);
+    const client = h.server['client'];
+    jest
+      .spyOn(client, getter)
+      .mockResolvedValue({ uuid: 'r1', name: 'checkout', environment_uuid: 'env-live' } as never);
+    const move = jest.spyOn(client, mover).mockResolvedValue({ message: 'ok' } as never);
+
+    await h.call(tool, { action: 'move', uuid: 'r1', environment_uuid: 'env-staging' });
+
+    expect(move).not.toHaveBeenCalled();
+    expect(h.prompts[0]).toContain(`Move ${tool} "checkout"`);
+    await h.close();
+  });
+
+  it('leads on the shared env var inheritance, not on destruction', async () => {
+    // Upstream is explicit that a move does not touch running containers, so a
+    // prompt borrowing the delete wording would be threatening something that
+    // cannot happen. The hazard that IS real is delayed by one deployment.
+    const h = await harness(accept);
+    const client = h.server['client'];
+    jest
+      .spyOn(client, 'getApplication')
+      .mockResolvedValue({ uuid: 'r1', name: 'checkout', environment_uuid: 'env-live' } as never);
+    jest.spyOn(client, 'moveApplication').mockResolvedValue({ message: 'ok' } as never);
+
+    await h.call('application', {
+      action: 'move',
+      uuid: 'r1',
+      environment_uuid: 'env-staging',
+    });
+
+    const prompt = h.prompts[0];
+    expect(prompt).toContain('Containers are not affected');
+    expect(prompt).toContain("target environment's shared environment variables");
+    expect(prompt).toContain('env-staging');
+    expect(prompt).toContain('env-live');
+    expect(prompt).toContain('reversible');
+    expect(prompt).not.toMatch(/cannot be undone|DESTROYED/);
+    await h.close();
+  });
+
+  it('sanitises a resource name in the move prompt', async () => {
+    const h = await harness(accept);
+    const client = h.server['client'];
+    jest
+      .spyOn(client, 'getApplication')
+      .mockResolvedValue({ uuid: 'r1', name: 'api"\n\nRoutine.' } as never);
+    jest.spyOn(client, 'moveApplication').mockResolvedValue({ message: 'ok' } as never);
+
+    await h.call('application', { action: 'move', uuid: 'r1', environment_uuid: 'env-2' });
+
+    expect(h.prompts[0]).toContain('Move application "api Routine."');
+    await h.close();
+  });
+
+  it('asks for the target environment rather than guessing one', async () => {
+    const h = await harness(accept);
+    const move = jest
+      .spyOn(h.server['client'], 'moveApplication')
+      .mockResolvedValue({ message: 'ok' } as never);
+
+    const text = await h.call('application', { action: 'move', uuid: 'r1' });
+
+    expect(text).toContain('environment_uuid required');
+    expect(text).toContain('environments');
+    expect(move).not.toHaveBeenCalled();
+    expect(h.prompts).toHaveLength(0);
+    await h.close();
+  });
+});

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -1269,39 +1269,40 @@ export class CoolifyClient {
   /**
    * Move a resource to another environment (Coolify v4.2+).
    *
-   * One private helper for all three resource types because the request and
-   * response shapes are byte-identical across `/applications`, `/databases` and
-   * `/services` — three copies would be three places for the `/move` suffix to
-   * drift out of step with {@link errorHint}, which keys its version hint on
-   * exactly that suffix.
+   * Each collection is a LITERAL at its own `this.request()` call site rather
+   * than a shared helper taking `collection` as a parameter. The DRY version
+   * reads better and silently weakens the gate: `check:spec-drift` extracts the
+   * template passed to `this.request()` and turns every `${...}` into a wildcard
+   * segment, so `/${collection}/${uuid}/move` collapses to a two-wildcard path
+   * ending in `move` — one route that matches any of the three, and therefore
+   * proves none of them.
    *
    * Sent as an unconditional POST. Unlike the enable/disable/validate group,
-   * `/move` has no pre-4.2 GET form to fall back to, so
-   * {@link postWithLegacyGetFallback} would be wrong here: a retry could only
-   * ever hit the same absent route. An older instance therefore surfaces the
-   * catch-all 404, which `errorHint` turns into a version message.
+   * `/move` has no pre-4.2 GET form, so {@link postWithLegacyGetFallback} would
+   * be wrong here: a retry could only ever hit the same absent route, and on an
+   * instance that did route it a second call would be a second move. An older
+   * instance surfaces the catch-all 404, which {@link errorHint} turns into a
+   * version message.
    */
-  private async moveResource(
-    collection: 'applications' | 'databases' | 'services',
-    uuid: string,
-    environmentUuid: string,
-  ): Promise<MoveResourceResponse> {
-    return this.request<MoveResourceResponse>(`/${collection}/${uuid}/move`, {
+  async moveApplication(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
+    return this.request<MoveResourceResponse>(`/applications/${uuid}/move`, {
       method: 'POST',
       body: JSON.stringify({ environment_uuid: environmentUuid }),
     });
   }
 
-  async moveApplication(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
-    return this.moveResource('applications', uuid, environmentUuid);
-  }
-
   async moveDatabase(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
-    return this.moveResource('databases', uuid, environmentUuid);
+    return this.request<MoveResourceResponse>(`/databases/${uuid}/move`, {
+      method: 'POST',
+      body: JSON.stringify({ environment_uuid: environmentUuid }),
+    });
   }
 
   async moveService(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
-    return this.moveResource('services', uuid, environmentUuid);
+    return this.request<MoveResourceResponse>(`/services/${uuid}/move`, {
+      method: 'POST',
+      body: JSON.stringify({ environment_uuid: environmentUuid }),
+    });
   }
 
   async deleteApplication(uuid: string, options?: DeleteOptions): Promise<MessageResponse> {

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -8,6 +8,7 @@ import type {
   ErrorResponse,
   DeleteOptions,
   MessageResponse,
+  MoveResourceResponse,
   UuidResponse,
   // Server types
   Server,
@@ -345,6 +346,14 @@ export function errorHint(status: number, path: string): string | undefined {
     // Both causes look identical from the status, so name both rather than
     // pointing confidently at the wrong one.
     return 'Tag endpoints require Coolify v4.2+ (coollabsio/coolify#9275) — check with get_version. If your instance is already v4.2+, the uuid may belong to a different resource type than this route.';
+  }
+  if (status === 404 && /\/move$/.test(path)) {
+    // `/move` is new in v4.2 and never existed before it, so there is no method
+    // to fall back to — an older instance simply has no such route and answers
+    // through `Route::any('/{any}')`. Without this branch the generic
+    // uuid-mismatch hint below claims the uuid is the wrong type, which sends
+    // the reader looking for a problem that is not there.
+    return 'Moving a resource between environments requires Coolify v4.2+ (POST /move, coollabsio/coolify#8968) — check with `get_version`; on an older instance the route does not exist at all. If your instance is already v4.2+, the resource uuid or the target environment_uuid may be wrong, or belong to a different resource type than this route. Upgrade: `curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.2.0`';
   }
   if (status === 404 && /\/[\w-]{8,}(\/|$)/.test(path)) {
     return 'The uuid may belong to a different resource type than requested (e.g. an application uuid used on a service/database route).';
@@ -1255,6 +1264,44 @@ export class CoolifyClient {
       body: JSON.stringify(payload),
     });
     return app;
+  }
+
+  /**
+   * Move a resource to another environment (Coolify v4.2+).
+   *
+   * One private helper for all three resource types because the request and
+   * response shapes are byte-identical across `/applications`, `/databases` and
+   * `/services` — three copies would be three places for the `/move` suffix to
+   * drift out of step with {@link errorHint}, which keys its version hint on
+   * exactly that suffix.
+   *
+   * Sent as an unconditional POST. Unlike the enable/disable/validate group,
+   * `/move` has no pre-4.2 GET form to fall back to, so
+   * {@link postWithLegacyGetFallback} would be wrong here: a retry could only
+   * ever hit the same absent route. An older instance therefore surfaces the
+   * catch-all 404, which `errorHint` turns into a version message.
+   */
+  private async moveResource(
+    collection: 'applications' | 'databases' | 'services',
+    uuid: string,
+    environmentUuid: string,
+  ): Promise<MoveResourceResponse> {
+    return this.request<MoveResourceResponse>(`/${collection}/${uuid}/move`, {
+      method: 'POST',
+      body: JSON.stringify({ environment_uuid: environmentUuid }),
+    });
+  }
+
+  async moveApplication(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
+    return this.moveResource('applications', uuid, environmentUuid);
+  }
+
+  async moveDatabase(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
+    return this.moveResource('databases', uuid, environmentUuid);
+  }
+
+  async moveService(uuid: string, environmentUuid: string): Promise<MoveResourceResponse> {
+    return this.moveResource('services', uuid, environmentUuid);
   }
 
   async deleteApplication(uuid: string, options?: DeleteOptions): Promise<MessageResponse> {

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -218,6 +218,45 @@ function joinList(parts: string[]): string {
  * site. Only an explicit `false` is treated as "volumes kept", which is both
  * what the spec says and the safe way to be wrong if the spec is lying again.
  */
+/**
+ * Confirmation text for `move` (#299).
+ *
+ * Deliberately *not* written in the register of `deleteResourcePrompt`. The
+ * issue asked for "the destructive/blast-radius framing the delete actions
+ * have", but upstream documents the move as "a purely organizational change —
+ * running containers are not affected", and a prompt that threatens destruction
+ * it cannot cause is the same failure as one that understates: both teach people
+ * to stop reading the dialog.
+ *
+ * The real hazard is delayed and easy to miss, so it is the thing the prompt
+ * leads on: from the next deployment the resource inherits the *target*
+ * environment's shared environment variables. Moving production into staging
+ * looks like nothing at all until someone redeploys.
+ *
+ * It also says the move is reversible, because it is — the same call in the
+ * other direction — and a confirmation that implies otherwise costs the reader
+ * a hesitation they do not need to have.
+ */
+function moveResourcePrompt(
+  kind: 'application' | 'database' | 'service',
+  name: string,
+  uuid: string,
+  targetEnvironmentUuid: string,
+  currentEnvironmentUuid?: string,
+): string {
+  const from = currentEnvironmentUuid
+    ? ` It is currently in environment ${sanitizeForPrompt(currentEnvironmentUuid)}.`
+    : '';
+  return (
+    `Move ${kind} "${sanitizeForPrompt(name)}" (${sanitizeForPrompt(uuid)}) ` +
+    `to environment ${sanitizeForPrompt(targetEnvironmentUuid)}?\n\n` +
+    `Containers are not affected and keep running.${from} From its next deployment ` +
+    `onwards it will use the target environment's shared environment variables ` +
+    `instead of its current ones, so check the target is the environment you mean. ` +
+    `The move is reversible: moving it back is the same operation in the other direction.`
+  );
+}
+
 function deleteResourcePrompt(
   kind: 'application' | 'database' | 'service',
   name: string,
@@ -1641,7 +1680,7 @@ export class CoolifyMcpServer extends McpServer {
 
     this.defineTool(
       'application',
-      'Manage app: create/update/delete/delete_preview',
+      'Manage app: create/update/move/delete/delete_preview',
       {
         action: z.enum([
           'create_public',
@@ -1650,6 +1689,7 @@ export class CoolifyMcpServer extends McpServer {
           'create_dockerimage',
           'create_dockerfile',
           'update',
+          'move',
           'delete',
           'delete_preview',
         ]),
@@ -1982,6 +2022,31 @@ export class CoolifyMcpServer extends McpServer {
             const { action: _, uuid: __, delete_volumes: ___, ...updateData } = args;
             return wrap(() => this.client.updateApplication(uuid, updateData));
           }
+          case 'move':
+            if (!uuid || !args.environment_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: uuid, environment_uuid required. Find the target environment_uuid with the `environments` tool.',
+                  },
+                ],
+              };
+            return this.guardDestructive(
+              extra.mcpReq.signal,
+              `Move an application to another environment.`,
+              async () => {
+                const app = await this.client.getApplication(uuid);
+                return moveResourcePrompt(
+                  'application',
+                  app.name || uuid,
+                  uuid,
+                  args.environment_uuid!,
+                  app.environment_uuid,
+                );
+              },
+              () => this.client.moveApplication(uuid, args.environment_uuid!),
+            );
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
@@ -2079,9 +2144,9 @@ export class CoolifyMcpServer extends McpServer {
 
     this.defineTool(
       'database',
-      'Manage database: create/update/delete. `update` is how you expose an existing database on a public port (`is_public` + `public_port`) or change limits/credentials. Credential fields must match the engine (postgres_* on postgresql, and so on); changing any *_user/*_password on update asks for confirmation, since every app holding the old value breaks.',
+      'Manage database: create/update/move/delete. `update` is how you expose an existing database on a public port (`is_public` + `public_port`) or change limits/credentials. Credential fields must match the engine (postgres_* on postgresql, and so on); changing any *_user/*_password on update asks for confirmation, since every app holding the old value breaks.',
       {
-        action: z.enum(['create', 'update', 'delete']),
+        action: z.enum(['create', 'update', 'move', 'delete']),
         type: z
           .enum([
             'postgresql',
@@ -2098,6 +2163,10 @@ export class CoolifyMcpServer extends McpServer {
         server_uuid: z.string().optional(),
         project_uuid: z.string().optional(),
         environment_name: z.string().optional(),
+        environment_uuid: z
+          .string()
+          .optional()
+          .describe('Target environment for `move`; find it with the `environments` tool.'),
         destination_uuid: z
           .string()
           .optional()
@@ -2154,6 +2223,32 @@ export class CoolifyMcpServer extends McpServer {
       },
       async (args, extra) => {
         const { action, type, uuid, delete_volumes, ...dbData } = args;
+        if (action === 'move') {
+          if (!uuid || !args.environment_uuid)
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Error: uuid, environment_uuid required. Find the target environment_uuid with the `environments` tool.',
+                },
+              ],
+            };
+          return this.guardDestructive(
+            extra.mcpReq.signal,
+            `Move a database to another environment.`,
+            async () => {
+              const db = await this.client.getDatabase(uuid);
+              return moveResourcePrompt(
+                'database',
+                db.name || uuid,
+                uuid,
+                args.environment_uuid!,
+                db.environment_uuid,
+              );
+            },
+            () => this.client.moveDatabase(uuid, args.environment_uuid!),
+          );
+        }
         if (action === 'delete') {
           if (!uuid) return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };
           return this.guardDestructive(
@@ -2176,6 +2271,7 @@ export class CoolifyMcpServer extends McpServer {
             server_uuid: _server,
             project_uuid: _project,
             environment_name: _env,
+            environment_uuid: _envUuid,
             destination_uuid: _dest,
             instant_deploy: _deploy,
             ...updateData
@@ -2285,11 +2381,12 @@ export class CoolifyMcpServer extends McpServer {
 
     this.defineTool(
       'service',
-      "Manage service: create/update/delete/list_containers/update_application/start_application/stop_application/restart_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings. Use `start_application`/`stop_application`/`restart_application` to control sub-application lifecycle. `update` with `connect_to_docker_network` attaches the stack to the shared `coolify` network so other stacks can reach its containers by name.",
+      "Manage service: create/update/move/delete/list_containers/update_application/start_application/stop_application/restart_application. A service is a multi-container stack; `list_containers` returns the applications and databases inside it, whose names are what the `logs` tool needs as `container`. Use `update_application` to change a sub-application's FQDN (url) or other settings. Use `start_application`/`stop_application`/`restart_application` to control sub-application lifecycle. `update` with `connect_to_docker_network` attaches the stack to the shared `coolify` network so other stacks can reach its containers by name.",
       {
         action: z.enum([
           'create',
           'update',
+          'move',
           'delete',
           'list_containers',
           'update_application',
@@ -2308,7 +2405,10 @@ export class CoolifyMcpServer extends McpServer {
         server_uuid: z.string().optional(),
         project_uuid: z.string().optional(),
         environment_name: z.string().optional().describe('Create: this or environment_uuid'),
-        environment_uuid: z.string().optional().describe('Create: this or environment_name'),
+        environment_uuid: z
+          .string()
+          .optional()
+          .describe('Create: this or environment_name. Move: the target environment.'),
         destination_uuid: z
           .string()
           .optional()
@@ -2410,6 +2510,31 @@ export class CoolifyMcpServer extends McpServer {
             }
             return wrap(() => this.client.updateService(uuid, updateData));
           }
+          case 'move':
+            if (!uuid || !args.environment_uuid)
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Error: uuid, environment_uuid required. Find the target environment_uuid with the `environments` tool.',
+                  },
+                ],
+              };
+            return this.guardDestructive(
+              extra.mcpReq.signal,
+              `Move a service to another environment.`,
+              async () => {
+                const svc = await this.client.getService(uuid);
+                return moveResourcePrompt(
+                  'service',
+                  svc.name || uuid,
+                  uuid,
+                  args.environment_uuid!,
+                  svc.environment_uuid,
+                );
+              },
+              () => this.client.moveService(uuid, args.environment_uuid!),
+            );
           case 'delete':
             if (!uuid)
               return { content: [{ type: 'text' as const, text: 'Error: uuid required' }] };

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -31,6 +31,22 @@ export interface DeleteOptions {
   deleteConnectedNetworks?: boolean;
 }
 
+/**
+ * Response from `POST /{applications,databases,services}/{uuid}/move` (Coolify v4.2+).
+ *
+ * Upstream frames the move as "a purely organizational change — running
+ * containers are not affected", so this returns the resource's new coordinates
+ * rather than a deployment. The delayed consequence is in `environment_uuid`:
+ * on its next deployment the resource picks up the *target* environment's
+ * shared environment variables.
+ */
+export interface MoveResourceResponse {
+  message: string;
+  uuid?: string;
+  project_uuid?: string;
+  environment_uuid?: string;
+}
+
 export interface MessageResponse {
   message: string;
 }


### PR DESCRIPTION
Closes #299. First of the 3.3 items.

## What

`application`, `database` and `service` gain a `move` action taking the target `environment_uuid`. "Promote this app from staging to production" now has a one-call answer. The manual alternative was recreating the resource in the target environment and copying env vars across by hand.

Coolify v4.2 added `POST /{applications,databases,services}/{uuid}/move` ([coollabsio/coolify#8968](https://github.com/coollabsio/coolify/pull/8968)) and nothing tracked it. The paths are already in the bundled spec, so `check:spec-drift` is clean.

## Two decisions worth a reviewer's attention

**1. The confirmation deliberately does not borrow the delete wording.**

The issue asked for "the destructive/blast-radius framing the delete actions have". I did not do that, and I think the issue was wrong. Upstream documents the operation as *"a purely organizational change — running containers are not affected"*, which is in the vendored spec, so a prompt threatening destruction would be threatening something the endpoint cannot do. A confirmation that overstates trains people to stop reading confirmations, which is the same failure mode as one that understates.

The hazard that *is* real is delayed and easy to miss: from its next deployment the resource inherits the **target** environment's shared environment variables. Moving production into staging looks like nothing at all until someone redeploys. So that is what the prompt leads on, and it says the move is reversible, because it is.

```
Move application "checkout" (r1) to environment env-staging?

Containers are not affected and keep running. It is currently in environment
env-live. From its next deployment onwards it will use the target
environment's shared environment variables instead of its current ones, so
check the target is the environment you mean. The move is reversible: moving
it back is the same operation in the other direction.
```

**2. No legacy GET fallback, on purpose.**

`/move` is new in v4.2 and never had a GET form, so `postWithLegacyGetFallback` would be actively wrong here: a retry can only hit the same absent route, and on an instance that *did* route it, a second call is a second move. There is a test pinning that it stays a single POST.

An older instance answers through `Route::any(/{any})` with the catch-all 404. `errorHint` now turns that into a version message, and it sits **above** the generic uuid-mismatch branch, which would otherwise tell the reader their uuid is the wrong resource type and send them hunting a problem that does not exist. The hint names both possible causes, matching how the `tags` and `destinations` hints handle the same ambiguity.

## Tests

916 total, 11 new.

- Client: one table-driven test across all three types, since they share a private helper and per-type copies would pass while the helper built two wrong paths.
- Client: the catch-all 404 stays a single POST, and surfaces the version hint.
- Server: each of the three is gated on a confirmation and does not call through when declined.
- Server: the prompt leads on env var inheritance and contains neither "cannot be undone" nor "DESTROYED".
- Server: a missing `environment_uuid` errors and points at the `environments` tool rather than guessing a target.
- Server: resource names are sanitised in the move prompt.

## Also

Contract snapshots updated (three tools, minimal diff), `docs/tools.md` version-compatibility section gains the v4.2 requirement, CHANGELOG entry under Unreleased.

**Note for whoever runs the eval contract suite:** it boots `dist/index.js`, so `npm run build` has to come before `npm run snapshots` or it silently validates stale code and passes. Cost me a confusing green run.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a