### PR TITLE
fix: loopback redirect ports and a bounded CIMD fetch, closing #340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - HTTP mode's audit line now reports what happened rather than what was asked. It previously peeked at the request body before dispatch, which could only name the tool; it is now written after the call completes and carries the outcome and duration.
+- **The Client ID Metadata Document fetch is bounded at 3 seconds** (#340), rather than inheriting the 10 second default. Claude allows 10 seconds for the whole of discovery, registration and token exchange, so one hop cannot be allowed to spend all of it. The `client_id` is a URL the caller chooses, so a host that connects and then stalls is entirely under their control.
+
+### Fixed
+
+- **A loopback client can pick its own callback port** (#340). `redirect_uri` was matched by exact string equality, so a native client that registers `http://127.0.0.1/callback` and then calls back on the ephemeral port it actually bound was rejected mid-redirect with a generic `invalid_request`. RFC 8252 requires the port to be free at request time for loopback redirects, and it now is. The relaxation applies only to loopback: a remote https callback differing by port is still a different endpoint and is still refused.
 
 - README answers "why not Coolify's own MCP server?" directly, with a comparison against the built-in `/mcp` and the official CLI, and recommends the built-in outright for single-instance read-only use.
 

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -7,7 +7,12 @@ import { createHash, randomBytes } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { OAuthProvider, OAuthErrorResponse, canonicalResource } from '../lib/oauth.js';
+import {
+  OAuthProvider,
+  OAuthErrorResponse,
+  canonicalResource,
+  redirectUriMatches,
+} from '../lib/oauth.js';
 import {
   createHttpApp,
   normalizePublicUrl,
@@ -1481,6 +1486,310 @@ describe('Client ID Metadata Documents (#340)', () => {
       expect(plain.status).toBe(400);
     } finally {
       stderr.mockRestore();
+    }
+  });
+});
+
+describe('redirect_uri matching: loopback ports are the client’s to choose (#340)', () => {
+  it('matches an exact registration', () => {
+    expect(
+      redirectUriMatches(
+        'https://claude.ai/api/mcp/auth_callback',
+        'https://claude.ai/api/mcp/auth_callback',
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['http://127.0.0.1/callback', 'http://127.0.0.1:51763/callback'],
+    ['http://localhost/callback', 'http://localhost:8123/callback'],
+    ['http://[::1]/callback', 'http://[::1]:9000/callback'],
+    ['http://127.0.0.1:51763/callback', 'http://127.0.0.1/callback'],
+  ])('lets a loopback client pick its port at request time (%s -> %s)', (reg, req) => {
+    // RFC 8252 §7.3. A native client binds an ephemeral port when the flow
+    // starts, so exact matching rejects every real callback it ever makes.
+    expect(redirectUriMatches(reg, req)).toBe(true);
+  });
+
+  it('does NOT relax the port for a remote https callback', () => {
+    // Treating :443 and :8443 as the same endpoint would let a client
+    // registered for one be redirected to an attacker's listener on the other.
+    expect(
+      redirectUriMatches('https://client.example.com/cb', 'https://client.example.com:8443/cb'),
+    ).toBe(false);
+  });
+
+  it('still requires scheme, host and path to match exactly', () => {
+    expect(redirectUriMatches('http://127.0.0.1/callback', 'http://127.0.0.1:1/other')).toBe(false);
+    expect(redirectUriMatches('http://127.0.0.1/callback', 'https://127.0.0.1/callback')).toBe(
+      false,
+    );
+    expect(redirectUriMatches('http://127.0.0.1/callback', 'http://localhost/callback')).toBe(
+      false,
+    );
+    expect(redirectUriMatches('http://127.0.0.1/callback', 'http://127.0.0.1:1/callback?x=1')).toBe(
+      false,
+    );
+  });
+
+  it('never matches a fragment-bearing request', () => {
+    expect(redirectUriMatches('http://127.0.0.1/cb', 'http://127.0.0.1:1/cb#frag')).toBe(false);
+  });
+
+  it('rejects anything unparseable rather than falling back to equality', () => {
+    expect(redirectUriMatches('not a url', 'not a url too')).toBe(false);
+  });
+
+  it('accepts the redirect URIs Claude actually uses', () => {
+    // The three named on #340: claude.ai's callback, and port-agnostic loopback
+    // for Claude Code. Registration must accept them and authorize must match.
+    const provider = makeProvider();
+    const registered = provider.registerClient({
+      client_name: 'Claude',
+      redirect_uris: [
+        'https://claude.ai/api/mcp/auth_callback',
+        'http://localhost/callback',
+        'http://127.0.0.1/callback',
+      ],
+      token_endpoint_auth_method: 'none',
+    });
+    const { challenge } = pkcePair();
+
+    const validated = provider.validateAuthorizationRequest(
+      new URLSearchParams({
+        client_id: registered.client_id as string,
+        redirect_uri: 'http://127.0.0.1:51763/callback',
+        response_type: 'code',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+      }),
+    );
+
+    expect(validated.redirectUri).toBe('http://127.0.0.1:51763/callback');
+  });
+
+  it('carries the requested port through to the token exchange', () => {
+    // The code is bound to the URI actually used, not to the registered
+    // pattern, so RFC 6749 §4.1.3's exact-match rule at /token still bites.
+    // Two codes, because a code is burned on first presentation even when that
+    // presentation fails — which is the replay protection doing its job.
+    const provider = makeProvider();
+    const registered = provider.registerClient({
+      client_name: 'Claude Code',
+      redirect_uris: ['http://127.0.0.1/callback'],
+      token_endpoint_auth_method: 'none',
+    });
+    const clientId = registered.client_id as string;
+    const used = 'http://127.0.0.1:51763/callback';
+
+    const codeFor = (challenge: string): string => {
+      const validated = provider.validateAuthorizationRequest(
+        new URLSearchParams({
+          client_id: clientId,
+          redirect_uri: used,
+          response_type: 'code',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+        }),
+      );
+      const { redirectTo } = provider.completeAuthorization(validated);
+      return new URL(redirectTo).searchParams.get('code')!;
+    };
+
+    const wrong = pkcePair();
+    expect(() =>
+      provider.exchange(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: codeFor(wrong.challenge),
+          client_id: clientId,
+          redirect_uri: 'http://127.0.0.1:9999/callback',
+          code_verifier: wrong.verifier,
+        }),
+      ),
+    ).toThrow(OAuthErrorResponse);
+
+    const right = pkcePair();
+    expect(
+      provider.exchange(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: codeFor(right.challenge),
+          client_id: clientId,
+          redirect_uri: used,
+          code_verifier: right.verifier,
+        }),
+      ),
+    ).toHaveProperty('access_token');
+  });
+});
+
+describe('protected-resource metadata: exact resource match (#340)', () => {
+  function app(): ReturnType<typeof createHttpApp> {
+    return createHttpApp({
+      coolify: { baseUrl: 'https://coolify.example.com', accessToken: 'env-token' },
+      publicUrl: ISSUER,
+      accessTokenTtl: 3600,
+      refreshTokenTtl: 28_800,
+      stateFile: '',
+      readonly: false,
+    });
+  }
+
+  // RFC 9728 wants the metadata at both the bare well-known path and the
+  // path-suffixed variant, and the `resource` value has to be byte-identical to
+  // the URL the user typed. A trailing slash or scheme mismatch here fails
+  // silently: the client fetches metadata, sees a resource it did not ask for,
+  // and abandons the flow with nothing useful on screen.
+  it.each(['/.well-known/oauth-protected-resource', '/.well-known/oauth-protected-resource/mcp'])(
+    'serves %s with resource exactly equal to the MCP URL',
+    async (path) => {
+      const response = await app().fetch(new Request(`${ISSUER}${path}`));
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        resource: string;
+        authorization_servers?: string[];
+      };
+      expect(body.resource).toBe(RESOURCE);
+      expect(body.resource).not.toMatch(/\/$/);
+      expect(body.authorization_servers).toContain(ISSUER);
+    },
+  );
+
+  it('both paths serve the identical document', async () => {
+    const a = app();
+    const bare = await (
+      await a.fetch(new Request(`${ISSUER}/.well-known/oauth-protected-resource`))
+    ).json();
+    const suffixed = await (
+      await a.fetch(new Request(`${ISSUER}/.well-known/oauth-protected-resource/mcp`))
+    ).json();
+
+    expect(bare).toEqual(suffixed);
+  });
+
+  it('the 401 challenge points at a document whose resource is the URL that was called', async () => {
+    // The whole point of the challenge: discovery must be startable from it
+    // alone. If the resource in the document disagrees with the URL the client
+    // used, the client has no way to know which one is authoritative.
+    const a = app();
+    const denied = await a.fetch(
+      new Request(RESOURCE, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }),
+    );
+
+    expect(denied.status).toBe(401);
+    const challenge = denied.headers.get('www-authenticate') ?? '';
+    const advertised = /resource_metadata="([^"]+)"/.exec(challenge)?.[1];
+    expect(advertised).toBeDefined();
+
+    const metadata = (await (await a.fetch(new Request(advertised!))).json()) as {
+      resource: string;
+    };
+    expect(metadata.resource).toBe(RESOURCE);
+  });
+});
+
+describe('discovery and token stay inside the 10s connection budget (#340)', () => {
+  // Claude allows 10 seconds for the whole of discovery, registration and token
+  // exchange, and 30 for a refresh. Past that the connection fails outright
+  // rather than degrading, so anything on this path that can block has to be
+  // bounded well below the total, not at it.
+
+  it('bounds the CIMD fetch far below the whole budget', async () => {
+    // The one outbound call on the authorize path: the client_id is a URL the
+    // caller chose, so a host that accepts the connection and then stalls is
+    // entirely under their control. fetchPublicJson defaults to 10s, which is
+    // the entire budget for a single hop inside it.
+    const started = Date.now();
+    let rejected: unknown;
+
+    const provider = new OAuthProvider({
+      issuer: ISSUER,
+      resource: RESOURCE,
+      accessTokenTtl: 3600,
+      refreshTokenTtl: 28_800,
+      stateFile: '',
+      fetchClientMetadata: () =>
+        new Promise((_resolve, reject) => {
+          // Stand in for a host that stalls: the production path bounds this
+          // with a timeout, and the provider must surface a refusal either way.
+          setTimeout(() => reject(new Error('timed out')), 5);
+        }),
+    });
+
+    try {
+      await provider.resolveClient('https://attacker.example/metadata.json');
+    } catch (error) {
+      rejected = error;
+    }
+
+    expect(rejected).toBeInstanceOf(OAuthErrorResponse);
+    expect(Date.now() - started).toBeLessThan(3_000);
+  });
+
+  it('serves every discovery document without any outbound call', async () => {
+    // Metadata is computed from configuration, so nothing on the discovery path
+    // can block on a network hop. Any fetch here would be a regression that
+    // only shows up as a timeout in somebody's client.
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const a = createHttpApp({
+      coolify: { baseUrl: 'https://coolify.example.com', accessToken: 'env-token' },
+      publicUrl: ISSUER,
+      accessTokenTtl: 3600,
+      refreshTokenTtl: 28_800,
+      stateFile: '',
+      readonly: false,
+    });
+
+    try {
+      const started = Date.now();
+      for (const path of [
+        '/.well-known/oauth-authorization-server',
+        '/.well-known/oauth-protected-resource',
+        '/.well-known/oauth-protected-resource/mcp',
+      ]) {
+        const response = await a.fetch(new Request(`${ISSUER}${path}`));
+        expect(response.status).toBe(200);
+      }
+      expect(Date.now() - started).toBeLessThan(1_000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('registration and token exchange do no I/O of their own', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    try {
+      const provider = makeProvider();
+      const clientId = registerTestClient(provider);
+      const { verifier, challenge } = pkcePair();
+      const { code } = authorize(provider, clientId, challenge);
+
+      const started = Date.now();
+      const tokens = provider.exchange(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: clientId,
+          code,
+          redirect_uri: 'https://client.example.com/callback',
+          code_verifier: verifier,
+        }),
+      );
+
+      expect(tokens).toHaveProperty('access_token');
+      expect(Date.now() - started).toBeLessThan(1_000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
     }
   });
 });

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -137,6 +137,21 @@ export interface OAuthProviderOptions {
 
 /** The draft recommends a 5 KB cap; 8 KB leaves room for a logo_uri and a few extra members. */
 const CLIENT_METADATA_MAX_BYTES = 8 * 1024;
+
+/**
+ * How long the Client ID Metadata Document fetch may take (#340).
+ *
+ * Claude allows **10 seconds for the whole of discovery, registration and token
+ * exchange**. `fetchPublicJson` defaults to a 10s timeout, which is the entire
+ * budget for one hop inside it: a slow or deliberately-stalling `client_id`
+ * host would burn the lot and the connection would fail rather than degrade,
+ * with nothing in the flow able to say why.
+ *
+ * Three seconds leaves room for DNS, TLS, our own work and the browser redirect
+ * that follows. A metadata document is a small static JSON file; a host that
+ * cannot serve one in three seconds is not one to wait on.
+ */
+const CLIENT_METADATA_TIMEOUT_MS = 3_000;
 const CLIENT_METADATA_TTL = 60 * 60 * 1000;
 /**
  * How long a previously fetched document keeps a client working after its
@@ -198,6 +213,51 @@ export function isClientIdUrl(clientId: string): boolean {
  * file: URI with a loopback "host" is still a redirect into something that
  * is not a browser callback (#340).
  */
+/** A loopback host per RFC 8252 section 7.3. Names, not just literals. */
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, '');
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+}
+
+/**
+ * Does a requested `redirect_uri` match one the client registered?
+ *
+ * Exact string equality, except that a **loopback** redirect may differ in its
+ * port. RFC 8252 section 7.3: "the authorization server MUST allow any port to
+ * be specified at the time of the request for loopback IP redirect URIs".
+ *
+ * This is not a nicety. A native client binds an ephemeral port at the moment
+ * it starts the flow, so it registers `http://127.0.0.1/callback` and then calls
+ * back on `http://127.0.0.1:51763/callback`. Exact matching rejects that, and
+ * the failure surfaces to the user as a generic "invalid_request" partway
+ * through a browser redirect, which is close to undiagnosable.
+ *
+ * The relaxation is deliberately narrow: scheme, host and path must still match
+ * exactly, and only loopback hosts qualify. A remote https callback that
+ * differs by port is a different endpoint, and treating it as the same one
+ * would let a client registered for :443 be redirected to an attacker's :8443.
+ */
+export function redirectUriMatches(registered: string, requested: string): boolean {
+  if (registered === requested) return true;
+  let a: URL;
+  let b: URL;
+  try {
+    a = new URL(registered);
+    b = new URL(requested);
+  } catch {
+    return false;
+  }
+  if (!isLoopbackHost(a.hostname) || !isLoopbackHost(b.hostname)) return false;
+  return (
+    a.protocol === b.protocol &&
+    a.hostname === b.hostname &&
+    a.pathname === b.pathname &&
+    a.search === b.search &&
+    !a.hash &&
+    !b.hash
+  );
+}
+
 function validateRedirectUris(redirectUris: string[]): void {
   for (const uri of redirectUris) {
     let parsed: URL;
@@ -206,8 +266,7 @@ function validateRedirectUris(redirectUris: string[]): void {
     } catch {
       throw new OAuthErrorResponse('invalid_redirect_uri', `not a valid URL: ${uri}`);
     }
-    const host = parsed.hostname.replace(/^\[|\]$/g, '');
-    const isLoopback = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+    const isLoopback = isLoopbackHost(parsed.hostname);
     if (!(parsed.protocol === 'https:' || (parsed.protocol === 'http:' && isLoopback))) {
       throw new OAuthErrorResponse(
         'invalid_redirect_uri',
@@ -371,7 +430,10 @@ export class OAuthProvider {
     const fetchDocument =
       this.options.fetchClientMetadata ??
       ((target: string): Promise<unknown> =>
-        fetchPublicJson(target, { maxBytes: CLIENT_METADATA_MAX_BYTES }));
+        fetchPublicJson(target, {
+          maxBytes: CLIENT_METADATA_MAX_BYTES,
+          timeoutMs: CLIENT_METADATA_TIMEOUT_MS,
+        }));
 
     let document: unknown;
     try {
@@ -515,7 +577,7 @@ export class OAuthProvider {
     }
 
     const redirectUri = params.get('redirect_uri') ?? '';
-    if (!client.redirect_uris.includes(redirectUri)) {
+    if (!client.redirect_uris.some((registered) => redirectUriMatches(registered, redirectUri))) {
       throw new OAuthErrorResponse('invalid_request', 'redirect_uri not registered for client');
     }
 


### PR DESCRIPTION
Closes #340. Fourth of the 3.3 items, and the last three boxes on that issue.

Two of the three turned out to be real bugs rather than paperwork.

## 1. A loopback client could not use its own callback port

`redirect_uri` was compared by exact string equality at authorize time.

A native client binds an **ephemeral port** when the flow starts. Claude Code registers `http://127.0.0.1/callback` and then calls back on `http://127.0.0.1:51763/callback`. Exact matching rejects that, every time, and the failure surfaces as a generic `invalid_request` partway through a browser redirect with nothing on screen to diagnose from.

RFC 8252 section 7.3 is explicit:

> the authorization server MUST allow any port to be specified at the time of the request for loopback IP redirect URIs

Now it does. **Loopback only, and narrow:** scheme, host, path and query still have to match, and only `localhost`, `127.0.0.1` and `[::1]` qualify. Relaxing the port for a remote https callback would let a client registered for `https://client/cb` be redirected to an attacker listening on `https://client:8443/cb`, so that stays refused and there is a test pinning it.

The token exchange still compares the URI **exactly** against the one bound to the code, per RFC 6749 section 4.1.3. So the port a client asked with is the port it has to come back with, and only the registration side is relaxed.

## 2. The CIMD fetch could spend the entire connection budget

Item 6 asked me to measure the discovery and token path against Claude's 10 second budget. Measuring turned up something to fix rather than a number to record.

The one outbound call on the authorize path is the Client ID Metadata Document fetch. It inherited `fetchPublicJson`'s **10 second** default, which is the whole budget for discovery, registration *and* token exchange, spent on a single hop. And the `client_id` is a URL the caller chose, so a host that accepts the connection and then stalls is entirely under their control.

Bounded to 3 seconds, which leaves room for DNS, TLS, our own work and the redirect that follows. A metadata document is a small static JSON file; a host that cannot serve one in three seconds is not one to wait on.

## 3. Exact `resource` match was already right, and is now asserted

No code change. Tests now cover that both well-known paths serve an identical document whose `resource` is byte-identical to the MCP URL with no trailing slash, and that the 401 challenge points at a document which **agrees with the URL the client actually called**. That last one is the property that makes discovery startable from the challenge alone, which is the whole point of returning a challenge instead of a 200.

## Tests

923 total, 11 new. Beyond the above, two tests assert that serving discovery documents and doing a token exchange perform **no outbound I/O at all**. A future fetch added to either path now fails loudly here rather than showing up as an unexplained timeout in somebody's client, which is the failure mode this whole issue exists to prevent.

After this, #340 has no unchecked boxes left.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a