### PR TITLE
feat: scheduled volume backups on the storages tool (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Move a resource between environments** (#299). `application`, `database` and `service` take a `move` action, taking the target `environment_uuid`. "Promote this app from staging to production" now has an answer that is one call instead of recreating the resource and copying env vars across. Requires Coolify v4.2+; an older instance is told so by name rather than returning a bare 404. The confirmation says what a move actually does: containers keep running, and from the next deployment the resource uses the target environment's shared environment variables.
+- **Scheduled volume backups** (#305). `storages` gains `backup_set`, `backup_delete` and `backup_run` for application, database and service volumes (Coolify v4.2+). `backup_delete` removes the archives as well as the schedule, so it asks first, and points at `backup_set` with `enabled: false` for the "stop backing up but keep what I have" case. Note two upstream limits: Coolify has no endpoint to read a schedule back, so `find_issues` still cannot flag a volume with no backup; and `backup_set` replaces the whole schedule rather than merging, so omitted fields revert to their defaults.
 
 ### Changed
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,30 +11,30 @@ the table below misses a tool the roster has.
 
 ## The surface
 
-| Category             | Tools                                                                                                                                                                           |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `system` (health, list_resources, enable/disable API)                                                          |
-| **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                                                                                |
-| **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                                                                                  |
-| **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`, `list_destinations`                                                                      |
-| **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                                                                 |
-| **Environments**     | `environments` (list, get, create, delete, verify_app — prove an app is bound to an exact project environment — via action param)                                               |
-| **Applications**     | `list_applications`, `get_application`, `application` (CRUD + move + delete_preview)                                                                                            |
-| **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, update incl. public port, move, delete), `database_backups` (CRUD schedules, executions incl. delete)             |
-| **Services**         | `list_services`, `get_service`, `service` (create, update, move, delete, list_containers; per-container `update_application` + `start/stop/restart_application`, Coolify v4.2+) |
-| **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                                                                    |
-| **Logs**             | `logs` (container logs for app, database, service; services need `container`), `application_logs` (superseded by `logs`)                                                        |
-| **Tags**             | `tags` (list, attach, detach for apps, databases, services; tag resources then `deploy` them together; Coolify v4.2+)                                                           |
-| **Env Vars**         | `env_vars` (CRUD + bulk_update for application, service, and database env vars)                                                                                                 |
-| **Storages**         | `storages` (list, create, update, delete persistent/file storages for apps, databases, services)                                                                                |
-| **Scheduled Tasks**  | `scheduled_tasks` (list, create, update, delete, list_executions, run_once for apps and services)                                                                               |
-| **Deployments**      | `list_deployments`, `deploy` (incl. wait-to-terminal-status), `deployment` (get, cancel, list_for_app)                                                                          |
-| **Private Keys**     | `private_keys` (list, get, create, update, delete via action param)                                                                                                             |
-| **GitHub Apps**      | `github_apps` (list, get, create, update, delete, list_repos, list_branches)                                                                                                    |
-| **Teams**            | `teams` (list, get, get_members, get_current, get_current_members)                                                                                                              |
-| **Cloud Tokens**     | `cloud_tokens` (Hetzner/DigitalOcean: list, get, create, update, delete, validate)                                                                                              |
-| **Hetzner Cloud**    | `hetzner` (list_locations, list_server_types, list_images, list_ssh_keys, create_server)                                                                                        |
-| **Documentation**    | `search_docs` (search across the Coolify docs index, bundled so it works offline)                                                                                               |
+| Category             | Tools                                                                                                                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Infrastructure**   | `get_infrastructure_overview`, `get_mcp_version`, `get_version`, `system` (health, list_resources, enable/disable API)                                                              |
+| **Diagnostics**      | `diagnose_app`, `diagnose_server`, `find_issues`                                                                                                                                    |
+| **Batch Operations** | `restart_project_apps`, `bulk_env_update`, `stop_all_apps`, `redeploy_project`                                                                                                      |
+| **Servers**          | `list_servers`, `get_server`, `validate_server`, `server_resources`, `server_domains`, `list_destinations`                                                                          |
+| **Projects**         | `projects` (list, get, create, update, delete via action param)                                                                                                                     |
+| **Environments**     | `environments` (list, get, create, delete, verify_app — prove an app is bound to an exact project environment — via action param)                                                   |
+| **Applications**     | `list_applications`, `get_application`, `application` (CRUD + move + delete_preview)                                                                                                |
+| **Databases**        | `list_databases`, `get_database`, `database` (create 8 types, update incl. public port, move, delete), `database_backups` (CRUD schedules, executions incl. delete)                 |
+| **Services**         | `list_services`, `get_service`, `service` (create, update, move, delete, list_containers; per-container `update_application` + `start/stop/restart_application`, Coolify v4.2+)     |
+| **Control**          | `control` (start/stop/restart for apps, databases, services)                                                                                                                        |
+| **Logs**             | `logs` (container logs for app, database, service; services need `container`), `application_logs` (superseded by `logs`)                                                            |
+| **Tags**             | `tags` (list, attach, detach for apps, databases, services; tag resources then `deploy` them together; Coolify v4.2+)                                                               |
+| **Env Vars**         | `env_vars` (CRUD + bulk_update for application, service, and database env vars)                                                                                                     |
+| **Storages**         | `storages` (list, create, update, delete persistent/file storages for apps, databases, services; `backup_set`/`backup_delete`/`backup_run` scheduled volume backups, Coolify v4.2+) |
+| **Scheduled Tasks**  | `scheduled_tasks` (list, create, update, delete, list_executions, run_once for apps and services)                                                                                   |
+| **Deployments**      | `list_deployments`, `deploy` (incl. wait-to-terminal-status), `deployment` (get, cancel, list_for_app)                                                                              |
+| **Private Keys**     | `private_keys` (list, get, create, update, delete via action param)                                                                                                                 |
+| **GitHub Apps**      | `github_apps` (list, get, create, update, delete, list_repos, list_branches)                                                                                                        |
+| **Teams**            | `teams` (list, get, get_members, get_current, get_current_members)                                                                                                                  |
+| **Cloud Tokens**     | `cloud_tokens` (Hetzner/DigitalOcean: list, get, create, update, delete, validate)                                                                                                  |
+| **Hetzner Cloud**    | `hetzner` (list_locations, list_server_types, list_images, list_ssh_keys, create_server)                                                                                            |
+| **Documentation**    | `search_docs` (search across the Coolify docs index, bundled so it works offline)                                                                                                   |
 
 With two or more instances configured ([fleet mode](fleet.md)) every tool
 also takes an optional `instance`, and one extra tool, `list_instances`,
@@ -86,6 +86,29 @@ for the release you have). Three v4.2 changes are worth knowing about:
 
 State-changing endpoints also moved from GET to POST in v4.2. The client
 handles this for you across both eras, so no action is needed.
+
+## Volume backup schedules
+
+`storages` can put a Coolify v4.2+ backup schedule on a persistent volume or
+directory storage, delete one, and queue an immediate run. Two things about it
+are upstream constraints rather than choices made here, and both change how you
+should call it.
+
+**You cannot read a schedule back.** Coolify exposes no `GET` for a volume
+backup schedule, and the storages listing returns the volume without its backup
+relation. So "is this volume backed up, and how often?" has no answer through
+the API, and `find_issues` cannot flag unprotected volumes. If that matters to
+you, it needs an upstream endpoint first.
+
+**`backup_set` replaces, it does not merge.** The upstream request schema marks
+only `frequency` as required and gives every other field a default, so a call
+that omits `save_s3` sets it to `false` rather than leaving it alone. Combined
+with the absent read endpoint, there is no safe read-modify-write: send the
+whole schedule you want every time.
+
+`backup_delete` deletes the local and S3 archives along with the schedule, so it
+asks for confirmation. To stop future backups while keeping the ones you have,
+use `backup_set` with `enabled: false` instead.
 
 ## Gotchas the tools already handle
 

--- a/evals/src/contract/__toolsnaps__/storages.json
+++ b/evals/src/contract/__toolsnaps__/storages.json
@@ -1,6 +1,6 @@
 {
   "name": "storages",
-  "description": "Manage persistent/file storages for app, database, or service: list/create/update/delete",
+  "description": "Manage persistent/file storages for app, database, or service: list/create/update/delete, plus volume backups (v4.2+): backup_set/backup_delete/backup_run. backup_set REPLACES the schedule — omitted fields revert to defaults and there is no read-back endpoint, so send it whole. backup_delete deletes the archives too.",
   "annotations": {
     "destructiveHint": true
   },
@@ -21,7 +21,10 @@
           "list",
           "create",
           "update",
-          "delete"
+          "delete",
+          "backup_set",
+          "backup_delete",
+          "backup_run"
         ]
       },
       "uuid": {
@@ -29,6 +32,47 @@
       },
       "storage_uuid": {
         "type": "string"
+      },
+      "frequency": {
+        "description": "backup_set: cron, e.g. `0 2 * * *`. Required.",
+        "type": "string"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "save_s3": {
+        "type": "boolean"
+      },
+      "disable_local_backup": {
+        "type": "boolean"
+      },
+      "stop_during_backup": {
+        "description": "Downtime: stops the container.",
+        "type": "boolean"
+      },
+      "s3_storage_uuid": {
+        "type": "string"
+      },
+      "retention_amount_locally": {
+        "type": "number"
+      },
+      "retention_days_locally": {
+        "type": "number"
+      },
+      "retention_max_storage_locally": {
+        "type": "number"
+      },
+      "retention_amount_s3": {
+        "type": "number"
+      },
+      "retention_days_s3": {
+        "type": "number"
+      },
+      "retention_max_storage_s3": {
+        "type": "number"
+      },
+      "timeout": {
+        "type": "number"
       },
       "type": {
         "type": "string",

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -7234,8 +7234,6 @@ describe('volume backup schedules (#305)', () => {
 });
 
 describe('volume backups on a pre-4.2 instance (#305)', () => {
-  const catchAll = { message: 'Not found.', docs: 'https://coolify.io/docs/api' };
-
   it.each([
     '/applications/app-1/storages/stor-1/backups',
     '/databases/db-1/storages/stor-1/backups',

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -7135,3 +7135,100 @@ describe('move between environments (#299)', () => {
     );
   });
 });
+
+describe('volume backup schedules (#305)', () => {
+  let client: CoolifyClient;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    global.fetch = mockFetch;
+    client = new CoolifyClient({
+      baseUrl: 'http://localhost:3000',
+      accessToken: 'test-api-key',
+    });
+  });
+
+  it.each([
+    ['setApplicationStorageBackup' as const, 'applications'],
+    ['setDatabaseStorageBackup' as const, 'databases'],
+    ['setServiceStorageBackup' as const, 'services'],
+  ])('%s PUTs the schedule to /%s/{uuid}/storages/{storage}/backups', async (m, collection) => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'b1', message: 'ok' }));
+
+    await client[m]('res-1', 'stor-1', { frequency: '0 2 * * *' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `http://localhost:3000/api/v1/${collection}/res-1/storages/stor-1/backups`,
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+
+  it.each([
+    ['deleteApplicationStorageBackup' as const, 'applications'],
+    ['deleteDatabaseStorageBackup' as const, 'databases'],
+    ['deleteServiceStorageBackup' as const, 'services'],
+  ])('%s DELETEs /%s/{uuid}/storages/{storage}/backups', async (m, collection) => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'deleted' }));
+
+    await client[m]('res-1', 'stor-1');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `http://localhost:3000/api/v1/${collection}/res-1/storages/stor-1/backups`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it.each([
+    ['runApplicationStorageBackup' as const, 'applications'],
+    ['runDatabaseStorageBackup' as const, 'databases'],
+    ['runServiceStorageBackup' as const, 'services'],
+  ])('%s POSTs /%s/{uuid}/storages/{storage}/backups/run', async (m, collection) => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'queued' }));
+
+    await client[m]('res-1', 'stor-1');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `http://localhost:3000/api/v1/${collection}/res-1/storages/stor-1/backups/run`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('sends false and zero rather than dropping them', async () => {
+    // The upstream schema defaults `enabled` to true and the retention numbers
+    // to non-zero, so a request builder that strips falsy values would silently
+    // turn "disabled, keep nothing locally" into "enabled, keep 7". Only
+    // `undefined` may be dropped.
+    mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'b1', message: 'ok' }));
+
+    await client.setApplicationStorageBackup('res-1', 'stor-1', {
+      frequency: '0 2 * * *',
+      enabled: false,
+      save_s3: false,
+      retention_amount_locally: 0,
+      s3_storage_uuid: null,
+    });
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body) as Record<
+      string,
+      unknown
+    >;
+    expect(body).toEqual({
+      frequency: '0 2 * * *',
+      enabled: false,
+      save_s3: false,
+      retention_amount_locally: 0,
+      s3_storage_uuid: null,
+    });
+  });
+
+  it('omits unset fields entirely rather than sending null for them', async () => {
+    // Omission means "take Coolify's default"; an explicit null would mean
+    // something different on `s3_storage_uuid`, the one nullable field.
+    mockFetch.mockResolvedValueOnce(mockResponse({ uuid: 'b1', message: 'ok' }));
+
+    await client.setApplicationStorageBackup('res-1', 'stor-1', { frequency: '@daily' });
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body) as object;
+    expect(body).toEqual({ frequency: '@daily' });
+  });
+});

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -7232,3 +7232,32 @@ describe('volume backup schedules (#305)', () => {
     expect(body).toEqual({ frequency: '@daily' });
   });
 });
+
+describe('volume backups on a pre-4.2 instance (#305)', () => {
+  const catchAll = { message: 'Not found.', docs: 'https://coolify.io/docs/api' };
+
+  it.each([
+    '/applications/app-1/storages/stor-1/backups',
+    '/databases/db-1/storages/stor-1/backups',
+    '/services/svc-1/storages/stor-1/backups/run',
+  ])('names the version requirement for %s', (path) => {
+    // Found by an end-to-end smoke test against a backend behaving like 4.1.2:
+    // without this the generic uuid-mismatch hint fired and told the user their
+    // uuid was the wrong resource type, sending them after a problem that does
+    // not exist. Same failure `/move` had.
+    expect(errorHint(404, path)).toMatch(/v4\.2\+/);
+  });
+
+  it('does NOT claim v4.2 for the long-standing database dump schedules', () => {
+    // `/databases/{uuid}/backups` is `database_backups`, which works on 4.0.
+    // The `/storages/` segment is the whole difference.
+    const hint = errorHint(404, '/databases/db-1/backups');
+    expect(hint ?? '').not.toMatch(/Volume backup schedules require/);
+  });
+
+  it('mentions database_backups so the two are not confused', () => {
+    expect(errorHint(404, '/applications/app-1/storages/stor-1/backups')).toContain(
+      'database_backups',
+    );
+  });
+});

--- a/src/__tests__/elicitation.test.ts
+++ b/src/__tests__/elicitation.test.ts
@@ -1246,3 +1246,113 @@ describe('move between environments asks first (#299)', () => {
     await h.close();
   });
 });
+
+describe('volume backup schedules (#305)', () => {
+  it('backup_delete asks first, and says the archives go too', async () => {
+    // Upstream deletes the schedule AND its local and S3 archives. "Stop backing
+    // up" and "throw away every backup I have" are different decisions, so the
+    // prompt has to name which one is happening and offer the other.
+    const h = await harness(decline);
+    const del = jest
+      .spyOn(h.server['client'], 'deleteApplicationStorageBackup')
+      .mockResolvedValue({ message: 'gone' } as never);
+
+    await h.call('storages', {
+      resource: 'application',
+      action: 'backup_delete',
+      uuid: 'app-1',
+      storage_uuid: 'stor-1',
+    });
+
+    expect(del).not.toHaveBeenCalled();
+    const prompt = h.prompts[0];
+    expect(prompt).toContain('archives are deleted with it');
+    expect(prompt).toContain('backup_set');
+    expect(prompt).toContain('enabled: false');
+    expect(prompt).toContain('cannot be undone');
+  });
+
+  it.each([
+    ['database', 'deleteDatabaseStorageBackup'],
+    ['service', 'deleteServiceStorageBackup'],
+  ] as const)('backup_delete is guarded for %s too', async (resource, method) => {
+    const h = await harness(decline);
+    const del = jest.spyOn(h.server['client'], method).mockResolvedValue({ message: 'x' } as never);
+
+    await h.call('storages', {
+      resource,
+      action: 'backup_delete',
+      uuid: 'r-1',
+      storage_uuid: 'stor-1',
+    });
+
+    expect(del).not.toHaveBeenCalled();
+    expect(h.prompts).toHaveLength(1);
+    await h.close();
+  });
+
+  it('backup_set and backup_run are not gated, because neither discards data', async () => {
+    const h = await harness(accept);
+    const set = jest
+      .spyOn(h.server['client'], 'setApplicationStorageBackup')
+      .mockResolvedValue({ uuid: 'b1', message: 'ok' } as never);
+    const run = jest
+      .spyOn(h.server['client'], 'runApplicationStorageBackup')
+      .mockResolvedValue({ message: 'queued' } as never);
+
+    await h.call('storages', {
+      resource: 'application',
+      action: 'backup_set',
+      uuid: 'app-1',
+      storage_uuid: 'stor-1',
+      frequency: '0 2 * * *',
+    });
+    await h.call('storages', {
+      resource: 'application',
+      action: 'backup_run',
+      uuid: 'app-1',
+      storage_uuid: 'stor-1',
+    });
+
+    expect(set).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
+    expect(h.prompts).toHaveLength(0);
+    await h.close();
+  });
+
+  it('backup_set refuses without a frequency and explains the replace semantics', async () => {
+    const h = await harness(accept);
+    const set = jest
+      .spyOn(h.server['client'], 'setApplicationStorageBackup')
+      .mockResolvedValue({ uuid: 'b1', message: 'ok' } as never);
+
+    const text = await h.call('storages', {
+      resource: 'application',
+      action: 'backup_set',
+      uuid: 'app-1',
+      storage_uuid: 'stor-1',
+    });
+
+    expect(text).toContain('frequency required');
+    expect(text).toContain('replaces the whole schedule');
+    expect(set).not.toHaveBeenCalled();
+    await h.close();
+  });
+
+  it('every backup action needs a storage_uuid', async () => {
+    const h = await harness(accept);
+
+    for (const action of ['backup_set', 'backup_delete', 'backup_run']) {
+      const text = await h.call('storages', {
+        resource: 'application',
+        action,
+        uuid: 'app-1',
+        frequency: '@daily',
+      });
+      expect(text).toContain('storage_uuid required');
+    }
+
+    expect(h.prompts).toHaveLength(0);
+    await h.close();
+  });
+});

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -357,6 +357,17 @@ export function errorHint(status: number, path: string): string | undefined {
     // the reader looking for a problem that is not there.
     return 'Moving a resource between environments requires Coolify v4.2+ (POST /move, coollabsio/coolify#8968) — check with `get_version`; on an older instance the route does not exist at all. If your instance is already v4.2+, the resource uuid or the target environment_uuid may be wrong, or belong to a different resource type than this route. Upgrade: `curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.2.0`';
   }
+  if (status === 404 && /\/storages\/[\w-]+\/backups(\/run)?$/.test(path)) {
+    // Volume backup schedules are v4.2+ and simply absent before it, so an
+    // older instance answers through the routing catch-all. Without this the
+    // generic uuid-mismatch branch below claims the uuid is the wrong resource
+    // type, which is the same misleading message `/move` used to give.
+    //
+    // The `/storages/` segment is what keeps this off `/databases/{uuid}/backups`
+    // — that is the long-standing database dump schedule, which exists on 4.0
+    // and must not be told it needs 4.2.
+    return 'Volume backup schedules require Coolify v4.2+ (coollabsio/coolify volume backups) — check with `get_version`; on an older instance the route does not exist at all. If your instance is already v4.2+, the resource uuid or storage_uuid may be wrong. Note this is different from `database_backups`, which schedules database dumps and works on older versions. Upgrade: `curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.2.0`';
+  }
   if (status === 404 && /\/[\w-]{8,}(\/|$)/.test(path)) {
     return 'The uuid may belong to a different resource type than requested (e.g. an application uuid used on a service/database route).';
   }

--- a/src/lib/coolify-client.ts
+++ b/src/lib/coolify-client.ts
@@ -9,6 +9,8 @@ import type {
   DeleteOptions,
   MessageResponse,
   MoveResourceResponse,
+  VolumeBackupScheduleRequest,
+  VolumeBackupScheduleResponse,
   UuidResponse,
   // Server types
   Server,
@@ -2106,6 +2108,97 @@ export class CoolifyClient {
     return this.request<MessageResponse>(`/applications/${uuid}/storages`, {
       method: 'PATCH',
       body: JSON.stringify(data),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Volume backup schedules (Coolify v4.2+, #305)
+  //
+  // Written out per resource type with the collection as a LITERAL, rather than
+  // shared through one helper taking `collection` as a parameter. The DRY version
+  // reads better and is wrong: `check:spec-drift` extracts the template passed to
+  // `this.request()` and turns every `${...}` into a wildcard segment, so
+  // `/${collection}/${uuid}/storages/${storageUuid}/backups` collapses to
+  // `/*/*/storages/*/backups` — one route that matches any of the three, proving
+  // none of them. Three literal call sites are three checked routes.
+  //
+  // There is deliberately no `get`/`list` here. Upstream's VolumeBackupsController
+  // defines only PUT, DELETE and the run POST — no GET route for a schedule exists
+  // — and the storages listing returns the raw volume models without the backup
+  // relation loaded. "Does this volume have a backup?" is unanswerable through the
+  // Coolify API today, not merely unimplemented here.
+  // ---------------------------------------------------------------------------
+
+  async setApplicationStorageBackup(
+    uuid: string,
+    storageUuid: string,
+    schedule: VolumeBackupScheduleRequest,
+  ): Promise<VolumeBackupScheduleResponse> {
+    return this.request<VolumeBackupScheduleResponse>(
+      `/applications/${uuid}/storages/${storageUuid}/backups`,
+      { method: 'PUT', body: JSON.stringify(cleanRequestData(schedule)) },
+    );
+  }
+
+  async setDatabaseStorageBackup(
+    uuid: string,
+    storageUuid: string,
+    schedule: VolumeBackupScheduleRequest,
+  ): Promise<VolumeBackupScheduleResponse> {
+    return this.request<VolumeBackupScheduleResponse>(
+      `/databases/${uuid}/storages/${storageUuid}/backups`,
+      { method: 'PUT', body: JSON.stringify(cleanRequestData(schedule)) },
+    );
+  }
+
+  async setServiceStorageBackup(
+    uuid: string,
+    storageUuid: string,
+    schedule: VolumeBackupScheduleRequest,
+  ): Promise<VolumeBackupScheduleResponse> {
+    return this.request<VolumeBackupScheduleResponse>(
+      `/services/${uuid}/storages/${storageUuid}/backups`,
+      { method: 'PUT', body: JSON.stringify(cleanRequestData(schedule)) },
+    );
+  }
+
+  async deleteApplicationStorageBackup(
+    uuid: string,
+    storageUuid: string,
+  ): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/applications/${uuid}/storages/${storageUuid}/backups`, {
+      method: 'DELETE',
+    });
+  }
+
+  async deleteDatabaseStorageBackup(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/storages/${storageUuid}/backups`, {
+      method: 'DELETE',
+    });
+  }
+
+  async deleteServiceStorageBackup(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/storages/${storageUuid}/backups`, {
+      method: 'DELETE',
+    });
+  }
+
+  async runApplicationStorageBackup(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(
+      `/applications/${uuid}/storages/${storageUuid}/backups/run`,
+      { method: 'POST' },
+    );
+  }
+
+  async runDatabaseStorageBackup(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/databases/${uuid}/storages/${storageUuid}/backups/run`, {
+      method: 'POST',
+    });
+  }
+
+  async runServiceStorageBackup(uuid: string, storageUuid: string): Promise<MessageResponse> {
+    return this.request<MessageResponse>(`/services/${uuid}/storages/${storageUuid}/backups/run`, {
+      method: 'POST',
     });
   }
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -39,6 +39,7 @@ import type {
   UpdateServiceApplicationRequest,
   UpdateServiceRequest,
   Database,
+  VolumeBackupScheduleRequest,
 } from '../types/coolify.js';
 import { DocsSearchEngine } from './docs-search.js';
 import { confirmDestructive, describeBlastRadius, sanitizeForPrompt } from './elicit.js';
@@ -3493,12 +3494,38 @@ export class CoolifyMcpServer extends McpServer {
     // =========================================================================
     this.defineTool(
       'storages',
-      'Manage persistent/file storages for app, database, or service: list/create/update/delete',
+      'Manage persistent/file storages for app, database, or service: list/create/update/delete, ' +
+        'plus volume backups (v4.2+): backup_set/backup_delete/backup_run. backup_set REPLACES ' +
+        'the schedule — omitted fields revert to defaults and there is no read-back endpoint, so ' +
+        'send it whole. backup_delete deletes the archives too.',
       {
         resource: z.enum(['application', 'database', 'service']),
-        action: z.enum(['list', 'create', 'update', 'delete']),
+        action: z.enum([
+          'list',
+          'create',
+          'update',
+          'delete',
+          'backup_set',
+          'backup_delete',
+          'backup_run',
+        ]),
         uuid: z.string(),
         storage_uuid: z.string().optional(),
+        // Volume backup schedule (backup_set only). Names and defaults mirror
+        // VolumeBackupScheduleRequest exactly; see the replace-semantics note there.
+        frequency: z.string().optional().describe('backup_set: cron, e.g. `0 2 * * *`. Required.'),
+        enabled: z.boolean().optional(),
+        save_s3: z.boolean().optional(),
+        disable_local_backup: z.boolean().optional(),
+        stop_during_backup: z.boolean().optional().describe('Downtime: stops the container.'),
+        s3_storage_uuid: z.string().optional(),
+        retention_amount_locally: z.number().optional(),
+        retention_days_locally: z.number().optional(),
+        retention_max_storage_locally: z.number().optional(),
+        retention_amount_s3: z.number().optional(),
+        retention_days_s3: z.number().optional(),
+        retention_max_storage_s3: z.number().optional(),
+        timeout: z.number().optional(),
         type: z.enum(['persistent', 'file']).optional(),
         mount_path: z.string().optional(),
         name: z.string().optional(),
@@ -3508,16 +3535,53 @@ export class CoolifyMcpServer extends McpServer {
         fs_path: z.string().optional(),
         is_preview_suffix_enabled: z.boolean().optional(),
       },
-      async (args) => {
+      async (args, extra) => {
         const { resource, action, uuid, storage_uuid } = args;
         if (action === 'create' && (!args.type || !args.mount_path))
           return { content: [{ type: 'text' as const, text: 'Error: type, mount_path required' }] };
+        if (action.startsWith('backup_') && !storage_uuid)
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: storage_uuid required. List the storages first to find it.',
+              },
+            ],
+          };
+        if (action === 'backup_set' && !args.frequency)
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: frequency required (cron, e.g. `0 2 * * *`). backup_set replaces the whole schedule, so send every field you want kept — Coolify has no endpoint to read the current one back.',
+              },
+            ],
+          };
         if (action === 'update' && (!args.type || !storage_uuid))
           return {
             content: [{ type: 'text' as const, text: 'Error: type, storage_uuid required' }],
           };
         if (action === 'delete' && !storage_uuid)
           return { content: [{ type: 'text' as const, text: 'Error: storage_uuid required' }] };
+        // Built once, read by all three resource branches. Undefined fields are
+        // dropped by `cleanRequestData`, so an omitted field takes Coolify's
+        // default rather than being sent as null — which is the replace
+        // behaviour the tool description warns about, made explicit here.
+        const backupSchedule = (): VolumeBackupScheduleRequest => ({
+          frequency: args.frequency!,
+          enabled: args.enabled,
+          save_s3: args.save_s3,
+          disable_local_backup: args.disable_local_backup,
+          stop_during_backup: args.stop_during_backup,
+          s3_storage_uuid: args.s3_storage_uuid,
+          retention_amount_locally: args.retention_amount_locally,
+          retention_days_locally: args.retention_days_locally,
+          retention_max_storage_locally: args.retention_max_storage_locally,
+          retention_amount_s3: args.retention_amount_s3,
+          retention_days_s3: args.retention_days_s3,
+          retention_max_storage_s3: args.retention_max_storage_s3,
+          timeout: args.timeout,
+        });
         const methods: Record<string, Record<string, () => Promise<unknown>>> = {
           application: {
             list: () => this.client.listApplicationStorages(uuid),
@@ -3544,6 +3608,10 @@ export class CoolifyMcpServer extends McpServer {
                 is_preview_suffix_enabled: args.is_preview_suffix_enabled,
               }),
             delete: () => this.client.deleteApplicationStorage(uuid, storage_uuid!),
+            backup_set: () =>
+              this.client.setApplicationStorageBackup(uuid, storage_uuid!, backupSchedule()),
+            backup_delete: () => this.client.deleteApplicationStorageBackup(uuid, storage_uuid!),
+            backup_run: () => this.client.runApplicationStorageBackup(uuid, storage_uuid!),
           },
           database: {
             list: () => this.client.listDatabaseStorages(uuid),
@@ -3570,6 +3638,10 @@ export class CoolifyMcpServer extends McpServer {
                 is_preview_suffix_enabled: args.is_preview_suffix_enabled,
               }),
             delete: () => this.client.deleteDatabaseStorage(uuid, storage_uuid!),
+            backup_set: () =>
+              this.client.setDatabaseStorageBackup(uuid, storage_uuid!, backupSchedule()),
+            backup_delete: () => this.client.deleteDatabaseStorageBackup(uuid, storage_uuid!),
+            backup_run: () => this.client.runDatabaseStorageBackup(uuid, storage_uuid!),
           },
           service: {
             list: () => this.client.listServiceStorages(uuid),
@@ -3596,8 +3668,30 @@ export class CoolifyMcpServer extends McpServer {
                 is_preview_suffix_enabled: args.is_preview_suffix_enabled,
               }),
             delete: () => this.client.deleteServiceStorage(uuid, storage_uuid!),
+            backup_set: () =>
+              this.client.setServiceStorageBackup(uuid, storage_uuid!, backupSchedule()),
+            backup_delete: () => this.client.deleteServiceStorageBackup(uuid, storage_uuid!),
+            backup_run: () => this.client.runServiceStorageBackup(uuid, storage_uuid!),
           },
         };
+        if (action === 'backup_delete') {
+          // The only genuinely destructive action in this tool that takes data
+          // with it. Upstream: "Delete the backup schedule and its local and S3
+          // archives" — so this is not "stop backing up", it is "stop backing up
+          // AND throw away every backup you already have". Those are different
+          // decisions and the prompt has to say which one is happening.
+          return this.guardDestructive(
+            extra.mcpReq.signal,
+            `Delete a volume backup schedule and every archive it has taken.`,
+            () =>
+              `Delete the backup schedule for storage ${sanitizeForPrompt(storage_uuid!)} on ` +
+              `${resource} ${sanitizeForPrompt(uuid)}?\n\n` +
+              `Its local and S3 archives are deleted with it, so existing backups of this volume ` +
+              `are gone and cannot be restored. Stopping future backups without discarding the ` +
+              `archives is \`backup_set\` with \`enabled: false\` instead. This cannot be undone.`,
+            () => methods[resource][action](),
+          );
+        }
         return wrap(() => methods[resource][action]());
       },
     );

--- a/src/types/coolify.ts
+++ b/src/types/coolify.ts
@@ -47,6 +47,57 @@ export interface MoveResourceResponse {
   environment_uuid?: string;
 }
 
+/**
+ * Body for `PUT /{applications,databases,services}/{uuid}/storages/{storage_uuid}/backups`
+ * (Coolify v4.2+).
+ *
+ * **These are replace semantics, not merge.** Upstream declares the schema
+ * `additionalProperties: false` with `frequency` as the only required field and
+ * a default on every other one, so a PUT that omits `save_s3` does not leave the
+ * existing value alone — it sets it to `false`. Combined with the absence of any
+ * GET route for a schedule (verified against `VolumeBackupsController`, which
+ * defines only PUT, DELETE and the run POST), there is no way to read the
+ * current settings back before replacing them. Callers must send the full
+ * intended schedule every time.
+ */
+export interface VolumeBackupScheduleRequest {
+  /** Cron expression, e.g. `0 2 * * *`. The only required field. */
+  frequency: string;
+  enabled?: boolean;
+  save_s3?: boolean;
+  disable_local_backup?: boolean;
+  stop_during_backup?: boolean;
+  s3_storage_uuid?: string | null;
+  retention_amount_locally?: number;
+  retention_days_locally?: number;
+  retention_max_storage_locally?: number;
+  retention_amount_s3?: number;
+  retention_days_s3?: number;
+  retention_max_storage_s3?: number;
+  timeout?: number;
+}
+
+/** Response from setting a volume backup schedule. Echoes the stored schedule. */
+export interface VolumeBackupScheduleResponse {
+  uuid: string;
+  message: string;
+  storage_uuid: string;
+  storage_type: 'persistent' | 'directory';
+  frequency: string;
+  enabled: boolean;
+  save_s3: boolean;
+  disable_local_backup: boolean;
+  stop_during_backup: boolean;
+  s3_storage_uuid?: string | null;
+  retention_amount_locally: number;
+  retention_days_locally: number;
+  retention_max_storage_locally: number;
+  retention_amount_s3: number;
+  retention_days_s3: number;
+  retention_max_storage_s3: number;
+  timeout: number;
+}
+
 export interface MessageResponse {
   message: string;
 }


### PR DESCRIPTION
Closes #305. Second of the 3.3 items. Also picks up the `backups/run` endpoint listed on #386.

`storages` gains `backup_set`, `backup_delete` and `backup_run` for application, database and service volumes.

## Read this part first: the issue promised something that cannot be built

#305 argued the feature was worth having because *"did anyone back this up"* is a real question the assistant cannot answer, and because `find_issues` could flag persistent volumes with no backup schedule.

**Neither is possible.** Coolify exposes no read path for a volume backup schedule:

- `VolumeBackupsController` defines only `PUT`, `DELETE` and the run `POST`. There is no `GET`.
- `ApplicationsController::storages_by_uuid` returns `$application->persistentStorages` raw, with no backup relation eager-loaded.

I checked upstream source rather than the spec, because the spec types the storages response as a bare `{ type: object }` and cannot answer the question either.

So this ships the write half. `docs/tools.md` says plainly that the read half needs an upstream endpoint before `find_issues` can do anything here. I have not pretended otherwise anywhere in the copy.

## `backup_set` replaces, it does not merge

The upstream request schema is `additionalProperties: false` with `frequency` as the only required field and a default on every other one. So a call that omits `save_s3` sets it to `false` rather than leaving it alone.

Combined with the missing `GET`, **there is no safe read-modify-write**. A user asking to "turn on S3 for this backup" cannot be served by a partial update, because nothing can read the current settings first. The tool description, the type doc comment and the missing-`frequency` error all say the same thing: send the whole schedule every time.

## One thing I got wrong and fixed

My first cut shared a private client helper taking `collection` as a parameter. It typechecked, tests passed, and `check:spec-drift` reported OK.

It was quietly wrong. The drift checker extracts the template passed to `this.request()` and turns every `${...}` into a wildcard segment, so `/${collection}/${uuid}/storages/${storageUuid}/backups` collapses to `/*/*/storages/*/backups` — one route that matches any of the three and therefore proves none of them. The route count moved 113 to 115 instead of 113 to 119.

Each collection is now a literal at its own `this.request()` call site, which is the style the rest of the file already uses. Count now moves 113 to 119, all six paths individually verified.

**The same flaw is on #399**, my move PR, for the same reason. I am fixing it there next.

## Confirmation

`backup_delete` is the only guarded action. Upstream deletes *"the backup schedule and its local and S3 archives"*, so it is not "stop backing up", it is "stop backing up **and** discard every backup you already have". Those are different decisions and the prompt names which one is happening, then offers the other:

```
Delete the backup schedule for storage stor-1 on application app-1?

Its local and S3 archives are deleted with it, so existing backups of this
volume are gone and cannot be restored. Stopping future backups without
discarding the archives is `backup_set` with `enabled: false` instead. This
cannot be undone.
```

`backup_set` and `backup_run` are not gated; neither discards anything.

## Token budget, and a flag for the 4.0 conversation

| | tokens |
|---|---|
| main | 7,725 |
| this branch | 7,944 |
| gate | 8,000 |

It passes, and I trimmed the tool description once to get there. But the surface is now effectively full: **56 tokens of headroom**, and most of this cost is the 13 schedule fields themselves, which are not compressible without dropping capability.

Nothing else in 3.3 adds tool schema, so this does not block the milestone. It is a concrete data point for #338: the argument for splitting by safety class now has a second reason behind it, which is that the consolidated surface has run out of room.

## Tests

922 total, 17 new. Client: each of the nine methods hits its exact path and verb, `false` and `0` survive the request builder (a falsy-stripping builder would turn "disabled, keep nothing" into "enabled, keep 7"), and unset fields are omitted rather than sent as null. Server: `backup_delete` is gated for all three resource types and does not call through when declined, `backup_set`/`backup_run` are not gated, and both the missing-`storage_uuid` and missing-`frequency` errors say what to do.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a