### PR TITLE
test: use reserved example domains in fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A loopback client can pick its own callback port** (#340). `redirect_uri` was matched by exact string equality, so a native client that registers `http://127.0.0.1/callback` and then calls back on the ephemeral port it actually bound was rejected mid-redirect with a generic `invalid_request`. RFC 8252 requires the port to be free at request time for loopback redirects, and it now is. The relaxation applies only to loopback: a remote https callback differing by port is still a different endpoint and is still refused.
 
 - README answers "why not Coolify's own MCP server?" directly, with a comparison against the built-in `/mcp` and the official CLI, and recommends the built-in outright for single-instance read-only use.
+- Test fixtures, docs examples and one README example prompt now use IANA-reserved `example.com` names instead of live third-party domains, and the blast-radius example reads the same way in the changelog as it does in `docs/security.md`. No behaviour change.
 
 ## [3.2.0] - 2026-09-10
 
@@ -217,7 +218,7 @@ No runtime changes. Safe to skip; nothing to upgrade for.
 ### Added
 
 - **Human confirmation for destructive operations** (#261). `stop_all_apps` was gated on a `confirm: true` parameter the _model_ fills in — the model confirming with itself. On clients supporting [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/changelog) the confirmation now happens in client UI, outside the model's control. Covers `stop_all_apps`, `redeploy_project`, `restart_project_apps`, `system disable_api`, the application / database / service / project / environment deletes, and `bulk_env_update` above three apps.
-- Prompts state their blast radius: "take down 12 running applications (api, worker, cockpit and 4 more) across 3 servers?". Delete prompts spell out volume destruction — `delete_volumes` defaults to `true` upstream, so omitting it destroys the data. Project deletes count applications, databases and services. Env var values are never shown.
+- Prompts state their blast radius: "take down 12 running applications (api, worker, dashboard and 4 more) across 3 servers?". Delete prompts spell out volume destruction — `delete_volumes` defaults to `true` upstream, so omitting it destroys the data. Project deletes count applications, databases and services. Env var values are never shown.
 - Progressive enhancement: clients without elicitation (Claude Desktop, claude.ai) behave exactly as before. Once a client advertises support it fails closed — decline, cancel, timeout and transport errors all abort. The tool call's abort signal is threaded through, so a client giving up at 60s cannot leave a prompt live that executes at t=90s.
 - `COOLIFY_MCP_ELICITATION=off` escape hatch, for a client that advertises elicitation but does not implement it.
 - Tool count unchanged at 44.
@@ -322,7 +323,7 @@ No runtime changes. Safe to skip; nothing to upgrade for.
 
 ### Added
 
-- **`custom_network_aliases` on `application` update** (#254) — gives an app container a stable DNS name for app-to-app traffic on a shared network. App containers get `<uuid>-<deploy-suffix>` container names that change every deploy (only databases get a uuid hostname), so this field is the only way to wire e.g. `ASR_URL=http://edator-asr:9000` between apps. Added to `UpdateApplicationRequest` and the `application` tool schema (update only — Coolify's create endpoints don't accept it).
+- **`custom_network_aliases` on `application` update** (#254) — gives an app container a stable DNS name for app-to-app traffic on a shared network. App containers get `<uuid>-<deploy-suffix>` container names that change every deploy (only databases get a uuid hostname), so this field is the only way to wire e.g. `ASR_URL=http://media-asr:9000` between apps. Added to `UpdateApplicationRequest` and the `application` tool schema (update only — Coolify's create endpoints don't accept it).
 - **MCPB bundle for one-click Claude Desktop install** — every release now attaches `coolify-mcp.mcpb` to the GitHub release; drag it into Claude Desktop Settings → Extensions and enter your Coolify URL + token. Built from `manifest.json` via `@anthropic-ai/mcpb` in the publish workflow. No Node install or JSON config editing needed.
 - **Automated MCP Registry publishing** — the publish workflow now pushes `server.json` to registry.modelcontextprotocol.io via `mcp-publisher` (GitHub OIDC) on every release, so the registry listing can no longer go stale.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Other third-party Coolify MCP servers exist. Choose on transport, on how many in
 
 ```text
 Give me an overview of my infrastructure
-Diagnose my stuartmason.co.uk app
+Diagnose my shop.example.com app
 Find any issues in my infrastructure
 Deploy application {uuid} and wait for it to finish
 Update the DATABASE_URL env var for application {uuid}

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,7 +14,7 @@ before you answer:
 
 ```text
 EMERGENCY STOP: take down 12 running applications
-(api, worker, dashboard, analytics, scheduler, mailer, search, billing and 4 more)
+(api, worker, dashboard, umami, scheduler, mailer, search, billing and 4 more)
 across 3 servers?
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,7 +14,7 @@ before you answer:
 
 ```text
 EMERGENCY STOP: take down 12 running applications
-(api, worker, cockpit, umami, scheduler, mailer, search, billing and 4 more)
+(api, worker, dashboard, analytics, scheduler, mailer, search, billing and 4 more)
 across 3 servers?
 ```
 

--- a/src/__tests__/coolify-client.test.ts
+++ b/src/__tests__/coolify-client.test.ts
@@ -2228,11 +2228,11 @@ describe('CoolifyClient', () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockApplication));
 
       await client.updateApplication('app-uuid', {
-        custom_network_aliases: 'edator-asr',
+        custom_network_aliases: 'media-asr',
       });
 
       const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
-      expect(callBody.custom_network_aliases).toBe('edator-asr');
+      expect(callBody.custom_network_aliases).toBe('media-asr');
     });
 
     it('should pass destination_uuid through in createApplicationPublic', async () => {
@@ -4130,9 +4130,9 @@ describe('CoolifyClient', () => {
         {
           id: 1,
           uuid: 'app-uuid-1',
-          name: 'tidylinker',
+          name: 'shop-frontend',
           status: 'running',
-          fqdn: 'https://tidylinker.com',
+          fqdn: 'https://shop.example.com',
           created_at: '2024-01-01',
           updated_at: '2024-01-01',
         },
@@ -4157,7 +4157,7 @@ describe('CoolifyClient', () => {
       it('should find application by name', async () => {
         mockFetch.mockResolvedValueOnce(mockResponse(mockApps));
 
-        const result = await client.resolveApplicationUuid('tidylinker');
+        const result = await client.resolveApplicationUuid('shop-frontend');
 
         expect(result).toBe('app-uuid-1');
       });
@@ -4165,7 +4165,7 @@ describe('CoolifyClient', () => {
       it('should find application by partial name (case-insensitive)', async () => {
         mockFetch.mockResolvedValueOnce(mockResponse(mockApps));
 
-        const result = await client.resolveApplicationUuid('TidyLink');
+        const result = await client.resolveApplicationUuid('Shop-Front');
 
         expect(result).toBe('app-uuid-1');
       });
@@ -4173,7 +4173,7 @@ describe('CoolifyClient', () => {
       it('should find application by domain', async () => {
         mockFetch.mockResolvedValueOnce(mockResponse(mockApps));
 
-        const result = await client.resolveApplicationUuid('tidylinker.com');
+        const result = await client.resolveApplicationUuid('shop.example.com');
 
         expect(result).toBe('app-uuid-1');
       });
@@ -4231,13 +4231,13 @@ describe('CoolifyClient', () => {
             ...mockApps[0],
             uuid: 'app-multi',
             // Trailing comma leaves an empty entry, which must never match.
-            fqdn: 'https://tidylinker.com,https://www.tidylinker.com,',
+            fqdn: 'https://shop.example.com,https://www.shop.example.com,',
           },
-          { ...mockApps[1], uuid: 'app-other', fqdn: 'https://www.tidylinker.com.mirror.dev' },
+          { ...mockApps[1], uuid: 'app-other', fqdn: 'https://www.shop.example.com.mirror.dev' },
         ];
         mockFetch.mockResolvedValueOnce(mockResponse(apps));
 
-        const result = await client.resolveApplicationUuid('www.tidylinker.com');
+        const result = await client.resolveApplicationUuid('www.shop.example.com');
 
         expect(result).toBe('app-multi');
       });
@@ -4658,7 +4658,7 @@ describe('CoolifyClient', () => {
       });
 
       it('should find application by domain and diagnose it', async () => {
-        const mockApps = [{ ...mockApp, uuid: 'found-uuid', fqdn: 'https://tidylinker.com' }];
+        const mockApps = [{ ...mockApp, uuid: 'found-uuid', fqdn: 'https://shop.example.com' }];
         mockFetch
           .mockResolvedValueOnce(mockResponse(mockApps)) // listApplications for lookup
           .mockResolvedValueOnce(mockResponse(mockApp))
@@ -4666,7 +4666,7 @@ describe('CoolifyClient', () => {
           .mockResolvedValueOnce(mockResponse(mockEnvVars))
           .mockResolvedValueOnce(mockResponse(mockDeployments));
 
-        const result = await client.diagnoseApplication('tidylinker.com');
+        const result = await client.diagnoseApplication('shop.example.com');
 
         expect(result.application).not.toBeNull();
       });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1072,12 +1072,12 @@ describe('CoolifyMcpServer v2', () => {
       await callApplication(server, {
         action: 'update',
         uuid: 'app-uuid',
-        custom_network_aliases: 'edator-asr',
+        custom_network_aliases: 'media-asr',
       });
 
       expect(spy).toHaveBeenCalledWith(
         'app-uuid',
-        expect.objectContaining({ custom_network_aliases: 'edator-asr' }),
+        expect.objectContaining({ custom_network_aliases: 'media-asr' }),
       );
     });
   });


### PR DESCRIPTION
Several test fixtures, one example in the security doc, and one README example prompt referenced live third-party domains and service names. Test data should not point at real hosts.

Replaced with names under `example.com`, which IANA reserves for exactly this purpose, matching the style the sibling fixtures already used next door (`api.example.com`).

## Behaviour is unchanged

Every assertion still exercises the same lookup paths:

- the comma-separated FQDN list, including its empty trailing entry
- the suffix that must not match
- the mixed-case partial name
- exact name beating a substring multi-match

1005 tests pass.

## Note

The old strings remain in git history. Rewriting history on a public repo with outside contributors costs more than it buys, so this fixes forward only.

https://claude.ai/code/session_01THRG6UFPUdMSARgJLcGf9a
